### PR TITLE
docs: add foreman/worker architecture design spec

### DIFF
--- a/docs/superpowers/specs/2026-03-13-foreman-worker-design.md
+++ b/docs/superpowers/specs/2026-03-13-foreman-worker-design.md
@@ -24,15 +24,15 @@ GitHub ──webhook──▶ Foreman (src/foreman.ts)
 - On startup, scans GitHub API for open issues labeled `brunel:ready` → seeds pending task queue
 - Accepts WebSocket connections from workers on the `/worker` path of the existing HTTP server
 - Assigns pending tasks to idle workers
-- Routes incoming webhook events to the worker handling the relevant issue/PR
+- Forwards incoming webhook events immediately to the assigned worker; queues them on the Task object if no worker is assigned yet
 - Tracks all state in memory; re-scans GitHub on restart as crash recovery
 
 **Worker** — new mode of `src/repl.ts` (`--worker-mode`):
 - Connects to foreman via WebSocket on startup
 - Receives typed structured messages (task assignments, event notifications)
-- Generates agent prompts from those messages using local templates
-- Runs the agent loop (`runQuery()`) until the agent stops naturally
-- After each loop: signals foreman it's idle; receives queued events or waits
+- Maintains a local `pendingEvents` queue populated by an always-on WebSocket message handler
+- Generates agent prompts from templates; runs `runQuery()` until the agent stops
+- After each agent loop, drains `pendingEvents` and generates the next prompt, or waits for the next input (user or event)
 - Accepts `/task-complete` slash command to release the task and return to idle
 
 Workers run in Docker devcontainers (one per worker). Foreman runs separately. All on one machine initially; designed to move to cloud without protocol changes. In cloud deployments, use `wss://` for `FOREMAN_URL` and configure TLS accordingly.
@@ -48,7 +48,6 @@ All messages are JSON. The same `worker_hello` message is used for both initial 
 | Message | Fields | When |
 |---------|--------|------|
 | `worker_hello` | `workerId`, `taskId?`, `status: "idle"\|"busy"` | On connect or reconnect |
-| `agent_idle` | `workerId`, `taskId` | Agent loop finished, ready for next prompt |
 | `task_complete` | `workerId`, `taskId` | User ran `/task-complete` |
 
 ### Foreman → Worker
@@ -56,18 +55,16 @@ All messages are JSON. The same `worker_hello` message is used for both initial 
 | Message | Fields | When |
 |---------|--------|------|
 | `task_assigned` | `taskId`, `issue: { number, title, body, labels, repoUrl }` | Task available for worker |
-| `event_notification` | `taskId`, `events: GitHubEvent[]` | One or more queued events for active task |
+| `event_notification` | `taskId`, `event: GitHubEvent` | Single event forwarded as it arrives |
 | `standby` | — | No tasks available; worker waits |
 
 The foreman **always** responds to `worker_hello` with either `task_assigned` or `standby`. Workers can rely on this to know they are registered.
 
-The foreman **always** responds to `agent_idle` with either `event_notification` or `standby`. Workers can rely on this to know their idle signal was received.
-
-The foreman **silently ignores** messages referencing unknown `taskId`s (e.g., a late `agent_idle` for a task already marked complete). No error response.
+The foreman **silently ignores** messages referencing unknown `taskId`s. No error response.
 
 ### `GitHubEvent` type
 
-Defined once in shared code (e.g., `src/types.ts`) and used in both the protocol and foreman state:
+Defined once in shared code (`src/types.ts`) and used throughout:
 
 ```typescript
 interface GitHubEvent {
@@ -82,34 +79,48 @@ interface GitHubEvent {
 Workers have **stable IDs** — a UUID generated on first startup and persisted to `.worker-id` in the working directory. This survives container restarts and foreman crashes.
 
 On reconnect, the worker sends `worker_hello` with its current state (`taskId`, `status`). The foreman reconciles:
-- If `status: "busy"` with a `taskId`: foreman marks that task as assigned to this worker, removing it from the pending queue if present. **First reconnecting claim wins** — if two workers somehow claim the same `taskId`, the second gets `standby`.
+- If `status: "busy"` with a `taskId`: foreman marks that task as assigned to this worker, removing it from the pending queue if present. Any events queued on the Task object are forwarded immediately. **First reconnecting claim wins** — if two workers claim the same `taskId`, the second gets `standby`.
 - If `status: "idle"`: foreman treats this as a fresh registration and assigns the next pending task or sends `standby`.
 
 **Workers continue working during disconnection.** The WebSocket and the agent loop are independent. If the foreman goes away mid-session, the worker keeps running `runQuery()` and reconnects in the background with exponential backoff. No work is lost.
 
-**`/task-complete` timing:** This slash command is only available between agent loops — the worker's input prompt is only shown after `runQuery()` returns. There is no risk of the user completing a task while the agent is still running.
+## Event Handling
+
+**Foreman forwards events immediately.** When a webhook arrives for an issue with an assigned worker, the foreman sends a single `event_notification` message over the WebSocket right away. No batching, no coalescing — the foreman is a router, not a scheduler.
+
+**Worker queues events locally.** The worker registers a persistent `message` handler on the WebSocket connection. While `runQuery()` is running, the Node.js event loop remains live (async generator + `for await`), so incoming WebSocket messages fire their handler between iterations and are pushed to a local `pendingEvents: GitHubEvent[]` array. No separate process or thread is needed.
+
+**Worker coalesces when ready.** After each `runQuery()` call returns, the worker checks `pendingEvents`:
+- Empty → proceed to "wait for input" (see below)
+- Non-empty → drain the queue, generate a single prompt using templates, call `runQuery()` again resuming the same session
+
+**Prompt generation from events:**
+- **Single event**: per-type template (e.g., CI failure → structured summary of the failure output)
+- **Multiple events**: static fallback: *"Multiple events have arrived since you last checked. Please review the current state of your PR and respond accordingly."*
+
+Templates live in `src/templates.ts` and are designed to become more sophisticated over time without protocol changes.
+
+**Events for pending tasks** (no worker assigned yet): queued on the `Task` object and forwarded to the worker when the task is eventually assigned.
+
+## Waiting for Input (Worker)
+
+When `pendingEvents` is empty after an agent loop (or when the worker is idle between tasks), the worker needs to wait for the next input. In worker mode, input can come from two sources:
+
+1. **WebSocket** — a `task_assigned` or `event_notification` message from the foreman
+2. **stdin** — the user types something (a question, feedback, or `/task-complete`)
+
+The worker waits by racing these two sources with `Promise.race()`. Whichever resolves first becomes the next prompt. If the WebSocket wins, the user's partially-typed input (if any) is cleared and the event is processed. This ensures events are never ignored while the worker is waiting at the prompt.
 
 ## Task Lifecycle
 
 1. Issue labeled `brunel:ready` on GitHub → foreman receives webhook (or finds it on startup scan) → task added to pending queue
-2. Idle worker sends `worker_hello` or `agent_idle` → foreman sends `task_assigned` or `standby`
+2. Worker sends `worker_hello` with `status: "idle"` → foreman sends `task_assigned` or `standby`
 3. Worker generates initial prompt from issue data using a local template → calls `runQuery()`
 4. Agent works: creates branch, writes code, opens PR
-5. GitHub events arrive (CI results, review comments, etc.) → foreman queues them on the `Task` object
-6. Agent finishes a loop → worker sends `agent_idle` → foreman sends `event_notification` (draining the task's event queue) or `standby` (if empty)
-7. Worker generates a prompt from the events → calls `runQuery()` resuming the same session
-8. User types `/task-complete` → worker sends `task_complete` → foreman labels issue `brunel:done`, removes from active tasks → worker goes idle → foreman sends next task or `standby`
-
-## Event Coalescing
-
-When the foreman sends `event_notification`, it drains the entire event queue for that task and sends all accumulated events in one message. The worker turns them into a prompt:
-
-- **Single event**: per-type template (e.g., CI failure → structured summary of the failure)
-- **Multiple events**: static fallback: *"Multiple events have arrived since you last checked. Please review the current state of your PR and respond accordingly."*
-
-Templates live in `src/templates.ts`. The coalescing logic is designed to become more sophisticated over time (e.g., latest CI status + latest CodeQL status + all new comments) without changing the protocol.
-
-**Events for pending tasks** (no worker assigned yet): queued on the `Task` object and delivered to the worker when the task is eventually assigned.
+5. GitHub events arrive → foreman forwards each as `event_notification` → worker's message handler pushes to `pendingEvents`
+6. Agent loop finishes → worker drains `pendingEvents`, generates coalesced prompt → calls `runQuery()` resuming the same session
+7. Repeat steps 5–6 until task is done
+8. User types `/task-complete` → worker sends `task_complete` → foreman labels issue `brunel:done`, removes task → worker sends `worker_hello` with `status: "idle"` → foreman sends next task or `standby`
 
 ## Foreman State
 
@@ -127,7 +138,7 @@ interface Task {
   repoUrl: string;
   status: "pending" | "assigned" | "complete";
   assignedWorkerId?: string;
-  eventQueue: GitHubEvent[];  // queued even before assignment
+  eventQueue: GitHubEvent[];  // only used while task is pending (no assigned worker)
 }
 
 interface WorkerState {
@@ -159,13 +170,14 @@ All via environment variables (`.env`):
 - `WorkerRegistry` class — connected workers, state
 - `TaskQueue` class — pending/assigned tasks, GitHub API seeding
 - WebSocket server on `/worker` upgrade path of existing HTTP server
-- Event router — on webhook, push to task's event queue; if task is assigned, notify worker immediately
+- Event router — on webhook, forward to assigned worker immediately or queue on Task if pending
 
 **`src/repl.ts`** — additions:
-- `workerMain()` alongside existing `main()` — WebSocket connection, worker loop
+- `workerMain()` alongside existing `main()` — WebSocket connection, worker loop, `pendingEvents` queue, `Promise.race()` input waiting
 - `/task-complete` slash command — new case in `parseSlashCommand()`
 
 **New files:**
+- `src/types.ts` — shared types (`GitHubEvent`, protocol message types)
 - `src/templates.ts` — prompt templates keyed by event type
 - `src/worker-id.ts` — reads/writes `.worker-id`
 


### PR DESCRIPTION
## Summary

- Adds `docs/superpowers/specs/2026-03-13-foreman-worker-design.md` — the design spec for the foreman/worker architecture
- No code changes; pure documentation

## Design highlights

- Foreman (evolves from `src/index.ts`) manages task queue, accepts worker WebSocket connections, routes GitHub events
- Workers (new `--worker-mode` in `src/repl.ts`) own prompt templates and event coalescing via a local `pendingEvents` queue
- Foreman streams events immediately to assigned workers; workers coalesce when ready between agent loops
- Workers have stable UUIDs (`.worker-id`) and reconnect with exponential backoff
- Workers wait for next input via `Promise.race(stdin, websocket)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)