### PR TITLE
Stop logging and printing hook events

### DIFF
--- a/src/display.ts
+++ b/src/display.ts
@@ -246,19 +246,6 @@ export const MESSAGE_FMT: FmtTable = {
   _default:         (m) => c.darkGray(`msg: ${m.type}`),
 };
 
-export const HOOK_FMT: FmtTable = {
-  PreToolUse:         { verbose: (h) => c.sageGreen(`hook: pre-tool  ${h.tool_name}(${fmtArgs(h.tool_input ?? {}, 30)})`) },
-  PostToolUse:        { verbose: (h) => c.sageGreen(`hook: post-tool ${h.tool_name}  (${h.tool_error == null ? "ok" : "error"})`) },
-  PostToolUseFailure: { verbose: (h) => c.sageGreen(`hook: tool fail ${h.tool_name}  ${trunc(String(h.tool_error ?? ""), 50)}`) },
-  Notification:       { verbose: (h) => c.sageGreen(`hook: notif "${trunc(String(h.message ?? ""), 60)}"`) },
-  UserPromptSubmit:   { verbose: (h) => c.sageGreen(`hook: user prompt "${trunc(String(h.prompt ?? ""), 60)}"`) },
-  PermissionRequest:  { verbose: (h) => c.sageGreen(`hook: permission ${h.tool_name ?? h.tool ?? "?"}  → ${h.status ?? h.decision ?? "?"}`) },
-  Stop:               { verbose: (h) => c.sageGreen(`hook: stop reason=${h.stop_reason ?? "?"}`) },
-  SubagentStart:      { verbose: (h) => c.sageGreen(`hook: subagent start id=${h.agent_id ?? "?"}`) },
-  SubagentStop:       { verbose: (h) => c.sageGreen(`hook: subagent stop  id=${h.agent_id ?? "?"}`) },
-  TaskCompleted:      { verbose: (h) => c.sageGreen(`hook: task completed id=${h.task_id ?? "?"}`) },
-  _default:           { verbose: (h) => c.sageGreen(`hook: ${h._event}`) },
-};
 
 export const FOREMAN_MESSAGE_FMT: FmtTable = {
   task_assigned:      (m) => c.lavender(`  Task assigned: #${m.issue.number} — ${m.issue.title}`),
@@ -365,9 +352,6 @@ export function printMessage(msg: unknown) {
   print(resolve(MESSAGE_FMT, m.type, m));
 }
 
-export function printHook(event: string, input: unknown) {
-  print(resolve(HOOK_FMT, event, { ...(input as any), _event: event }));
-}
 
 export function printForemanMessage(msg: unknown) {
   const m = msg as any;

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import { fileURLToPath } from "url";
-import { query, type HookCallback } from "@anthropic-ai/claude-agent-sdk";
+import { query } from "@anthropic-ai/claude-agent-sdk";
 import * as display from "./display.js";
 import { ask, listCommandNames, dispatchInput } from "./input.js";
 import { workerMain } from "./worker.js";
@@ -20,44 +20,6 @@ export function logFull(label: string, data: unknown) {
     "\n";
   fs.appendFileSync(LOG_FILE, entry);
 }
-
-// ── Hook factory ──────────────────────────────────────────────────────────────
-
-function makeHook(event: string): HookCallback {
-  return async (input) => {
-    logFull(`HOOK ${event}`, input);
-    display.printHook(event, input);
-    return {};
-  };
-}
-
-const ALL_HOOK_EVENTS = [
-  "PreToolUse",
-  "PostToolUse",
-  "PostToolUseFailure",
-  "Notification",
-  "UserPromptSubmit",
-  "SessionStart",
-  "SessionEnd",
-  "Stop",
-  "SubagentStart",
-  "SubagentStop",
-  "PreCompact",
-  "PermissionRequest",
-  "Setup",
-  "TeammateIdle",
-  "TaskCompleted",
-  "ConfigChange",
-] as const;
-
-type HookEvent = (typeof ALL_HOOK_EVENTS)[number];
-
-const hooks = Object.fromEntries(
-  ALL_HOOK_EVENTS.map((event) => [
-    event,
-    [{ matcher: ".*", hooks: [makeHook(event)] }],
-  ])
-) as Record<HookEvent, [{ matcher: string; hooks: [HookCallback] }]>;
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
@@ -98,7 +60,6 @@ export async function runQuery(prompt: string, sessionId: string | undefined) {
       includePartialMessages: true,
       ...(BYPASS ? { allowDangerouslySkipPermissions: true } : {}),
       ...(sessionId ? { resume: sessionId } : {}),
-      hooks,
     },
   })) {
     const m = message as any;

--- a/tests/repl.formats.test.ts
+++ b/tests/repl.formats.test.ts
@@ -10,7 +10,6 @@ import {
   TOOL_ERROR_FMT,
   SYSTEM_FMT,
   MESSAGE_FMT,
-  HOOK_FMT,
   type FmtTable,
 } from "../src/display.js";
 
@@ -314,79 +313,3 @@ describe("MESSAGE_FMT", () => {
   });
 });
 
-describe("HOOK_FMT", () => {
-  afterEach(() => setVerbose(false));
-
-  it("PreToolUse, VERBOSE=false → null", () => {
-    setVerbose(false);
-    expect(resolve(HOOK_FMT, "PreToolUse", { tool_name: "Bash", tool_input: {} })).toBeNull();
-  });
-
-  it("PreToolUse, VERBOSE=true → hook: pre-tool <name>(<args>)", () => {
-    setVerbose(true);
-    const result = r(HOOK_FMT, "PreToolUse", { tool_name: "Bash", tool_input: { command: "ls" } });
-    expect(result).toContain("hook: pre-tool");
-    expect(result).toContain("Bash");
-  });
-
-  it("PostToolUse, VERBOSE=true, no error → (ok)", () => {
-    setVerbose(true);
-    const result = r(HOOK_FMT, "PostToolUse", { tool_name: "Read", tool_error: null });
-    expect(result).toContain("(ok)");
-  });
-
-  it("PostToolUse, VERBOSE=true, with error → (error)", () => {
-    setVerbose(true);
-    const result = r(HOOK_FMT, "PostToolUse", { tool_name: "Read", tool_error: "oops" });
-    expect(result).toContain("(error)");
-  });
-
-  it("Notification, VERBOSE=true → hook: notif \"<message>\"", () => {
-    setVerbose(true);
-    const result = r(HOOK_FMT, "Notification", { message: "hello" });
-    expect(result).toContain('hook: notif "hello"');
-  });
-
-  it("UserPromptSubmit, VERBOSE=true → hook: user prompt \"<prompt>\"", () => {
-    setVerbose(true);
-    const result = r(HOOK_FMT, "UserPromptSubmit", { prompt: "do something" });
-    expect(result).toContain('hook: user prompt "do something"');
-  });
-
-  it("PermissionRequest, VERBOSE=true → hook: permission <name> → <status>", () => {
-    setVerbose(true);
-    const result = r(HOOK_FMT, "PermissionRequest", { tool_name: "Bash", status: "approved" });
-    expect(result).toContain("hook: permission Bash");
-    expect(result).toContain("→ approved");
-  });
-
-  it("Stop, VERBOSE=true → hook: stop reason=<reason>", () => {
-    setVerbose(true);
-    const result = r(HOOK_FMT, "Stop", { stop_reason: "end_turn" });
-    expect(result).toContain("hook: stop reason=end_turn");
-  });
-
-  it("SubagentStart, VERBOSE=true → hook: subagent start id=<id>", () => {
-    setVerbose(true);
-    const result = r(HOOK_FMT, "SubagentStart", { agent_id: "agent-123" });
-    expect(result).toContain("hook: subagent start id=agent-123");
-  });
-
-  it("SubagentStop, VERBOSE=true → hook: subagent stop id=<id>", () => {
-    setVerbose(true);
-    const result = r(HOOK_FMT, "SubagentStop", { agent_id: "agent-123" });
-    expect(result).toContain("hook: subagent stop  id=agent-123");
-  });
-
-  it("TaskCompleted, VERBOSE=true → hook: task completed id=<id>", () => {
-    setVerbose(true);
-    const result = r(HOOK_FMT, "TaskCompleted", { task_id: "task-456" });
-    expect(result).toContain("hook: task completed id=task-456");
-  });
-
-  it("_default, VERBOSE=true → hook: <event name>", () => {
-    setVerbose(true);
-    const result = r(HOOK_FMT, "_default", { _event: "SomeEvent" });
-    expect(result).toContain("hook: SomeEvent");
-  });
-});

--- a/tests/repl.printing.test.ts
+++ b/tests/repl.printing.test.ts
@@ -3,7 +3,6 @@ import { stripAnsi } from "./helpers.js";
 import {
   printBlock,
   printMessage,
-  printHook,
   startStatus,
   stopStatus,
   print,
@@ -315,25 +314,6 @@ describe("printMessage", () => {
   });
 });
 
-describe("printHook", () => {
-  afterEach(() => setVerbose(false));
-
-  it("routes hook event through HOOK_FMT, injects _event", () => {
-    setVerbose(true);
-    const output = captureOutput(() => {
-      printHook("Stop", { stop_reason: "end_turn" });
-    });
-    expect(stripAnsi(output)).toContain("hook: stop reason=end_turn");
-  });
-
-  it("verbose=false → null (nothing printed)", () => {
-    setVerbose(false);
-    const output = captureOutput(() => {
-      printHook("PreToolUse", { tool_name: "Bash", tool_input: {} });
-    });
-    expect(output).toBe("");
-  });
-});
 
 describe("print()", () => {
   it("print(null) is a no-op", () => {


### PR DESCRIPTION
## Summary

- Removed `HOOK_FMT` and `printHook` from `src/display.ts` — hooks are no longer printed to the console in any mode (including verbose)
- Removed hook logging from `src/repl.ts` — hooks are no longer written to `repl.log`
- Dropped the entire hook registration infrastructure (`makeHook`, `ALL_HOOK_EVENTS`, `hooks`) since it only served for logging
- Removed the corresponding tests for `HOOK_FMT` and `printHook`

## Test plan

- [ ] Run `npm test` — 455 tests pass (14 hook tests removed, no regressions)
- [ ] Run `npx tsc --noEmit` — no type errors
- [ ] Run `npm run lint` — no new errors

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)