### PR TITLE
fix: print one-liner when worker receives event_notification

### DIFF
--- a/src/display.ts
+++ b/src/display.ts
@@ -344,3 +344,52 @@ export function printMessage(msg: unknown) {
 export function printHook(event: string, input: unknown) {
   print(resolve(HOOK_FMT, event, { ...(input as any), _event: event }));
 }
+
+// ── GitHub event formatting ────────────────────────────────────────────────────
+
+function truncTitle(title: unknown, max = 50): string {
+  const t = String(title ?? "").replace(/\s+/g, " ").trim();
+  return t.length > max ? t.slice(0, max - 1) + "…" : t;
+}
+
+export function summaryEvent(id: string, name: string, payload: unknown): string {
+  const p = payload as Record<string, unknown>;
+  const action = typeof p.action === "string" ? `/${p.action}` : "";
+  const repo = (p.repository as Record<string, unknown> | undefined)?.full_name;
+  const sender = (p.sender as Record<string, unknown> | undefined)?.login;
+
+  let detail = "";
+  const issue = p.issue as Record<string, unknown> | undefined;
+  const pr = p.pull_request as Record<string, unknown> | undefined;
+
+  if (issue) {
+    detail = ` #${issue.number} "${truncTitle(issue.title)}"`;
+  } else if (pr) {
+    detail = ` #${pr.number} "${truncTitle(pr.title)}"`;
+  } else if (name === "push") {
+    const ref = String(p.ref ?? "");
+    const count = (p.commits as unknown[] | undefined)?.length ?? 0;
+    detail = ` ${ref} (${count} commit${count === 1 ? "" : "s"})`;
+  }
+
+  const parts: string[] = [`${name}${action}${detail}`];
+  if (sender) parts.push(`by ${sender}`);
+  if (repo) parts.push(`(${repo})`);
+
+  return `[event] ${parts.join(" ")}`;
+}
+
+// ── Foreman → Worker message formatting ───────────────────────────────────────
+
+import type { ForemanMessage } from "./types.js";
+
+/**
+ * Returns a display string for a ForemanMessage received by a worker, or null
+ * if the message type handles its own printing elsewhere in the worker loop.
+ */
+export function formatForemanMessage(msg: ForemanMessage): string | null {
+  if (msg.type === "event_notification") {
+    return summaryEvent(msg.event.id, msg.event.name, msg.event.payload);
+  }
+  return null;
+}

--- a/src/foreman.ts
+++ b/src/foreman.ts
@@ -4,6 +4,7 @@ import "dotenv/config";
 import { WebSocketServer } from "ws";
 import type { WebSocket as WsSocket } from "ws";
 import type { WorkerMessage, ForemanMessage, GitHubEvent } from "./types.js";
+export { summaryEvent } from "./display.js";
 
 type R = Record<string, unknown>;
 
@@ -206,38 +207,6 @@ if (webhooks) {
     printEvent(id, name as string, payload);
     routeEventToWorker(id, name as string, payload);
   });
-}
-
-function truncTitle(title: unknown, max = 50): string {
-  const s = String(title ?? "").replace(/\s+/g, " ").trim();
-  return s.length > max ? s.slice(0, max - 1) + "…" : s;
-}
-
-export function summaryEvent(id: string, name: string, payload: unknown): string {
-  const p = payload as Record<string, unknown>;
-  const action = typeof p.action === "string" ? `/${p.action}` : "";
-  const repo = (p.repository as Record<string, unknown> | undefined)?.full_name;
-  const sender = (p.sender as Record<string, unknown> | undefined)?.login;
-
-  let detail = "";
-  const issue = p.issue as Record<string, unknown> | undefined;
-  const pr = p.pull_request as Record<string, unknown> | undefined;
-
-  if (issue) {
-    detail = ` #${issue.number} "${truncTitle(issue.title)}"`;
-  } else if (pr) {
-    detail = ` #${pr.number} "${truncTitle(pr.title)}"`;
-  } else if (name === "push") {
-    const ref = String(p.ref ?? "");
-    const count = (p.commits as unknown[] | undefined)?.length ?? 0;
-    detail = ` ${ref} (${count} commit${count === 1 ? "" : "s"})`;
-  }
-
-  const parts: string[] = [`${name}${action}${detail}`];
-  if (sender) parts.push(`by ${sender}`);
-  if (repo) parts.push(`(${repo})`);
-
-  return `[event] ${parts.join(" ")}`;
 }
 
 function printEvent(id: string, name: string, payload: unknown) {

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -634,6 +634,7 @@ export async function workerMain() {
         resolveWsInput?.(WS_TASK_ASSIGNED);
         resolveWsInput = null;
       } else if (msg.type === "event_notification") {
+        display.print(display.c.darkGray(`  ${display.formatForemanMessage(msg)}`));
         pendingEvents.push(msg.event);
         resolveWsInput?.(WS_EVENT);
         resolveWsInput = null;

--- a/tests/repl.foreman-message-fmt.test.ts
+++ b/tests/repl.foreman-message-fmt.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for formatForemanMessage — the function that maps each ForemanMessage
+ * to a display string (or null if the message type handles its own printing).
+ *
+ * This covers the bug in issue #55: event_notification messages were received
+ * silently by the worker with nothing printed to the console.
+ */
+import { describe, it, expect } from "vitest";
+import { formatForemanMessage } from "../src/display.js";
+import type { ForemanMessage } from "../src/types.js";
+
+const baseEvent = {
+  id: "evt-1",
+  name: "issues",
+  payload: {
+    action: "labeled",
+    label: { name: "brunel:ready" },
+    issue: { number: 42, title: "Fix the bug" },
+    sender: { login: "alice" },
+    repository: { full_name: "owner/repo" },
+  },
+};
+
+describe("formatForemanMessage", () => {
+  it("returns a one-line string for event_notification", () => {
+    const msg: ForemanMessage = {
+      type: "event_notification",
+      taskId: "42",
+      event: baseEvent,
+    };
+    const text = formatForemanMessage(msg);
+    expect(text).not.toBeNull();
+    expect(text).not.toContain("\n");
+  });
+
+  it("event_notification string includes event name", () => {
+    const msg: ForemanMessage = {
+      type: "event_notification",
+      taskId: "42",
+      event: baseEvent,
+    };
+    const text = formatForemanMessage(msg)!;
+    expect(text).toContain("issues");
+  });
+
+  it("event_notification string includes issue number", () => {
+    const msg: ForemanMessage = {
+      type: "event_notification",
+      taskId: "42",
+      event: baseEvent,
+    };
+    const text = formatForemanMessage(msg)!;
+    expect(text).toMatch(/#42/);
+  });
+
+  it("event_notification works for non-issue events (e.g. push)", () => {
+    const msg: ForemanMessage = {
+      type: "event_notification",
+      taskId: "1",
+      event: {
+        id: "evt-2",
+        name: "push",
+        payload: {
+          ref: "refs/heads/main",
+          commits: [{}],
+          repository: { full_name: "owner/repo" },
+          sender: { login: "bob" },
+        },
+      },
+    };
+    const text = formatForemanMessage(msg);
+    expect(text).not.toBeNull();
+    expect(text).not.toContain("\n");
+    expect(text).toContain("push");
+  });
+
+  it("returns null for task_assigned (printed later in the task flow)", () => {
+    const msg: ForemanMessage = {
+      type: "task_assigned",
+      taskId: "1",
+      issue: { number: 1, title: "Fix bug", body: "", labels: [], repoUrl: "" },
+    };
+    expect(formatForemanMessage(msg)).toBeNull();
+  });
+
+  it("returns null for standby (printed inline in the handler)", () => {
+    const msg: ForemanMessage = { type: "standby" };
+    expect(formatForemanMessage(msg)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- **Bug:** When the foreman forwarded a GitHub event (`event_notification`) to a worker — e.g. a PR was opened or a comment was added — the worker silently queued it with nothing printed to the console.
- **Fix:** Worker now immediately prints a concise one-liner (e.g. `[event] issues/labeled #42 "Fix the bug" by alice (owner/repo)`) when it receives any `event_notification`.
- **Refactor:** Moved `summaryEvent` from `foreman.ts` to `display.ts` so both foreman (webhook logging) and repl/worker (received-event logging) share the same formatter. Re-exported from `foreman.ts` for backward compatibility with existing tests.
- Added `formatForemanMessage(msg: ForemanMessage): string | null` to `display.ts` — returns the formatted string for `event_notification`, `null` for types that already handle their own printing (`task_assigned`, `standby`).

Fixes #55

## Test plan

- [x] 6 new unit tests for `formatForemanMessage` in `tests/repl.foreman-message-fmt.test.ts`
- [x] All 352 tests pass
- [ ] Manual: start foreman + worker, trigger a GitHub event on an open issue — confirm worker prints a one-liner immediately on receipt

🤖 Generated with [Claude Code](https://claude.com/claude-code)