### PR TITLE
feat: add trailing space after tab-completion of slash commands

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -595,7 +595,7 @@ export function ask(
         else if (ch === "\x1f")                       { moveTo(cursor + 1); }    // →
         else if (ch === "\x09") {                                                 // Tab
           const matches = computeMatches();
-          if (matches.length > 0) { replaceBuffer("/" + matches[0]); }
+          if (matches.length > 0) { replaceBuffer("/" + matches[0] + " "); }
         }
         else if (code >= 32)                          { insert(ch); }
       }

--- a/tests/repl.autocomplete.test.ts
+++ b/tests/repl.autocomplete.test.ts
@@ -402,6 +402,18 @@ describe("ask() - Tab completion", () => {
       expect(result).toBe("/exit");
     });
   });
+
+  it("Tab adds trailing space so arguments can be typed immediately", async () => {
+    await withFakeStdin(async (stdin) => {
+      const p = ask("> ", cmds);
+      stdin.push("/ex");
+      stdin.push("\x09");   // Tab — completes to "/exit "
+      stdin.push("arg1");   // type argument right away, no extra space needed
+      stdin.push("\r");
+      const result = await p;
+      expect(result).toBe("/exit arg1");
+    });
+  });
 });
 
 // ── Enter completion ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- When tab-completing a slash command (e.g. `/ex` → Tab), a trailing space is now appended so arguments can be typed immediately
- No change to Enter-completion behavior
- The trailing space is trimmed on submit, so commands without arguments work exactly as before

## Test plan

- [x] Existing Tab completion tests still pass (trailing space is trimmed on submit)
- [x] New test: Tab then type argument immediately → `"/exit arg1"` (no extra space needed)

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)