### PR TITLE
feat: add no-template-curly-in-string ESLint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,6 +14,7 @@ export default [
     rules: {
       "@typescript-eslint/no-floating-promises": "error",
       "@typescript-eslint/no-explicit-any": "warn",
+      "no-template-curly-in-string": "error",
     },
   },
 ];


### PR DESCRIPTION
Adds the [`no-template-curly-in-string`](https://eslint.org/docs/latest/rules/no-template-curly-in-string) ESLint rule as an error.

This catches the class of bug found during PR #105, where a template literal was accidentally written with regular quotes instead of backticks, causing `${...}` to be emitted verbatim instead of being interpolated.

Closes #109