### PR TITLE
feat: mute workflow_job and workflow_run events from foreman console logs

### DIFF
--- a/src/foreman.ts
+++ b/src/foreman.ts
@@ -212,7 +212,12 @@ export function summaryEvent(id: string, name: string, payload: unknown): string
   return `[event] ${parts.join(" ")}`;
 }
 
+export function isMutedEvent(name: string): boolean {
+  return name === "workflow_job" || name === "workflow_run";
+}
+
 function printEvent(id: string, name: string, payload: unknown) {
+  if (isMutedEvent(name)) return;
   flog(summaryEvent(id, name, payload));
 }
 

--- a/tests/foreman.logging.test.ts
+++ b/tests/foreman.logging.test.ts
@@ -1,5 +1,31 @@
 import { describe, it, expect } from "vitest";
-import { summaryEvent } from "../src/foreman.js";
+import { summaryEvent, isMutedEvent } from "../src/foreman.js";
+
+describe("isMutedEvent", () => {
+  it("mutes workflow_job events", () => {
+    expect(isMutedEvent("workflow_job")).toBe(true);
+  });
+
+  it("mutes workflow_run events", () => {
+    expect(isMutedEvent("workflow_run")).toBe(true);
+  });
+
+  it("does not mute check_run events", () => {
+    expect(isMutedEvent("check_run")).toBe(false);
+  });
+
+  it("does not mute check_suite events", () => {
+    expect(isMutedEvent("check_suite")).toBe(false);
+  });
+
+  it("does not mute issues events", () => {
+    expect(isMutedEvent("issues")).toBe(false);
+  });
+
+  it("does not mute pull_request events", () => {
+    expect(isMutedEvent("pull_request")).toBe(false);
+  });
+});
 
 describe("summaryEvent", () => {
   it("renders a single line with no newlines", () => {


### PR DESCRIPTION
## Summary

- Adds `isMutedEvent()` helper that returns `true` for `workflow_job` and `workflow_run` events
- `printEvent` now skips console output for those events, reducing foreman log noise
- These events will still be captured in the detailed logfile once #56 is implemented

## Test plan

- [ ] `isMutedEvent` unit tests added covering both muted and non-muted event types
- [ ] Full test suite passes (522 tests, 0 failures)

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)