### PR TITLE
fix: /exit hangs terminal (#7)

### DIFF
--- a/src/repl.ts
+++ b/src/repl.ts
@@ -769,6 +769,8 @@ async function main() {
 
     if (action.type === "exit") {
       process.stdout.write("\x1b[?2004l\r\n");
+      process.stdin.setRawMode(false);
+      process.stdin.pause();
       break;
     }
 


### PR DESCRIPTION
## Summary
- Closes #7
- `/exit` called `break` after disabling bracketed paste, but left `process.stdin` in raw mode and resumed — keeping the event loop alive
- Added `process.stdin.setRawMode(false)` and `process.stdin.pause()` before `break` so the process exits cleanly

## Test Plan
- [ ] `npm start` (or `npm run repl`), type `/exit` — shell prompt returns immediately
- [ ] All 237 existing tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)