### PR TITLE
fix: add containerEnv for auth tokens; document git workflow

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,5 +7,10 @@
   "features": {
     "ghcr.io/jasoncrawford/devcontainer-claude/setup:1": {}
   },
+  "containerEnv": {
+    "GH_TOKEN": "${localEnv:GH_TOKEN}",
+    "VERCEL_TOKEN": "${localEnv:VERCEL_TOKEN}",
+    "CLAUDE_CODE_OAUTH_TOKEN": "${localEnv:CLAUDE_CODE_OAUTH_TOKEN}"
+  },
   "waitFor": "postStartCommand"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,11 @@ npx smee-client --url https://smee.io/YOUR_CHANNEL --target http://localhost:300
 npm start
 ```
 
+## Git workflow
+
+- Always create a feature branch and PR for changes — never commit directly to `main`.
+- Do NOT auto-merge PRs — leave merging to the user after UAT.
+
 ## Key conventions
 
 - TypeScript with ESM (`"type": "module"`). New dependencies must be ESM-compatible.


### PR DESCRIPTION
## Summary

- Add `containerEnv` with `GH_TOKEN`, `VERCEL_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`. Feature `containerEnv` cannot resolve `${localEnv:...}` at Docker build time (devcontainers/cli#308); must be in project `devcontainer.json` instead.
- Add git workflow section to `CLAUDE.md` (always branch + PR, no auto-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)