### PR TITLE
chore: allow smee.io through devcontainer firewall

### DIFF
--- a/.devcontainer/firewall-extras.txt
+++ b/.devcontainer/firewall-extras.txt
@@ -1,1 +1,1 @@
-# brunel has no extra firewall domains
+smee.io


### PR DESCRIPTION
Adds smee.io to firewall-extras.txt so the smee webhook proxy client can reach smee.io from inside the devcontainer.