### PR TITLE
fix: fall back to GH_TOKEN if GITHUB_TOKEN is not set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ npm run worker
 
 Required env vars (in `.env`):
 - `GITHUB_REPO` — e.g. `owner/repo`
-- `GITHUB_TOKEN` — personal access token with `repo` scope
+- `GITHUB_TOKEN` or `GH_TOKEN` — personal access token with `repo` scope (`GH_TOKEN` is already forwarded in the devcontainer)
 - `TASK_LABEL` — label that triggers work (default: `brunel:ready`)
 - `DONE_LABEL` — label applied on completion (default: `brunel:done`)
 - `FOREMAN_URL` — WebSocket URL workers connect to (default: `ws://localhost:3000`)

--- a/src/foreman.ts
+++ b/src/foreman.ts
@@ -146,7 +146,7 @@ export class TaskQueue {
 function ghEnv() {
   return {
     repo:       process.env.GITHUB_REPO ?? "",
-    token:      process.env.GITHUB_TOKEN ?? "",
+    token:      process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN ?? "",
     taskLabel:  process.env.TASK_LABEL ?? "brunel:ready",
     doneLabel:  process.env.DONE_LABEL ?? "brunel:done",
   };


### PR DESCRIPTION
`ghEnv()` now checks `GH_TOKEN` as a fallback, which is already forwarded into the devcontainer. No need to set `GITHUB_TOKEN` separately when running inside the container.