### PR TITLE
fix: strengthen test assertions and remove timing fragility

### DIFF
--- a/tests/foreman.websocket.test.ts
+++ b/tests/foreman.websocket.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import assert from "node:assert";
 import http from "http";
 import { WebSocket, WebSocketServer } from "ws";
 import type { AddressInfo } from "net";
@@ -111,9 +112,9 @@ describe("foreman WebSocket protocol", () => {
     const reply = nextMsg(ws);
     send(ws, { type: "worker_hello", workerId: "w1", status: "idle" });
     const msg = await reply;
-    expect(msg.type).toBe("task_assigned");
-    expect((msg as any).issue.number).toBe(1);
-    expect((msg as any).taskId).toBe("1");
+    assert(msg.type === "task_assigned");
+    expect(msg.issue.number).toBe(1);
+    expect(msg.taskId).toBe("1");
     expect(queue.get("1")?.status).toBe("assigned");
     expect(registry.get("w1")?.status).toBe("busy");
   });
@@ -135,14 +136,14 @@ describe("foreman WebSocket protocol", () => {
     const ws = await connect();
     send(ws, { type: "worker_hello", workerId: "w1", status: "idle" });
     const first = await nextMsg(ws);
-    expect(first.type).toBe("task_assigned");
-    expect((first as any).issue.number).toBe(1);
+    assert(first.type === "task_assigned");
+    expect(first.issue.number).toBe(1);
 
     const second = nextMsg(ws);
     send(ws, { type: "task_complete", workerId: "w1", taskId: "1" });
     const msg = await second;
-    expect(msg.type).toBe("task_assigned");
-    expect((msg as any).issue.number).toBe(2);
+    assert(msg.type === "task_assigned");
+    expect(msg.issue.number).toBe(2);
 
     expect(labelDone).toHaveBeenCalledWith(1);
     expect(queue.get("1")?.status).toBe("complete");
@@ -194,9 +195,9 @@ describe("foreman WebSocket protocol", () => {
     const reply = nextMsg(ws);
     routeEvent("evt-1", "issue_comment", { issue: { number: 1 }, comment: { body: "hi" } });
     const msg = await reply;
-    expect(msg.type).toBe("event_notification");
-    expect((msg as any).taskId).toBe("1");
-    expect((msg as any).event.name).toBe("issue_comment");
+    assert(msg.type === "event_notification");
+    expect(msg.taskId).toBe("1");
+    expect(msg.event.name).toBe("issue_comment");
   });
 
   it("routeEventToWorker queues event when no worker is assigned", () => {
@@ -276,15 +277,15 @@ describe("foreman WebSocket protocol", () => {
     const wsA = await connect();
     send(wsA, { type: "worker_hello", workerId: "worker-a", status: "idle" });
     const msgA = await nextMsg(wsA);
-    expect(msgA.type).toBe("task_assigned");
-    expect((msgA as any).issue.number).toBe(53);
+    assert(msgA.type === "task_assigned");
+    expect(msgA.issue.number).toBe(53);
 
     // Worker B connects and gets task 55
     const wsB = await connect();
     send(wsB, { type: "worker_hello", workerId: "worker-b", status: "idle" });
     const msgB = await nextMsg(wsB);
-    expect(msgB.type).toBe("task_assigned");
-    expect((msgB as any).issue.number).toBe(55);
+    assert(msgB.type === "task_assigned");
+    expect(msgB.issue.number).toBe(55);
 
     // Event for issue 55 should go ONLY to worker B
     const replyB = nextMsg(wsB);

--- a/tests/repl.query.test.ts
+++ b/tests/repl.query.test.ts
@@ -140,13 +140,15 @@ describe("runQuery - stream event stat accumulation", () => {
       { type: "stream_event", parent_tool_use_id: null, event: { type: "message_stop" } },
       { type: "result", duration_ms: 1000, num_turns: 1, usage: { input_tokens: 50, output_tokens: 10 } },
     ]);
-    // Just verify no errors
     const cap = captureConsole();
     try {
       await runQuery("test", undefined);
     } finally {
       cap.restore();
     }
+    // Subagent tokens (999) must not appear in the stats output; only the top-level 50 in.
+    const plain = cap.lines.map(stripAnsi).join("\n");
+    expect(plain).not.toContain("999");
   });
 });
 

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { EventEmitter } from "events";
 import { WorkerSession } from "../src/worker.js";
 import type { ForemanMessage, GitHubEvent, TaskIssue } from "../src/types.js";
@@ -52,9 +52,7 @@ describe("task_assigned", () => {
   it("calls runQuery with the initial prompt when task_assigned is received", async () => {
     const issue = makeIssue();
     sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
-    // Give the async chain a tick to run
-    await new Promise((r) => setTimeout(r, 0));
-    expect(runQuery).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(runQuery).toHaveBeenCalledOnce());
     const [prompt] = runQuery.mock.calls[0];
     expect(prompt).toContain(issue.title);
   });
@@ -62,7 +60,7 @@ describe("task_assigned", () => {
   it("updates currentTaskId and currentIssue when task_assigned is received", async () => {
     const issue = makeIssue();
     sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
-    await new Promise((r) => setTimeout(r, 0));
+    await vi.waitFor(() => expect(runQuery).toHaveBeenCalled());
     // The state is observable via /task-complete behavior: if task is set,
     // task_complete message is sent to WS
     const action = session.handleUserInput("/task-complete");
@@ -74,10 +72,9 @@ describe("task_assigned", () => {
   it("calls display.printForemanMessage for task_assigned", async () => {
     const issue = makeIssue();
     sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
-    await new Promise((r) => setTimeout(r, 0));
-    expect(display.printForemanMessage).toHaveBeenCalledWith(
+    await vi.waitFor(() => expect(display.printForemanMessage).toHaveBeenCalledWith(
       expect.objectContaining({ type: "task_assigned" })
-    );
+    ));
   });
 });
 
@@ -88,7 +85,7 @@ describe("event_notification", () => {
     const promise = session.createWsInputPromise();
     sendMsg(fakeWs, { type: "event_notification", taskId: "42", event: makeEvent() });
     const result = await promise;
-    expect(result).toBe("__event__");
+    expect(result).toBeTruthy(); // promise resolved (sentinel value is internal impl detail)
   });
 
   it("queues event when event_notification arrives during runQuery", async () => {
@@ -100,25 +97,22 @@ describe("event_notification", () => {
 
     // Assign task → starts runQuery (blocking)
     sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
-    await new Promise((r) => setTimeout(r, 0)); // let task_assigned fire
+    await vi.waitFor(() => expect(runQuery).toHaveBeenCalledOnce());
 
     // Deliver event while query is running
     sendMsg(fakeWs, { type: "event_notification", taskId: "42", event: makeEvent("issue_comment") });
-    await new Promise((r) => setTimeout(r, 0));
-
     // First runQuery not yet finished — only called once so far
     expect(runQuery).toHaveBeenCalledOnce();
 
     // Finish first runQuery → should trigger event runQuery
     resolveFirst("session-1");
-    await new Promise((r) => setTimeout(r, 10));
+    await vi.waitFor(() => expect(runQuery).toHaveBeenCalledTimes(2));
 
-    expect(runQuery).toHaveBeenCalledTimes(2);
     const [eventPrompt] = runQuery.mock.calls[1];
     // Second call is with a different prompt (not the initial task prompt)
     const [initialPrompt] = runQuery.mock.calls[0];
     expect(eventPrompt).not.toBe(initialPrompt);
-    expect(typeof eventPrompt).toBe("string");
+    expect(eventPrompt).toContain("A comment was added"); // issue_comment template content
   });
 
   it("batches multiple pending events into a single runQuery call", async () => {
@@ -128,22 +122,19 @@ describe("event_notification", () => {
     runQuery.mockResolvedValue("session-2");
 
     sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
-    await new Promise((r) => setTimeout(r, 0));
+    await vi.waitFor(() => expect(runQuery).toHaveBeenCalledOnce());
 
     // Two events during query
     sendMsg(fakeWs, { type: "event_notification", taskId: "42", event: makeEvent("push") });
     sendMsg(fakeWs, { type: "event_notification", taskId: "42", event: makeEvent("issue_comment") });
-    await new Promise((r) => setTimeout(r, 0));
 
     resolveFirst("session-1");
-    await new Promise((r) => setTimeout(r, 10));
+    await vi.waitFor(() => expect(runQuery).toHaveBeenCalledTimes(2));
 
     // Only 2 total runQuery calls: initial + 1 batched event call
-    expect(runQuery).toHaveBeenCalledTimes(2);
-    // buildEventPrompt with multiple events returns a generic message
+    // buildEventPrompt with multiple events returns a "Multiple events" message
     const [batchedPrompt] = runQuery.mock.calls[1];
-    expect(typeof batchedPrompt).toBe("string");
-    expect(batchedPrompt.length).toBeGreaterThan(0);
+    expect(batchedPrompt).toContain("Multiple events");
   });
 });
 
@@ -153,7 +144,7 @@ describe("handleUserInput", () => {
   it("/task-complete sends task_complete to WS and clears task state", async () => {
     const issue = makeIssue();
     sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
-    await new Promise((r) => setTimeout(r, 10));
+    await vi.waitFor(() => expect(runQuery).toHaveBeenCalled());
 
     await session.handleUserInput("/task-complete");
 
@@ -169,7 +160,7 @@ describe("handleUserInput", () => {
   it("/clear clears sessionId but not task state", async () => {
     const issue = makeIssue();
     sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
-    await new Promise((r) => setTimeout(r, 10));
+    await vi.waitFor(() => expect(runQuery).toHaveBeenCalled());
 
     await session.handleUserInput("/clear");
 
@@ -189,8 +180,7 @@ describe("handleUserInput", () => {
     const issue = makeIssue();
     // Simulate what the ws message handler does before resolving the promise
     sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
-    await new Promise((r) => setTimeout(r, 0));
-    expect(runQuery).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(runQuery).toHaveBeenCalledOnce());
     const [prompt] = runQuery.mock.calls[0];
     expect(prompt).toContain(issue.title);
   });
@@ -202,7 +192,7 @@ describe("state after task_complete", () => {
   it("currentTaskId / currentIssue / currentSessionId are cleared after /task-complete", async () => {
     const issue = makeIssue();
     sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
-    await new Promise((r) => setTimeout(r, 10));
+    await vi.waitFor(() => expect(runQuery).toHaveBeenCalled());
 
     await session.handleUserInput("/task-complete");
 
@@ -247,10 +237,10 @@ describe("reconnect", () => {
 // ── createWsInputPromise ──────────────────────────────────────────────────────
 
 describe("createWsInputPromise", () => {
-  it("resolves with WS_TASK_ASSIGNED when task_assigned arrives", async () => {
+  it("resolves when task_assigned arrives", async () => {
     const promise = session.createWsInputPromise();
     sendMsg(fakeWs, { type: "task_assigned", taskId: "1", issue: makeIssue() });
-    expect(await promise).toBe("__task_assigned__");
+    expect(await promise).toBeTruthy(); // sentinel value is internal impl detail
   });
 
   it("each new promise abandons the previous one (previous never resolves)", async () => {
@@ -262,7 +252,7 @@ describe("createWsInputPromise", () => {
     sendMsg(fakeWs, { type: "task_assigned", taskId: "1", issue: makeIssue() });
 
     // second gets resolved since it holds the current resolveWsInput
-    expect(await second).toBe("__task_assigned__");
+    expect(await second).toBeTruthy(); // sentinel value is internal impl detail
     // first was abandoned and never resolves
     const firstResult = await Promise.race([first, new Promise<"timeout">((r) => setTimeout(() => r("timeout"), 20))]);
     expect(firstResult).toBe("timeout");


### PR DESCRIPTION
## Summary

Addresses all five test quality issues from #85:

1. **`as any` casts in `foreman.websocket.test.ts`** — replaced with typed discriminated union narrowing via `assert(msg.type === "...")` so TypeScript will flag shape changes to `ForemanMessage`.

2. **No-op test in `repl.query.test.ts`** — added `expect(plain).not.toContain("999")` assertion so a regression that counts subagent tokens in stats would actually fail.

3. **Weak prompt assertions in `worker.test.ts`** — replaced `typeof … === "string"` / `length > 0` with concrete content checks (`toContain("A comment was added")`, `toContain("Multiple events")`).

4. **Sentinel string assertions in `worker.test.ts`** — replaced `toBe("__task_assigned__")` / `toBe("__event__")` with `toBeTruthy()`, since the exact sentinel value is an internal implementation detail.

5. **Fragile timing in `worker.test.ts`** — replaced all `setTimeout(r, 0)` / `setTimeout(r, 10)` polling with `vi.waitFor(...)` calls that wait on explicit spy assertions.

## Test plan

- [x] All 45 tests in the three changed files pass
- [x] `npx tsc --noEmit` — no errors
- [x] `npm run lint` — no errors (pre-existing warnings unchanged)

Closes #85