### PR TITLE
feat: improve rendering of time and token counts

### DIFF
--- a/src/display.ts
+++ b/src/display.ts
@@ -52,7 +52,7 @@ export function fmtDuration(secs: number): string {
 }
 
 export function fmtNum(n: number): string {
-  if (n >= 1000) return `${Math.floor(n / 1000)}k`;
+  if (n >= 1000) return `${parseFloat((n / 1000).toPrecision(3))}k`;
   return `${n}`;
 }
 

--- a/tests/repl.helpers.test.ts
+++ b/tests/repl.helpers.test.ts
@@ -109,8 +109,16 @@ describe("fmtNum", () => {
     expect(fmtNum(31026)).toBe("31k");
   });
 
-  it("rounds down (floor)", () => {
-    expect(fmtNum(1999)).toBe("1k");
+  it("1990 is 1.99k (3 significant figures)", () => {
+    expect(fmtNum(1990)).toBe("1.99k");
+  });
+
+  it("1999 rounds to 2k", () => {
+    expect(fmtNum(1999)).toBe("2k");
+  });
+
+  it("15342 is 15.3k (3 significant figures)", () => {
+    expect(fmtNum(15342)).toBe("15.3k");
   });
 
   it("0 is 0", () => {


### PR DESCRIPTION
## Summary

- Adds `fmtDuration(secs)`: formats seconds as `Xm Ys` for ≥60s (e.g. `630s` → `10m30s`), or plain `Xs` for under a minute
- Adds `fmtNum(n)`: formats numbers ≥1000 with a `k` suffix (e.g. `31026` → `31k`)
- Updates `fmtStats` to use both, applied to the live "Working…" status line and the session result message

## Test plan

- [ ] `fmtDuration` and `fmtNum` unit tests added and passing
- [ ] `fmtStats` tests updated with large-value examples
- [ ] All 328 existing tests continue to pass

Closes #19