### PR TITLE
fix: forward issue_comment events on PRs to the assigned worker

### DIFF
--- a/src/foreman.ts
+++ b/src/foreman.ts
@@ -391,6 +391,10 @@ export function createForemanWss(
 
     let task = taskQueue.getTaskForIssue(issueNumber);
 
+    // GitHub issue_comment events on PRs have the PR number in issue.number.
+    // Fall back to PR lookup so comments on worker-opened PRs are forwarded.
+    if (!task) task = taskQueue.getTaskForPr(issueNumber);
+
     // If the issue isn't queued yet, check if this webhook should enqueue it.
     if (!task && name === "issues" && issue) {
       const action = p.action as string | undefined;

--- a/tests/foreman.webhook-routing.test.ts
+++ b/tests/foreman.webhook-routing.test.ts
@@ -138,6 +138,15 @@ function prReviewCommentPayload(prNumber: number) {
   };
 }
 
+function issueCommentPayload(prOrIssueNumber: number, body = "LGTM") {
+  return {
+    action: "created",
+    issue: { number: prOrIssueNumber, title: `Issue/PR ${prOrIssueNumber}`, pull_request: {} },
+    comment: { body, user: { login: "reviewer" } },
+    repository: { html_url: "https://github.com/owner/repo" },
+  };
+}
+
 function checkSuitePayload(prNumber: number, conclusion: string) {
   return {
     action: "completed",
@@ -554,6 +563,32 @@ describe("PR event forwarding to workers", () => {
     expect(raceResult).toBe("timeout");
   });
 });
+
+  it("issue_comment/created on a PR is forwarded to the worker handling that issue", async () => {
+    queue.addTask({
+      taskId: "42",
+      issueNumber: 42,
+      title: "Issue 42",
+      body: "Body",
+      labels: ["brunel:ready"],
+      repoUrl: "https://github.com/owner/repo",
+    });
+
+    const ws = await connect();
+    send(ws, { type: "worker_hello", workerId: "w1", status: "idle" });
+    await nextMsg(ws); // task_assigned
+
+    // Worker opens PR #10 that closes issue #42
+    routeEvent("evt-pr", "pull_request", prOpenedPayload(10, "Closes #42"));
+
+    // User posts a top-level comment on PR #10 — issue.number = 10 (the PR number)
+    const reply = nextMsg(ws);
+    routeEvent("evt-cmt", "issue_comment", issueCommentPayload(10, "Please address the nit above."));
+
+    const msg = await reply;
+    expect(msg.type).toBe("event_notification");
+    expect((msg as any).event.name).toBe("issue_comment");
+  });
 
 describe("foreman event filtering", () => {
   it("pull_request/synchronize is dropped and not forwarded to worker", async () => {


### PR DESCRIPTION
## Summary

- `issue_comment` events on PRs have `issue.number` set to the **PR number**, not the linked issue number
- The foreman was only doing `getTaskForIssue(prNumber)` which returned undefined, causing the event to be silently dropped
- Fix: fall back to `getTaskForPr(issueNumber)` so top-level PR comments are forwarded to the worker as `event_notification` messages

## Test plan

- Added test: `issue_comment/created on a PR is forwarded to the worker handling that issue` — verified it fails before the fix and passes after
- Full test suite (517 tests) passes

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)