### PR TITLE
chore: add npm ci to postCreateCommand for node_modules volume

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,5 +12,6 @@
     "VERCEL_TOKEN": "${localEnv:VERCEL_TOKEN}",
     "CLAUDE_CODE_OAUTH_TOKEN": "${localEnv:CLAUDE_CODE_OAUTH_TOKEN}"
   },
+  "postCreateCommand": "npm ci",
   "waitFor": "postStartCommand"
 }


### PR DESCRIPTION
The devcontainer feature (as of v1.0.2) now mounts a named volume at `/workspace/node_modules` to shadow the host darwin-arm64 `node_modules`. This `postCreateCommand` populates that volume with linux-x64 binaries on first container creation.

Fixes the esbuild platform mismatch error when running `npm run repl` (or any script using native modules) inside the devcontainer.

## Test plan
- [ ] Rebuild the devcontainer (`ccnuke` or `devcontainer up`)
- [ ] Verify `npm run repl -- --dangerously-skip-permissions` runs without the esbuild platform error

🤖 Generated with [Claude Code](https://claude.com/claude-code)