### PR TITLE
Fix: worker reconnecting with completed taskId no longer gets reassigned

### DIFF
--- a/src/foreman.ts
+++ b/src/foreman.ts
@@ -469,8 +469,8 @@ export function createForemanWss(
 
         if (msg.status === "busy" && msg.taskId) {
           const existing = taskQueue.get(msg.taskId);
-          if (existing && (existing.status !== "assigned" || existing.assignedWorkerId === workerId)) {
-            // Task is free, or this is the worker that owns it — reclaim.
+          if (existing && existing.status !== "complete" && (existing.status !== "assigned" || existing.assignedWorkerId === workerId)) {
+            // Task is pending/assigned to this worker — reclaim.
             registry.register(workerId, ws, "busy", msg.taskId);
             taskQueue.assignTask(msg.taskId, workerId);
             const queued = taskQueue.drainEvents(msg.taskId);

--- a/tests/foreman.websocket.test.ts
+++ b/tests/foreman.websocket.test.ts
@@ -262,4 +262,17 @@ describe("foreman WebSocket protocol", () => {
     expect(await reply).toEqual({ type: "standby" });
     expect(queue.get("1")?.status).toBe("complete");
   });
+
+  it("worker reconnects as busy with a completed taskId gets standby", async () => {
+    queue.addTask(makeTask(1));
+    // Mark task as complete directly (simulates another path completing it while worker was disconnected)
+    queue.assignTask("1", "w1");
+    queue.completeTask("1");
+
+    const ws = await connect();
+    const reply = nextMsg(ws);
+    send(ws, { type: "worker_hello", workerId: "w1", taskId: "1", status: "busy" });
+    expect(await reply).toEqual({ type: "standby" });
+    expect(registry.get("w1")?.status).toBe("idle");
+  });
 });


### PR DESCRIPTION
Fixes #40.

## Summary

- Added `existing.status !== "complete"` guard to the worker reconnect condition in `foreman.ts`
- Before this fix, a worker reconnecting as busy with a `taskId` that had already been marked complete would silently reclaim the task as if it were still in progress
- Added a regression test covering this edge case

## Test Plan

- [ ] All 315 tests pass (`npm test`)
- [ ] New test: "worker reconnects as busy with a completed taskId gets standby" — verifies worker gets `standby` and is registered as idle

Closes #40