### PR TITLE
fix: instruct workers to use EnterWorktree/ExitWorktree tools

### DIFF
--- a/src/templates.ts
+++ b/src/templates.ts
@@ -13,7 +13,7 @@ You should ask for any clarifications you need about requirements or product spe
 Remember key practices:
 
 1. Use proper branch discipline. Pull main to get the latest, then create a new branch.
-2. Create a new worktree to avoid conflicts with other agents. Make no changes in the main workspace, only in the worktree.
+2. Use the EnterWorktree tool to create an isolated worktree for this task. Make no changes in the main workspace, only in the worktree.
 3. As much as possible, use test-driven development.
 4. Create a PR when done, and include the text "Closes #${issue.number}".
 
@@ -62,7 +62,7 @@ export const EVENT_FMT: EventTemplateFmtTable = {
 * Are there any followup issues we should file?
 * Are there any updates to skills that we should make, or new skills to record?
 * Are there any updates to be made to project documentation?
-* Clean up your worktree by running \`git worktree remove <path>\` on the worktree you created for this task.
+* Clean up your worktree by calling ExitWorktree with action: "remove".
 
 Please do the above if necessary. Then summarize what you did, and anything else the user should know.`;
     }


### PR DESCRIPTION
## Summary

- Replace manual `git worktree add` instruction with `EnterWorktree` tool, which persistently changes the session CWD
- Replace `git worktree remove <path>` cleanup instruction with `ExitWorktree(action: "remove")`

## Why

Workers were managing worktrees manually and running `git status` / `git rebase` without `git -C`, because `cd` doesn't persist between Bash tool calls. This caused agents to see a clean status in the main workspace while the worktree had uncommitted changes, leading to misdiagnosed rebase failures and abandoned branches.

`EnterWorktree` solves this at the root: it changes the session's working directory persistently, so all subsequent Bash and file tool calls operate in the worktree without any special flags.

## Test plan

- [ ] Verify existing tests pass (`npm test`)
- [ ] Manual: spawn a worker and confirm it uses `EnterWorktree` rather than `git worktree add`

🤖 Generated with [Claude Code](https://claude.com/claude-code)