### PR TITLE
feat: concise one-line foreman logging for webhook events and worker messages

### DIFF
--- a/src/foreman.ts
+++ b/src/foreman.ts
@@ -208,144 +208,40 @@ if (webhooks) {
   });
 }
 
-function printEvent(id: string, name: string, payload: unknown) {
+function truncTitle(title: unknown, max = 50): string {
+  const s = String(title ?? "").replace(/\s+/g, " ").trim();
+  return s.length > max ? s.slice(0, max - 1) + "…" : s;
+}
+
+export function summaryEvent(id: string, name: string, payload: unknown): string {
   const p = payload as Record<string, unknown>;
-  const action = typeof p.action === "string" ? ` / ${p.action}` : "";
+  const action = typeof p.action === "string" ? `/${p.action}` : "";
+  const repo = (p.repository as Record<string, unknown> | undefined)?.full_name;
+  const sender = (p.sender as Record<string, unknown> | undefined)?.login;
 
-  console.log(`\n${"═".repeat(70)}`);
-  console.log(`EVENT   ${name}${action}`);
-  console.log(`ID      ${id}`);
-  console.log("─".repeat(70));
+  let detail = "";
+  const issue = p.issue as Record<string, unknown> | undefined;
+  const pr = p.pull_request as Record<string, unknown> | undefined;
 
-  const repo = p.repository as R | undefined;
-  const sender = p.sender as R | undefined;
-  if (repo) console.log(`REPO    ${repo.full_name}`);
-  if (sender) console.log(`BY      ${sender.login}`);
-
-  details(name, p);
-  console.log("═".repeat(70));
-}
-
-function field(label: string, value: unknown) {
-  if (value == null || value === "" || value === false) return;
-  console.log(`${label.padEnd(8)}${value}`);
-}
-
-function body(label: string, text: unknown) {
-  const s = String(text ?? "").trim();
-  if (!s) return;
-  console.log(`\n${label}:\n${s}`);
-}
-
-function logins(items: R[] | undefined) {
-  return items?.map((i) => i.login).join(", ") ?? "";
-}
-
-function labels(items: { name: string }[] | undefined) {
-  return items?.map((l) => l.name).join(", ") ?? "";
-}
-
-function details(name: string, p: R) {
-  const issue = p.issue as R | undefined;
-  const pr = p.pull_request as R | undefined;
-  const comment = p.comment as R | undefined;
-  const review = p.review as R | undefined;
-
-  switch (name) {
-    case "issues": {
-      if (!issue) break;
-      field("ISSUE", `#${issue.number}: ${issue.title}`);
-      field("STATE", issue.state);
-      field("LABELS", labels(issue.labels as { name: string }[]));
-      field("ASSIGN", logins(issue.assignees as R[]));
-      body("BODY", issue.body);
-      if (p.action === "labeled" || p.action === "unlabeled") {
-        field("LABEL", (p.label as R)?.name);
-      }
-      break;
-    }
-
-    case "issue_comment": {
-      if (!issue || !comment) break;
-      field("ISSUE", `#${issue.number}: ${issue.title}`);
-      field("STATE", issue.state);
-      field("LABELS", labels(issue.labels as { name: string }[]));
-      body("COMMENT", comment.body);
-      break;
-    }
-
-    case "pull_request": {
-      if (!pr) break;
-      const head = pr.head as R;
-      const base = pr.base as R;
-      field("PR", `#${pr.number}: ${pr.title}`);
-      field("BRANCH", `${head.ref} → ${base.ref}`);
-      field("STATE", `${pr.state}${pr.draft ? " (draft)" : ""}${pr.merged ? " (merged)" : ""}`);
-      field("LABELS", labels(pr.labels as { name: string }[]));
-      field("ASSIGN", logins(pr.assignees as R[]));
-      field("REVIEW", logins(pr.requested_reviewers as R[]));
-      body("BODY", pr.body);
-      break;
-    }
-
-    case "pull_request_review": {
-      if (!pr || !review) break;
-      field("PR", `#${pr.number}: ${pr.title}`);
-      field("STATE", review.state);
-      body("REVIEW", review.body);
-      break;
-    }
-
-    case "pull_request_review_comment": {
-      if (!pr || !comment) break;
-      field("PR", `#${pr.number}: ${pr.title}`);
-      field("FILE", `${comment.path} (line ${comment.original_line ?? comment.line ?? "?"})`);
-      body("DIFF", comment.diff_hunk);
-      body("COMMENT", comment.body);
-      break;
-    }
-
-    case "push": {
-      const commits = p.commits as R[] | undefined;
-      field("REF", p.ref);
-      field("COMMITS", commits?.length ?? 0);
-      commits?.forEach((c) => {
-        const author = (c.author as R)?.name ?? "?";
-        const sha = String(c.id).slice(0, 7);
-        console.log(`  ${sha}  ${c.message}  (${author})`);
-      });
-      break;
-    }
-
-    case "check_run": {
-      const run = p.check_run as R;
-      const output = run.output as R | undefined;
-      field("CHECK", run.name);
-      field("STATUS", `${run.status} / ${run.conclusion ?? "pending"}`);
-      if (output?.title) body("OUTPUT", `${output.title}\n${output.summary ?? ""}`);
-      break;
-    }
-
-    case "workflow_run": {
-      const run = p.workflow_run as R;
-      field("WORKFLOW", run.name);
-      field("BRANCH", run.head_branch);
-      field("STATUS", `${run.status} / ${run.conclusion ?? "pending"}`);
-      break;
-    }
-
-    case "create":
-    case "delete":
-      field("REF", `${p.ref} (${p.ref_type})`);
-      break;
-
-    case "release": {
-      const release = p.release as R;
-      field("RELEASE", `${release.tag_name}: ${release.name}`);
-      body("BODY", release.body);
-      break;
-    }
+  if (issue) {
+    detail = ` #${issue.number} "${truncTitle(issue.title)}"`;
+  } else if (pr) {
+    detail = ` #${pr.number} "${truncTitle(pr.title)}"`;
+  } else if (name === "push") {
+    const ref = String(p.ref ?? "");
+    const count = (p.commits as unknown[] | undefined)?.length ?? 0;
+    detail = ` ${ref} (${count} commit${count === 1 ? "" : "s"})`;
   }
+
+  const parts: string[] = [`${name}${action}${detail}`];
+  if (sender) parts.push(`by ${sender}`);
+  if (repo) parts.push(`(${repo})`);
+
+  return `[event] ${parts.join(" ")}`;
+}
+
+function printEvent(id: string, name: string, payload: unknown) {
+  console.log(summaryEvent(id, name, payload));
 }
 
 // ── HTTP server ───────────────────────────────────────────────────────────────

--- a/tests/foreman.logging.test.ts
+++ b/tests/foreman.logging.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { summaryEvent } from "../src/foreman.js";
+
+describe("summaryEvent", () => {
+  it("renders a single line with no newlines", () => {
+    const result = summaryEvent("id-1", "issues", {
+      action: "labeled",
+      issue: { number: 42, title: "Fix the bug" },
+      sender: { login: "alice" },
+      repository: { full_name: "owner/repo" },
+    });
+    expect(result).not.toContain("\n");
+  });
+
+  it("includes event name and action for issues/labeled", () => {
+    const result = summaryEvent("id-1", "issues", {
+      action: "labeled",
+      issue: { number: 42, title: "Fix the bug" },
+      sender: { login: "alice" },
+      repository: { full_name: "owner/repo" },
+    });
+    expect(result).toMatch(/issues\/labeled/);
+    expect(result).toContain("#42");
+    expect(result).toContain("Fix the bug");
+    expect(result).toContain("alice");
+    expect(result).toContain("owner/repo");
+  });
+
+  it("includes event name and action for issue_comment/created", () => {
+    const result = summaryEvent("id-2", "issue_comment", {
+      action: "created",
+      issue: { number: 7, title: "Another issue" },
+      comment: { body: "Great work!" },
+      sender: { login: "bob" },
+      repository: { full_name: "owner/repo" },
+    });
+    expect(result).toMatch(/issue_comment\/created/);
+    expect(result).toContain("#7");
+    expect(result).toContain("bob");
+  });
+
+  it("includes PR number for pull_request events", () => {
+    const result = summaryEvent("id-3", "pull_request", {
+      action: "opened",
+      pull_request: { number: 5, title: "Add feature" },
+      sender: { login: "carol" },
+      repository: { full_name: "owner/repo" },
+    });
+    expect(result).toMatch(/pull_request\/opened/);
+    expect(result).toContain("#5");
+    expect(result).toContain("Add feature");
+    expect(result).not.toContain("\n");
+  });
+
+  it("includes ref and commit count for push events", () => {
+    const result = summaryEvent("id-4", "push", {
+      ref: "refs/heads/main",
+      commits: [{}, {}, {}],
+      sender: { login: "dave" },
+      repository: { full_name: "owner/repo" },
+    });
+    expect(result).toContain("push");
+    expect(result).toContain("refs/heads/main");
+    expect(result).toContain("3");
+    expect(result).not.toContain("\n");
+  });
+
+  it("handles event with no action gracefully", () => {
+    const result = summaryEvent("id-5", "ping", {
+      sender: { login: "user" },
+      repository: { full_name: "owner/repo" },
+    });
+    expect(result).toContain("ping");
+    expect(result).not.toMatch(/ping\//);  // no slash after event name when no action
+    expect(result).not.toContain("\n");
+  });
+
+  it("truncates long titles to stay concise", () => {
+    const longTitle = "A".repeat(100);
+    const result = summaryEvent("id-6", "issues", {
+      action: "opened",
+      issue: { number: 1, title: longTitle },
+      repository: { full_name: "owner/repo" },
+    });
+    expect(result).not.toContain("\n");
+    // The full 100-char title should not appear verbatim
+    expect(result).not.toContain(longTitle);
+  });
+
+  it("omits sender when not present", () => {
+    const result = summaryEvent("id-7", "issues", {
+      action: "opened",
+      issue: { number: 1, title: "Test" },
+      repository: { full_name: "owner/repo" },
+    });
+    expect(result).not.toContain("by undefined");
+    expect(result).not.toContain("by null");
+  });
+
+  it("omits repo when not present", () => {
+    const result = summaryEvent("id-8", "issues", {
+      action: "opened",
+      issue: { number: 1, title: "Test" },
+    });
+    expect(result).not.toContain("undefined");
+    expect(result).not.toContain("null");
+  });
+});

--- a/tests/foreman.worker-logging.test.ts
+++ b/tests/foreman.worker-logging.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests that verify the foreman logs concise one-liners for every message
+ * sent to or received from a worker.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import http from "http";
+import { WebSocket, WebSocketServer } from "ws";
+import type { AddressInfo } from "net";
+import { TaskQueue, WorkerRegistry, createForemanWss } from "../src/foreman.js";
+import type { ForemanMessage } from "../src/types.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function connectWorker(port: number): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://localhost:${port}/worker`);
+    ws.once("open", () => resolve(ws));
+    ws.once("error", reject);
+  });
+}
+
+function nextMsg(ws: WebSocket): Promise<ForemanMessage> {
+  return new Promise((resolve) => {
+    ws.once("message", (data) => resolve(JSON.parse(data.toString())));
+  });
+}
+
+function send(ws: WebSocket, msg: object) {
+  ws.send(JSON.stringify(msg));
+}
+
+function closeClient(ws: WebSocket): Promise<void> {
+  return new Promise((resolve) => {
+    if (ws.readyState === WebSocket.CLOSED) { resolve(); return; }
+    ws.once("close", resolve);
+    ws.close();
+  });
+}
+
+// ── Test harness ──────────────────────────────────────────────────────────────
+
+let queue: TaskQueue;
+let registry: WorkerRegistry;
+let httpServer: http.Server;
+let wss: WebSocketServer;
+let routeEvent: (id: string, name: string, payload: unknown) => void;
+let port: number;
+let logLines: string[];
+const openClients: WebSocket[] = [];
+
+function connect(): Promise<WebSocket> {
+  return connectWorker(port).then((ws) => { openClients.push(ws); return ws; });
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
+  process.env.GITHUB_REPO = "owner/repo";
+  process.env.GITHUB_TOKEN = "token";
+  process.env.DONE_LABEL = "brunel:done";
+
+  logLines = [];
+  vi.spyOn(console, "log").mockImplementation((...args) => {
+    logLines.push(args.join(" "));
+  });
+
+  queue = new TaskQueue();
+  registry = new WorkerRegistry();
+  httpServer = http.createServer();
+  ({ wss, routeEventToWorker: routeEvent } = createForemanWss(queue, registry, httpServer));
+
+  return new Promise<void>((resolve) => {
+    httpServer.listen(0, () => {
+      port = (httpServer.address() as AddressInfo).port;
+      resolve();
+    });
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  delete process.env.GITHUB_REPO;
+  delete process.env.GITHUB_TOKEN;
+  delete process.env.DONE_LABEL;
+
+  return new Promise<void>((resolve) => {
+    const clients = openClients.splice(0);
+    const alive = clients.filter((c) => c.readyState !== WebSocket.CLOSED);
+    if (alive.length === 0) {
+      wss.close(() => httpServer.close(resolve));
+      return;
+    }
+    let pending = alive.length;
+    for (const c of alive) {
+      c.once("close", () => {
+        if (--pending === 0) wss.close(() => httpServer.close(resolve));
+      });
+      c.close();
+    }
+  });
+});
+
+// ── Scenarios ─────────────────────────────────────────────────────────────────
+
+describe("foreman worker message logging", () => {
+  it("logs worker_hello (idle) as a one-liner", async () => {
+    const ws = await connect();
+    const reply = nextMsg(ws);
+    send(ws, { type: "worker_hello", workerId: "worker-abc123", status: "idle" });
+    await reply;
+
+    // Log format: "[worker <first-8-chars>] ..."
+    const workerLogs = logLines.filter(l => l.startsWith("[worker "));
+    expect(workerLogs.length).toBeGreaterThan(0);
+    // Each log line must be a single line (no embedded newlines)
+    for (const line of workerLogs) {
+      expect(line).not.toContain("\n");
+    }
+  });
+
+  it("logs standby sent to worker as a one-liner", async () => {
+    const ws = await connect();
+    const reply = nextMsg(ws);
+    send(ws, { type: "worker_hello", workerId: "worker-abc123", status: "idle" });
+    await reply; // standby
+
+    const standbyLog = logLines.find(l => l.includes("standby"));
+    expect(standbyLog).toBeDefined();
+    expect(standbyLog).not.toContain("\n");
+  });
+
+  it("logs task_assigned sent to worker as a one-liner", async () => {
+    queue.addTask({
+      taskId: "1",
+      issueNumber: 1,
+      title: "Fix the thing",
+      body: "Body",
+      labels: [],
+      repoUrl: "https://github.com/owner/repo",
+    });
+
+    const ws = await connect();
+    const reply = nextMsg(ws);
+    send(ws, { type: "worker_hello", workerId: "worker-abc123", status: "idle" });
+    await reply; // task_assigned
+
+    const taskLog = logLines.find(l => l.includes("task_assigned"));
+    expect(taskLog).toBeDefined();
+    expect(taskLog).not.toContain("\n");
+    // Should include issue number for context
+    expect(taskLog).toMatch(/#1/);
+  });
+
+  it("logs task_complete received from worker as a one-liner", async () => {
+    queue.addTask({
+      taskId: "1",
+      issueNumber: 1,
+      title: "Fix the thing",
+      body: "Body",
+      labels: [],
+      repoUrl: "https://github.com/owner/repo",
+    });
+
+    const ws = await connect();
+    send(ws, { type: "worker_hello", workerId: "worker-abc123", status: "idle" });
+    await nextMsg(ws); // task_assigned
+
+    logLines.length = 0; // reset to focus on task_complete log
+    send(ws, { type: "task_complete", workerId: "worker-abc123", taskId: "1" });
+    await nextMsg(ws); // standby
+
+    const completeLog = logLines.find(l => l.includes("task_complete"));
+    expect(completeLog).toBeDefined();
+    expect(completeLog).not.toContain("\n");
+  });
+
+  it("logs event_notification sent to worker as a one-liner", async () => {
+    queue.addTask({
+      taskId: "1",
+      issueNumber: 1,
+      title: "Fix the thing",
+      body: "Body",
+      labels: [],
+      repoUrl: "https://github.com/owner/repo",
+    });
+
+    const ws = await connect();
+    send(ws, { type: "worker_hello", workerId: "worker-abc123", status: "idle" });
+    await nextMsg(ws); // task_assigned
+
+    logLines.length = 0;
+    const reply = nextMsg(ws);
+    routeEvent("evt-1", "issue_comment", { issue: { number: 1 }, comment: { body: "hi" } });
+    await reply;
+
+    const eventLog = logLines.find(l => l.includes("event_notification"));
+    expect(eventLog).toBeDefined();
+    expect(eventLog).not.toContain("\n");
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces multi-line decorated webhook event log blocks with a concise single-line summary per event (e.g. `[event] issues/labeled #42 "Fix the bug" by alice (owner/repo)`)
- Removes ~130 lines of `printEvent`/`field`/`body`/`details` formatting code
- Extracts `summaryEvent(id, name, payload): string` as a tested, exported function
- Worker message logging was already one-liner; adds tests to verify it stays that way

## Test plan

- [ ] 9 unit tests for `summaryEvent` covering issues, issue_comment, pull_request, push, no-action events, long title truncation, missing sender/repo
- [ ] 5 integration tests confirming `console.log` is called with single-line strings for `worker_hello`, `standby`, `task_assigned`, `task_complete`, and `event_notification`
- [ ] All 346 tests pass (332 existing + 14 new)

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)