### PR TITLE
feat: slash commands for REPL

### DIFF
--- a/src/repl.ts
+++ b/src/repl.ts
@@ -413,6 +413,89 @@ const hooks = Object.fromEntries(
   ])
 ) as Record<HookEvent, [{ matcher: string; hooks: [HookCallback] }]>;
 
+// ── Slash commands ────────────────────────────────────────────────────────────
+
+export type SlashCommandResult =
+  | { type: "exit" }
+  | { type: "clear" }
+  | { type: "unknown_command"; command: string };
+
+/**
+ * Parse a slash command from raw user input.
+ * Returns null if the input is not a slash command.
+ */
+export function parseSlashCommand(input: string): SlashCommandResult | null {
+  if (!input.startsWith("/")) return null;
+  const command = input.slice(1).split(/\s+/)[0];
+  if (!command) return null;
+  if (command === "exit") return { type: "exit" };
+  if (command === "clear") return { type: "clear" };
+  return { type: "unknown_command", command };
+}
+
+/**
+ * Convert a slash command name to its file path under ~/.claude/commands/.
+ * Colons become path separators: "foo:bar" → ~/.claude/commands/foo/bar.md
+ */
+export function resolveCommandFilePath(command: string): string {
+  const home = process.env.HOME ?? process.env.USERPROFILE ?? "";
+  const rel = command.replace(/:/g, "/");
+  return `${home}/.claude/commands/${rel}.md`;
+}
+
+/**
+ * Load a custom slash command from disk, returning the file content as the
+ * query prompt, or null if the file does not exist.
+ * The readFile parameter is injectable for testing.
+ */
+export function loadCommandFile(
+  command: string,
+  readFile: (path: string) => string | null = defaultReadFile,
+): string | null {
+  const filePath = resolveCommandFilePath(command);
+  return readFile(filePath);
+}
+
+function defaultReadFile(path: string): string | null {
+  try {
+    return fs.readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+export type DispatchResult =
+  | { type: "skip" }
+  | { type: "exit" }
+  | { type: "clear" }
+  | { type: "query"; prompt: string }
+  | { type: "unknown_command"; command: string };
+
+/**
+ * Dispatch user input to the appropriate REPL action.
+ * readFile is injectable for testing.
+ */
+export async function dispatchInput(
+  input: string,
+  readFile: (path: string) => string | null = defaultReadFile,
+): Promise<DispatchResult> {
+  if (!input) return { type: "skip" };
+
+  const slash = parseSlashCommand(input);
+  if (slash) {
+    if (slash.type === "exit" || slash.type === "clear") return slash;
+    // unknown_command: look up file
+    const { command } = slash;
+    const content = loadCommandFile(command, readFile);
+    if (content === null) return { type: "unknown_command", command };
+    const args = input.slice(1 + command.length).trim();
+    const prompt = args ? `${content}\n${args}` : content;
+    return { type: "query", prompt };
+  }
+
+  return { type: "query", prompt: input };
+}
+
 // ── Config ────────────────────────────────────────────────────────────────────
 
 const BYPASS = process.argv.includes("--dangerously-skip-permissions");
@@ -674,23 +757,34 @@ async function main() {
   print(c.sageGreen(hr("═")));
   print(c.skyBlue(s.bold("  Claude Agent SDK REPL")));
   print(c.lavender(`  Permissions: ${PERMISSION_MODE} | Output: ${VERBOSE ? "verbose" : "quiet"} | Log: ${LOG_FILE}`));
-  print(c.lavender(`  Type 'exit' to quit, 'reset' to start a new session.`));
+  print(c.lavender(`  Type /exit to quit, /clear to start a new session.`));
   print(c.sageGreen(hr("═")));
 
   while (true) {
     const input = await ask("\n> ");
 
-    if (!input) continue;
-    if (input === "exit") { process.stdout.write("\x1b[?2004l\r\n"); break; }
+    const action = await dispatchInput(input);
 
-    if (input === "reset") {
+    if (action.type === "skip") continue;
+
+    if (action.type === "exit") {
+      process.stdout.write("\x1b[?2004l\r\n");
+      break;
+    }
+
+    if (action.type === "clear") {
       sessionId = undefined;
-      print("Session reset.");
+      print("Session cleared.");
+      continue;
+    }
+
+    if (action.type === "unknown_command") {
+      print(c.boldRed(`Unknown command: /${action.command}`));
       continue;
     }
 
     try {
-      sessionId = await runQuery(input, sessionId);
+      sessionId = await runQuery(action.prompt, sessionId);
     } catch (err) {
       console.error(c.boldRed(`\nERROR: ${err}`));
       logFull("ERROR", err instanceof Error ? { message: err.message, stack: err.stack } : err);

--- a/tests/repl.dispatch.test.ts
+++ b/tests/repl.dispatch.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { dispatchInput } from "../src/repl.js";
+
+describe("dispatchInput", () => {
+  it("empty input returns { type: 'skip' }", async () => {
+    const result = await dispatchInput("", () => null);
+    expect(result).toEqual({ type: "skip" });
+  });
+
+  it("/exit returns { type: 'exit' }", async () => {
+    const result = await dispatchInput("/exit", () => null);
+    expect(result).toEqual({ type: "exit" });
+  });
+
+  it("/clear returns { type: 'clear' }", async () => {
+    const result = await dispatchInput("/clear", () => null);
+    expect(result).toEqual({ type: "clear" });
+  });
+
+  it("/unknown with no file returns { type: 'unknown_command', command }", async () => {
+    const result = await dispatchInput("/unknown", () => null);
+    expect(result).toEqual({ type: "unknown_command", command: "unknown" });
+  });
+
+  it("/known with file returns { type: 'query', prompt: fileContent }", async () => {
+    const result = await dispatchInput("/mycommand", (_path) => "Do something creative.");
+    expect(result).toEqual({ type: "query", prompt: "Do something creative." });
+  });
+
+  it("plain text returns { type: 'query', prompt: input }", async () => {
+    const result = await dispatchInput("hello world", () => null);
+    expect(result).toEqual({ type: "query", prompt: "hello world" });
+  });
+
+  it("/command with extra args appends args to prompt", async () => {
+    const result = await dispatchInput("/mycommand some extra args", (_path) => "Base prompt.");
+    expect(result).toEqual({ type: "query", prompt: "Base prompt.\nsome extra args" });
+  });
+});

--- a/tests/repl.slash.test.ts
+++ b/tests/repl.slash.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { parseSlashCommand, resolveCommandFilePath, loadCommandFile } from "../src/repl.js";
+
+describe("parseSlashCommand", () => {
+  it("returns null for non-slash input", () => {
+    expect(parseSlashCommand("hello")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseSlashCommand("")).toBeNull();
+  });
+
+  it("returns null for bare slash", () => {
+    expect(parseSlashCommand("/")).toBeNull();
+  });
+
+  it("recognizes /exit as builtin exit", () => {
+    expect(parseSlashCommand("/exit")).toEqual({ type: "exit" });
+  });
+
+  it("recognizes /clear as builtin clear", () => {
+    expect(parseSlashCommand("/clear")).toEqual({ type: "clear" });
+  });
+
+  it("returns unknown for unrecognized command with no file", () => {
+    const result = parseSlashCommand("/unknown");
+    expect(result).toEqual({ type: "unknown_command", command: "unknown" });
+  });
+
+  it("parses command name from input with arguments", () => {
+    const result = parseSlashCommand("/foo some args");
+    expect(result).toEqual({ type: "unknown_command", command: "foo" });
+  });
+
+  it("parses command name with colon namespace", () => {
+    const result = parseSlashCommand("/foo:bar");
+    expect(result).toEqual({ type: "unknown_command", command: "foo:bar" });
+  });
+});
+
+describe("resolveCommandFilePath", () => {
+  it("simple command maps to ~/.claude/commands/<cmd>.md", () => {
+    const path = resolveCommandFilePath("brainstorming");
+    expect(path).toMatch(/\.claude\/commands\/brainstorming\.md$/);
+  });
+
+  it("colon in command name maps to slash in path", () => {
+    const path = resolveCommandFilePath("foo:bar");
+    expect(path).toMatch(/\.claude\/commands\/foo\/bar\.md$/);
+  });
+
+  it("multiple colons produce nested path", () => {
+    const path = resolveCommandFilePath("a:b:c");
+    expect(path).toMatch(/\.claude\/commands\/a\/b\/c\.md$/);
+  });
+
+  it("path starts from home directory", () => {
+    const path = resolveCommandFilePath("cmd");
+    const home = process.env.HOME ?? process.env.USERPROFILE ?? "";
+    expect(path.startsWith(home)).toBe(true);
+  });
+});
+
+describe("loadCommandFile", () => {
+  it("returns file content when file exists", () => {
+    const content = loadCommandFile("brainstorming", (_path) => "# Brainstorm\nThink creatively.");
+    expect(content).toBe("# Brainstorm\nThink creatively.");
+  });
+
+  it("returns null when file does not exist", () => {
+    const content = loadCommandFile("nonexistent", (_path) => null);
+    expect(content).toBeNull();
+  });
+
+  it("passes the resolved path to readFile", () => {
+    let capturedPath = "";
+    loadCommandFile("foo:bar", (path) => { capturedPath = path; return null; });
+    expect(capturedPath).toMatch(/\.claude\/commands\/foo\/bar\.md$/);
+  });
+});


### PR DESCRIPTION
## Summary

Implements [issue #1](https://github.com/jasoncrawford/gh-agent/issues/1) — slash command support in the REPL.

- `/exit` and `/clear` replace the old `exit`/`reset` text commands
- Custom commands (e.g. `/brainstorming`) load `~/.claude/commands/brainstorming.md` and pass the content as a query
- Colons become path separators: `/foo:bar` loads `~/.claude/commands/foo/bar.md`
- Extra text after the command name is appended to the loaded prompt (e.g. `/brainstorming focus on UX`)
- Unknown commands (no matching builtin and no matching file) print `Unknown command: /name`

## Implementation

- `parseSlashCommand(input)` — pure function, detects and classifies slash input
- `resolveCommandFilePath(command)` — maps command name to `~/.claude/commands/*.md` path
- `loadCommandFile(command, readFile?)` — loads the file; `readFile` is injectable for testing
- `dispatchInput(input, readFile?)` — full dispatch logic; returns a typed `DispatchResult` for easy testing and use in `main()`

## Test plan

- [x] 22 new tests across `repl.slash.test.ts` and `repl.dispatch.test.ts`
- [x] All 237 tests pass (`npm test`)
- [x] TDD: wrote failing tests before implementing each function

🤖 Generated with [Claude Code](https://claude.com/claude-code)