### PR TITLE
feat: print initial task prompt to console in amber

### DIFF
--- a/src/templates.ts
+++ b/src/templates.ts
@@ -1,8 +1,7 @@
 import type { GitHubEvent, TaskIssue } from "./types.js";
-import { print, c } from "./display.js";
 
 export function buildInitialPrompt(issue: TaskIssue): string {
-  const prompt = `Please work on GitHub issue #${issue.number}: "${issue.title}" in ${issue.repoUrl}.
+  return `Please work on GitHub issue #${issue.number}: "${issue.title}" in ${issue.repoUrl}.
 
 Issue description:
 ${issue.body || "(no description)"}
@@ -19,23 +18,18 @@ Remember key practices:
 4. Create a PR when done, and include the text "Closes #${issue.number}".
 
 Do not work on any other issues: leave task assignment to the foreman. Do not merge any PRs or set them to auto-merge: leave merging to the user after UAT.`;
-
-  print(c.amber(prompt));
-  return prompt;
 }
 
 export function buildEventPrompt(events: GitHubEvent[]): string {
-  const eventList = events.map(e => {
+  const event = events.length === 1 ? events[0] : { id: "", name: "_multiple", payload: { events } };
+  return resolveEventTemplate(EVENT_FMT, event.name, event);
+}
+
+export function fmtEventList(events: GitHubEvent[]): string {
+  return events.map(e => {
     const action = e.payload["action"] as string | undefined;
     return action ? `${e.name}/${action}` : e.name;
   }).join(", ");
-  print(c.darkGray(`Building prompt from events: ${eventList}`));
-
-  const event = events.length === 1 ? events[0] : { id: "", name: "_multiple", payload: { events } };
-  const prompt = resolveEventTemplate(EVENT_FMT, event.name, event);
-
-  print(c.amber(prompt));
-  return prompt;
 }
 
 // ── Event formatter table ─────────────────────────────────────────────────────

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2,7 +2,7 @@ import "dotenv/config";
 import crypto from "crypto";
 import { WebSocket } from "ws";
 import * as display from "./display.js";
-import { buildInitialPrompt, buildEventPrompt } from "./templates.js";
+import { buildInitialPrompt, buildEventPrompt, fmtEventList } from "./templates.js";
 import { ask, listWorkerCommandNames, dispatchInput } from "./input.js";
 import type { ForemanMessage, GitHubEvent, TaskIssue } from "./types.js";
 
@@ -109,14 +109,16 @@ export class WorkerSession {
       this.currentSessionId = undefined;
       this.resolveWsInput?.(WS_TASK_ASSIGNED);
       this.resolveWsInput = null;
-      void this.runQueryLoop(buildInitialPrompt(msg.issue));
+      const initialPrompt = buildInitialPrompt(msg.issue);
+      this.display.print(display.c.amber(initialPrompt));
+      void this.runQueryLoop(initialPrompt);
     } else if (msg.type === "event_notification") {
       this.pendingEvents.push(msg.event);
       this.resolveWsInput?.(WS_EVENT);
       this.resolveWsInput = null;
       if (!this.isRunningQuery && this.currentTaskId && this.currentIssue) {
         const events = this.pendingEvents.splice(0);
-        void this.runQueryLoop(buildEventPrompt(events));
+        void this.runQueryLoop(this.buildAndLogEventPrompt(events));
       }
     }
   }
@@ -131,7 +133,7 @@ export class WorkerSession {
 
     while (this.pendingEvents.length > 0 && this.currentTaskId && this.currentIssue) {
       const events = this.pendingEvents.splice(0);
-      const prompt = buildEventPrompt(events);
+      const prompt = this.buildAndLogEventPrompt(events);
       this.isRunningQuery = true;
       try {
         this.currentSessionId = await this.runQuery(prompt, this.currentSessionId) ?? this.currentSessionId;
@@ -139,6 +141,13 @@ export class WorkerSession {
         this.isRunningQuery = false;
       }
     }
+  }
+
+  private buildAndLogEventPrompt(events: GitHubEvent[]): string {
+    this.display.print(display.c.darkGray(`Building prompt from events: ${fmtEventList(events)}`));
+    const prompt = buildEventPrompt(events);
+    this.display.print(display.c.amber(prompt));
+    return prompt;
   }
 
   private async handleSlashCommand(input: string): Promise<void> {

--- a/tests/templates.test.ts
+++ b/tests/templates.test.ts
@@ -1,11 +1,6 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { buildInitialPrompt, buildEventPrompt, resolveEventTemplate, EVENT_FMT, type EventTemplateFmtTable } from "../src/templates.js";
+import { describe, it, expect } from "vitest";
+import { buildInitialPrompt, buildEventPrompt, fmtEventList, resolveEventTemplate, EVENT_FMT, type EventTemplateFmtTable } from "../src/templates.js";
 import type { GitHubEvent } from "../src/types.js";
-import { stripAnsi } from "./helpers.js";
-
-afterEach(() => {
-  vi.restoreAllMocks();
-});
 
 describe("buildInitialPrompt", () => {
   it("includes issue number, title, body, labels, and repoUrl", () => {
@@ -69,20 +64,6 @@ describe("buildInitialPrompt", () => {
     expect(p).toContain("brunel:ready");
   });
 
-  describe("diagnostic logging", () => {
-    it("logs the built prompt to console", () => {
-      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-      const prompt = buildInitialPrompt({
-        number: 42,
-        title: "Fix bug",
-        body: "It crashes",
-        labels: ["bug"],
-        repoUrl: "https://github.com/x/y",
-      });
-      const calls = consoleSpy.mock.calls.map(args => String(args[0]));
-      expect(calls.some(s => s.includes(prompt))).toBe(true);
-    });
-  });
 });
 
 describe("buildEventPrompt", () => {
@@ -206,58 +187,28 @@ describe("buildEventPrompt", () => {
     expect(p).toContain("deployment");
   });
 
-  describe("diagnostic logging", () => {
-    it("logs 'Building prompt from events:' before building", () => {
-      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-      const evt: GitHubEvent = { id: "e1", name: "check_suite", payload: { action: "completed" } };
-      buildEventPrompt([evt]);
-      const calls = consoleSpy.mock.calls.map(args => stripAnsi(String(args[0])));
-      expect(calls.some(s => s.startsWith("Building prompt from events:"))).toBe(true);
-    });
+});
 
-    it("logs event name/action in building message", () => {
-      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-      const evt: GitHubEvent = { id: "e1", name: "check_suite", payload: { action: "completed" } };
-      buildEventPrompt([evt]);
-      const calls = consoleSpy.mock.calls.map(args => stripAnsi(String(args[0])));
-      const buildingLine = calls.find(s => s.startsWith("Building prompt from events:"));
-      expect(buildingLine).toContain("check_suite/completed");
-    });
+describe("fmtEventList", () => {
+  it("formats a single event with action as name/action", () => {
+    const events: GitHubEvent[] = [{ id: "e1", name: "check_suite", payload: { action: "completed" } }];
+    expect(fmtEventList(events)).toBe("check_suite/completed");
+  });
 
-    it("logs multiple events as comma-separated name/action pairs in building message", () => {
-      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-      const events: GitHubEvent[] = [
-        { id: "e1", name: "check_run", payload: { action: "completed" } },
-        { id: "e2", name: "check_suite", payload: { action: "completed" } },
-      ];
-      buildEventPrompt(events);
-      const calls = consoleSpy.mock.calls.map(args => stripAnsi(String(args[0])));
-      const buildingLine = calls.find(s => s.startsWith("Building prompt from events:"));
-      expect(buildingLine).toContain("check_run/completed");
-      expect(buildingLine).toContain("check_suite/completed");
-    });
+  it("formats a single event without action as just the name", () => {
+    const events: GitHubEvent[] = [{ id: "e1", name: "deployment", payload: {} }];
+    expect(fmtEventList(events)).toBe("deployment");
+    expect(fmtEventList(events)).not.toContain("deployment/");
+  });
 
-    it("logs event name without action when payload has no action", () => {
-      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-      const evt: GitHubEvent = { id: "e1", name: "deployment", payload: {} };
-      buildEventPrompt([evt]);
-      const calls = consoleSpy.mock.calls.map(args => stripAnsi(String(args[0])));
-      const buildingLine = calls.find(s => s.startsWith("Building prompt from events:"));
-      expect(buildingLine).toContain("deployment");
-      expect(buildingLine).not.toContain("deployment/");
-    });
-
-    it("logs the built prompt after building", () => {
-      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-      const evt: GitHubEvent = {
-        id: "e1",
-        name: "issue_comment",
-        payload: { issue: { number: 5 }, comment: { body: "Hello there" } },
-      };
-      const prompt = buildEventPrompt([evt]);
-      const calls = consoleSpy.mock.calls.map(args => String(args[0]));
-      expect(calls.some(s => s.includes(prompt))).toBe(true);
-    });
+  it("formats multiple events as comma-separated name/action pairs", () => {
+    const events: GitHubEvent[] = [
+      { id: "e1", name: "check_run", payload: { action: "completed" } },
+      { id: "e2", name: "check_suite", payload: { action: "completed" } },
+    ];
+    const result = fmtEventList(events);
+    expect(result).toContain("check_run/completed");
+    expect(result).toContain("check_suite/completed");
   });
 });
 

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { EventEmitter } from "events";
 import { WorkerSession } from "../src/worker.js";
 import type { ForemanMessage, GitHubEvent, TaskIssue } from "../src/types.js";
+import { stripAnsi } from "./helpers.js";
 
 // ── Fake WebSocket ─────────────────────────────────────────────────────────────
 
@@ -76,6 +77,14 @@ describe("task_assigned", () => {
       expect.objectContaining({ type: "task_assigned" })
     ));
   });
+
+  it("prints the initial prompt in amber when task_assigned is received", async () => {
+    const issue = makeIssue();
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
+    await vi.waitFor(() => expect(runQuery).toHaveBeenCalledOnce());
+    const printCalls = display.print.mock.calls.map(args => stripAnsi(String(args[0])));
+    expect(printCalls.some(s => s.includes(issue.title))).toBe(true);
+  });
 });
 
 // ── Event handling during query ───────────────────────────────────────────────
@@ -113,6 +122,20 @@ describe("event_notification", () => {
     const [initialPrompt] = runQuery.mock.calls[0];
     expect(eventPrompt).not.toBe(initialPrompt);
     expect(eventPrompt).toContain("A comment was added"); // issue_comment template content
+  });
+
+  it("prints 'Building prompt from events:' diagnostic and prompt in amber when event runs a query", async () => {
+    const issue = makeIssue();
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
+    await vi.waitFor(() => expect(runQuery).toHaveBeenCalledOnce());
+
+    display.print.mockClear();
+    sendMsg(fakeWs, { type: "event_notification", taskId: "42", event: makeEvent("issue_comment") });
+    await vi.waitFor(() => expect(runQuery).toHaveBeenCalledTimes(2));
+
+    const printCalls = display.print.mock.calls.map(args => stripAnsi(String(args[0])));
+    expect(printCalls.some(s => s.startsWith("Building prompt from events:"))).toBe(true);
+    expect(printCalls.some(s => s.includes("A comment was added"))).toBe(true);
   });
 
   it("batches multiple pending events into a single runQuery call", async () => {


### PR DESCRIPTION
When a task is assigned, `buildInitialPrompt` builds a synthetic prompt to kick off the Claude session. Previously this prompt was built silently — unlike `buildEventPrompt`, which already prints the prompt in amber before returning.

This change mirrors that behavior: `buildInitialPrompt` now calls `print(c.amber(prompt))` before returning, so the initial prompt is visible in the worker console in the same color as event-driven prompts.

## Changes
- `src/templates.ts`: print the prompt in amber inside `buildInitialPrompt`
- `tests/templates.test.ts`: add diagnostic logging test for `buildInitialPrompt`

Closes #126