### PR TITLE
fix: treat check_suite/completed with conclusion skipped as log_only

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -15,8 +15,11 @@ export function classifyEvent(event: GitHubEvent): "actionable" | "log_only" {
     case "check_run":
       return "log_only";
 
-    case "check_suite":
-      return action === "completed" ? "actionable" : "log_only";
+    case "check_suite": {
+      if (action !== "completed") return "log_only";
+      const conclusion = (event.payload.check_suite as Record<string, unknown> | undefined)?.conclusion;
+      return conclusion === "skipped" ? "log_only" : "actionable";
+    }
 
     case "pull_request":
       return action === "closed" ? "actionable" : "log_only";

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -347,8 +347,8 @@ describe("waitUntilIdle", () => {
 // ── classifyEvent ─────────────────────────────────────────────────────────────
 
 describe("classifyEvent", () => {
-  function evt(name: string, action?: string): GitHubEvent {
-    return { id: "e1", name, payload: action ? { action } : {} };
+  function evt(name: string, action?: string, extra?: Record<string, unknown>): GitHubEvent {
+    return { id: "e1", name, payload: { ...(action ? { action } : {}), ...extra } };
   }
 
   describe("log_only events", () => {
@@ -366,6 +366,9 @@ describe("classifyEvent", () => {
     });
     it("check_suite/rerequested is log_only", () => {
       expect(classifyEvent(evt("check_suite", "rerequested"))).toBe("log_only");
+    });
+    it("check_suite/completed with conclusion skipped is log_only", () => {
+      expect(classifyEvent(evt("check_suite", "completed", { check_suite: { conclusion: "skipped" } }))).toBe("log_only");
     });
     it("pull_request/labeled is log_only", () => {
       expect(classifyEvent(evt("pull_request", "labeled"))).toBe("log_only");


### PR DESCRIPTION
## Summary

- `classifyEvent` now returns `log_only` for `check_suite/completed` when `conclusion === "skipped"`
- Previously, all `check_suite/completed` events were actionable, causing spurious Claude queries for skipped suites
- Added a test for the new case; extended the `evt` helper to accept extra payload fields

## Test plan

- [ ] `npm test` passes (504 tests)
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run lint` passes
- [ ] Manually trigger a `check_suite/completed` with `conclusion: skipped` webhook — should be logged only, not trigger a query

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)