### PR TITLE
fix: remove blank line between event notifications (issue #132)

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -409,8 +409,9 @@ export function ask(
       if (done) return;
       totalDrawnRows = 0; // reset: we're drawing from a new position
       const displayStr = buffer.replace(/\n/g, "\r\n    ");
-      // Start on a fresh line
-      process.stdout.write("\r\n" + promptLine + displayStr);
+      // display.print() already moved the cursor to a new line via console.log's
+      // trailing \n; \r ensures we're at column 0 without adding an extra blank line.
+      process.stdout.write("\r" + promptLine + displayStr);
 
       const { row: endRow } = screenPosOf(buffer.length);
 

--- a/tests/repl.input.test.ts
+++ b/tests/repl.input.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { PassThrough } from "stream";
 import { ask } from "../src/input.js";
+import * as display from "../src/display.js";
 
 function makeStdin() {
   const stream = new PassThrough();
@@ -434,5 +435,31 @@ describe("ask() - submit output", () => {
     const writes = writeSpy.mock.calls.map((c) => String(c[0]));
     // The suggestion-row clear must NOT include a trailing \r\n
     expect(writes).not.toContain("\r\n\x1b[K\r\n");
+  });
+});
+
+describe("ask() - drawFresh after print()", () => {
+  it("print() while ask() is running does not add a blank line before the redrawn prompt", async () => {
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await withFakeStdin(async (stdin) => {
+      const p = ask("> ", () => []);
+
+      // Simulate display.print() being called (e.g., an event notification arriving)
+      display.print("  Event received: some_event");
+
+      // The drawFresh callback redraws the prompt. Collect all write calls made
+      // during/after the print.
+      const writes = writeSpy.mock.calls.map((c) => String(c[0]));
+
+      // drawFresh should NOT write \r\n before the prompt — that creates a blank
+      // line between the event text and the redrawn prompt (issue #132).
+      const hasLeadingBlankLine = writes.some((w) => w.startsWith("\r\n"));
+      expect(hasLeadingBlankLine).toBe(false);
+
+      stdin.push("\r");
+      await p;
+    });
   });
 });

--- a/tests/repl.multiline.test.ts
+++ b/tests/repl.multiline.test.ts
@@ -277,10 +277,11 @@ describe("display.print() callback for ask() redraw", () => {
       // Simulate display.print() being called while ask() is running
       display.print("  Connected to foreman.");
 
-      // The prompt should be redrawn after print
+      // The prompt should be redrawn after print, starting with \r (not \r\n —
+      // console.log already moved to a new line, so no extra blank line needed)
       const output = collectOutput(writeSpy);
       // Should write the prompt again (either "> " or the buffer)
-      expect(output).toMatch(/\r\n.*>/);
+      expect(output).toMatch(/\r.*>/);
 
       stdin.push("\r");
       expect(await p).toBe("hello");


### PR DESCRIPTION
## Summary

- `drawFresh()` in `input.ts` was writing `\r\n` before redrawing the prompt after a `print()` call
- But `console.log()` (inside `print()`) already moves the cursor to a new line via its trailing `\n`
- The extra `\n` in `\r\n` created a blank line between each event notification and the redrawn prompt, making events appear double-spaced
- Fix: use `\r` alone (go to column 0 of the current blank line) instead of `\r\n` (go to column 0 then down to a new line)

## Test plan

- [x] New test in `repl.input.test.ts`: verifies that `process.stdout.write` is never called with a `\r\n`-prefixed string after `display.print()` fires while `ask()` is running
- [x] Updated existing test in `repl.multiline.test.ts` that expected the old `\r\n` behavior
- [x] All 498 tests pass

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)