### PR TITLE
fix: use remoteEnv for token secrets instead of containerEnv

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
   "features": {
     "ghcr.io/jasoncrawford/devcontainer-claude/setup:1": {}
   },
-  "containerEnv": {
+  "remoteEnv": {
     "GH_TOKEN": "${localEnv:GH_TOKEN}",
     "VERCEL_TOKEN": "${localEnv:VERCEL_TOKEN}",
     "CLAUDE_CODE_OAUTH_TOKEN": "${localEnv:CLAUDE_CODE_OAUTH_TOKEN}"


### PR DESCRIPTION
Moves `GH_TOKEN`, `VERCEL_TOKEN`, and `CLAUDE_CODE_OAUTH_TOKEN` from `containerEnv` to `remoteEnv`. Prevents tokens from being baked into ephemeral Docker image layers during devcontainer build. See jasoncrawford/devcontainer-claude#17.