### PR TITLE
fix: suppress repeated prompt in worker mode on websocket updates

### DIFF
--- a/src/display.ts
+++ b/src/display.ts
@@ -415,6 +415,10 @@ export function stopStatus() {
 export function print(line: string | null) {
   if (line === null) return;
   _clearStatus();
+  // If ask() is waiting with a visible prompt, erase the prompt line before
+  // printing so the message appears on a clean line (not appended to the
+  // prompt). The prompt is then redrawn below via _inputPrintCallback.
+  if (_inputPrintCallback) process.stdout.write("\r\x1b[K");
   console.log(line);
   _drawStatus();
   // Only redraw the input prompt when no query is running. During a query the

--- a/src/input.ts
+++ b/src/input.ts
@@ -430,8 +430,11 @@ export function ask(
       if (targetCol > 0) process.stdout.write(`\x1b[${targetCol}C`);
     }
 
-    // Register the fresh-redraw hook so display.print() can notify us
-    display.setInputPrintCallback(drawFresh);
+    // Register the fresh-redraw hook so display.print() can notify us.
+    // Only register when there is a visible prompt to redraw — an empty prompt
+    // string means the caller doesn't want any prompt shown (e.g. worker
+    // standby mode), so no redraw is needed and no line-clear should fire.
+    if (promptLine) display.setInputPrintCallback(drawFresh);
 
     if (abort) {
       void abort.then((value) => {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -54,6 +54,7 @@ export class WorkerSession {
   private isRunningQuery = false;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly DEBOUNCE_MS = 3000;
+  private queryDoneResolvers: Array<() => void> = [];
 
   constructor(
     private workerId: string,
@@ -74,6 +75,19 @@ export class WorkerSession {
     return new Promise<string>((resolve) => {
       this.resolveWsInput = resolve;
     });
+  }
+
+  /**
+   * Resolves when no query is currently running. If a query is already
+   * running, waits until runQueryLoop completes (including any pending
+   * events it drains). Multiple concurrent callers are all notified.
+   */
+  async waitUntilIdle(): Promise<void> {
+    while (this.isRunningQuery) {
+      await new Promise<void>((resolve) => {
+        this.queryDoneResolvers.push(resolve);
+      });
+    }
   }
 
   /**
@@ -104,6 +118,11 @@ export class WorkerSession {
   }
 
   // ── Private ───────────────────────────────────────────────────────────────
+
+  private notifyQueryDone(): void {
+    const resolvers = this.queryDoneResolvers.splice(0);
+    for (const r of resolvers) r();
+  }
 
   private connect(): void {
     const ws = this.wsFactory(this.workerId, this.currentTaskId);
@@ -190,6 +209,8 @@ export class WorkerSession {
         this.isRunningQuery = false;
       }
     }
+
+    this.notifyQueryDone();
   }
 
   private buildAndLogEventPrompt(events: GitHubEvent[]): string {
@@ -263,9 +284,27 @@ export async function workerMain(runQueryFn: RunQuery): Promise<void> {
 
   session.start();
 
+  // Start with no visible prompt: the worker is waiting for the foreman to
+  // assign a task and is not in a mode that accepts interactive user input.
+  // The prompt becomes visible after the first task query completes.
+  let showPrompt = false;
+
   while (true) {
     const wsAbort = session.createWsInputPromise();
-    const input = await ask("\n[worker] > ", listWorkerCommandNames, wsAbort);
+    // Use an empty prompt string when not ready for interactive input.  An
+    // empty promptLine suppresses the drawFresh callback so incoming messages
+    // are printed cleanly without a prompt preceding or following them.
+    const promptStr = showPrompt ? "\n[worker] > " : "";
+    const input = await ask(promptStr, listWorkerCommandNames, wsAbort);
+
+    const isSentinel = input === WS_TASK_ASSIGNED || input === WS_EVENT;
+    if (isSentinel) {
+      // A WS message arrived. Hide the prompt and wait for the triggered
+      // query to finish before showing it again.
+      showPrompt = false;
+      await session.waitUntilIdle();
+      showPrompt = true;
+    }
 
     try {
       const result = await session.handleUserInput(input);

--- a/tests/repl.printing.test.ts
+++ b/tests/repl.printing.test.ts
@@ -9,6 +9,7 @@ import {
   toolUseNames,
   setVerbose,
   _statusActive,
+  setInputPrintCallback,
 } from "../src/display.js";
 
 function captureOutput(fn: () => void): string {
@@ -328,6 +329,30 @@ describe("print()", () => {
       print("hello");
     });
     expect(stripAnsi(output)).toContain("hello");
+  });
+
+  it("print(text) with inputPrintCallback set: clears current line before logging", () => {
+    const cb = vi.fn();
+    setInputPrintCallback(cb);
+    try {
+      const output = captureOutput(() => {
+        print("hello");
+      });
+      // \r\x1b[K (CR + clear to end of line) must appear BEFORE the logged text
+      const clearIdx = output.indexOf("\r\x1b[K");
+      const helloIdx = output.indexOf("hello");
+      expect(clearIdx).toBeGreaterThan(-1);
+      expect(helloIdx).toBeGreaterThan(clearIdx);
+    } finally {
+      setInputPrintCallback(null);
+    }
+  });
+
+  it("print(text) while inactive (no callback): does NOT write \\r\\x1b[K", () => {
+    const output = captureOutput(() => {
+      print("hello");
+    });
+    expect(output).not.toContain("\r\x1b[K");
   });
 });
 

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -289,6 +289,61 @@ describe("createWsInputPromise", () => {
   });
 });
 
+// ── waitUntilIdle ─────────────────────────────────────────────────────────────
+
+describe("waitUntilIdle", () => {
+  it("resolves immediately when no query is running", async () => {
+    // No task assigned — not running a query
+    const result = await Promise.race([
+      session.waitUntilIdle().then(() => "idle"),
+      new Promise<"timeout">((r) => setTimeout(() => r("timeout"), 50)),
+    ]);
+    expect(result).toBe("idle");
+  });
+
+  it("waits until runQuery completes when a query is running", async () => {
+    let resolveQuery!: (v: string | undefined) => void;
+    runQuery.mockReturnValueOnce(new Promise<string | undefined>((r) => { resolveQuery = r; }));
+
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "1", issue: makeIssue() });
+    await vi.waitFor(() => expect(runQuery).toHaveBeenCalledOnce());
+
+    // waitUntilIdle should not resolve while query is running
+    const idlePromise = session.waitUntilIdle();
+    const raceResult1 = await Promise.race([
+      idlePromise.then(() => "idle"),
+      new Promise<"pending">((r) => setTimeout(() => r("pending"), 20)),
+    ]);
+    expect(raceResult1).toBe("pending");
+
+    // Resolve the query
+    resolveQuery("session-done");
+
+    // Now waitUntilIdle should resolve
+    const raceResult2 = await Promise.race([
+      idlePromise.then(() => "idle"),
+      new Promise<"timeout">((r) => setTimeout(() => r("timeout"), 100)),
+    ]);
+    expect(raceResult2).toBe("idle");
+  });
+
+  it("multiple waitUntilIdle callers all resolve when query completes", async () => {
+    let resolveQuery!: (v: string | undefined) => void;
+    runQuery.mockReturnValueOnce(new Promise<string | undefined>((r) => { resolveQuery = r; }));
+
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "1", issue: makeIssue() });
+    await vi.waitFor(() => expect(runQuery).toHaveBeenCalledOnce());
+
+    const p1 = session.waitUntilIdle();
+    const p2 = session.waitUntilIdle();
+
+    resolveQuery("session-done");
+
+    await expect(p1).resolves.toBeUndefined();
+    await expect(p2).resolves.toBeUndefined();
+  });
+});
+
 // ── classifyEvent ─────────────────────────────────────────────────────────────
 
 describe("classifyEvent", () => {


### PR DESCRIPTION
## Summary

- **display.ts**: `print()` writes `\r\x1b[K` before `console.log` when a prompt is active, so incoming messages appear on a clean line instead of being appended to the `[worker] > ` prompt
- **input.ts**: `ask()` only registers the `drawFresh` redraw callback when `promptLine` is non-empty — an empty prompt string means no visible prompt, so no clear/redraw should fire
- **worker.ts**: `workerMain` starts with no visible prompt (`showPrompt = false`) and only shows `[worker] > ` after a query completes; `WorkerSession` gains `waitUntilIdle()` so the main loop waits for the triggered `runQueryLoop` before redisplaying

**Before:** `[worker] > ` appeared before every incoming message (Connected, Standby, Task assigned) because messages were printed at the cursor position (end of the prompt line), and `drawFresh` immediately redrew the prompt after each one.

**After:** No prompt at startup or while a query runs. The prompt appears cleanly once the first task finishes and the worker is ready for interactive input.

## Test plan

- New test: `print()` with `_inputPrintCallback` set writes `\r\x1b[K` before the message
- New test: `print()` with no callback does NOT write `\r\x1b[K`
- New tests: `waitUntilIdle()` resolves immediately when idle, waits when query is running, notifies multiple callers
- All 502 existing tests continue to pass

Closes #106