### PR TITLE
ci: add tsc --noEmit to catch type errors at PR time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
         env:
           CI: true
 
+      - run: npx tsc --noEmit
+
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -557,6 +557,8 @@ async function main() {
       continue;
     }
 
+    if (action.type !== "query") continue;
+
     try {
       sessionId = await runQuery(action.prompt, sessionId);
     } catch (err) {
@@ -629,7 +631,7 @@ export async function workerMain() {
   display.print(display.c.lavender(`  Worker ID: ${workerId} | Foreman: ${FOREMAN_URL}`));
   display.print(display.c.sageGreen(display.hr("═")));
 
-  let ws: WebSocket;
+  let ws!: WebSocket;
 
   function connectWs(): void {
     ws = connectToForeman(FOREMAN_URL, workerId, currentTaskId);


### PR DESCRIPTION
## Summary

- Adds `npx tsc --noEmit` as a CI step after `npm test` so TypeScript type errors are caught at PR time rather than at runtime
- Fixes two pre-existing type errors in `src/repl.ts` that would have caused the new step to fail:
  - Added `action.type !== "query"` guard before accessing `action.prompt` (TypeScript couldn't narrow the union type after the other guards)
  - Changed `let ws: WebSocket` to `let ws!: WebSocket` (definite assignment assertion — TypeScript can't statically prove `connectWs()` assigns it, but the runtime guarantee holds)

Closes #66

## Test plan

- [ ] CI passes on this PR (both `npm test` and `npx tsc --noEmit` green)
- [ ] Verify the two type fixes don't change runtime behavior (they're purely type-level narrowing)