### PR TITLE
feat: instruct workers to clean up worktrees on PR close

### DIFF
--- a/src/templates.ts
+++ b/src/templates.ts
@@ -62,6 +62,7 @@ export const EVENT_FMT: EventTemplateFmtTable = {
 * Are there any followup issues we should file?
 * Are there any updates to skills that we should make, or new skills to record?
 * Are there any updates to be made to project documentation?
+* Clean up your worktree by running \`git worktree remove <path>\` on the worktree you created for this task.
 
 Please do the above if necessary. Then summarize what you did, and anything else the user should know.`;
     }

--- a/tests/templates.test.ts
+++ b/tests/templates.test.ts
@@ -260,6 +260,16 @@ describe("EVENT_FMT table", () => {
     expect(result).toContain("PR #5");
   });
 
+  it("pull_request/closed — instructs worker to clean up its worktree", () => {
+    const evt: GitHubEvent = {
+      id: "e1",
+      name: "pull_request",
+      payload: { action: "closed", pull_request: { number: 5, merged: true } },
+    };
+    const result = EVENT_FMT.pull_request(evt.payload, evt);
+    expect(result).toContain("worktree");
+  });
+
   it("pull_request/closed not merged — asks how to proceed", () => {
     const evt: GitHubEvent = {
       id: "e1",


### PR DESCRIPTION
## Summary

- Adds a worktree cleanup bullet to the `pull_request/closed` event prompt
- Workers are now instructed to run `git worktree remove <path>` on their worktree as part of PR close wrap-up
- Adds a test verifying the closed-PR prompt contains "worktree"

## Test plan

- [ ] Run `npm test` — all 504 tests pass
- [ ] Verify `pull_request/closed` prompt in `templates.ts` includes worktree cleanup step
- [ ] In a real worker session, close a PR and confirm the agent runs `git worktree remove`

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)