### PR TITLE
Ignore repl.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules/
 dist/
 .env
+repl.log


### PR DESCRIPTION
Adds repl.log to .gitignore — test PR to verify CI is working.