### PR TITLE
chore: add .worker-id to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 dist/
 .env
 repl.log
+.worker-id


### PR DESCRIPTION
Worker stable ID (`.worker-id`) is machine-specific state generated on first run — no reason to track it in git.

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)