### PR TITLE
feat: coalesce multiple actionable events before building prompts

### DIFF
--- a/src/templates.ts
+++ b/src/templates.ts
@@ -145,10 +145,10 @@ export const EVENT_FMT: EventTemplateFmtTable = {
   _check_suites: (p) => {
     const failed = p.failed as string[];
     if (p.status === "failed") {
-      return `Checks have failed: ${failed.join(", ")}`;
+      return `Checks have failed: ${failed.join(", ")}. Please review the failing checks on your PR and fix any issues.`;
     }
     const succeeded = p.succeeded as string[];
-    return `Checks succeeded: ${succeeded.join(", ")}`;
+    return `Checks succeeded: ${succeeded.join(", ")}. Check if the branch is up to date, and if not, rebase it. Then check if the PR can be merged. If anything is blocking merge, resolve it, but do not merge yourself.`;
   },
 
   _code_review: (p) => {

--- a/tests/templates.test.ts
+++ b/tests/templates.test.ts
@@ -419,7 +419,7 @@ describe("buildEventPrompt — pipeline behavior", () => {
 });
 
 describe("EVENT_FMT — new entries", () => {
-  it("_check_suites with failures → lists only failed suite names", () => {
+  it("_check_suites with failures → lists only failed suite names and instructs to fix", () => {
     const evt: GitHubEvent = {
       id: "e1",
       name: "_check_suites",
@@ -430,9 +430,10 @@ describe("EVENT_FMT — new entries", () => {
     expect(result).toContain("CI / test");
     expect(result).toContain("CI / lint");
     expect(result).not.toContain("CI / build");
+    expect(result).toContain("review the failing checks");
   });
 
-  it("_check_suites all succeeded → lists all suite names", () => {
+  it("_check_suites all succeeded → lists all suite names and instructs to verify merge-readiness", () => {
     const evt: GitHubEvent = {
       id: "e1",
       name: "_check_suites",
@@ -442,6 +443,7 @@ describe("EVENT_FMT — new entries", () => {
     expect(result).toContain("Checks succeeded");
     expect(result).toContain("CI / test");
     expect(result).toContain("CI / build");
+    expect(result).toContain("PR can be merged");
   });
 
   it("_code_review renders PR number, review state, body, and inline comments", () => {


### PR DESCRIPTION
## Summary

- Replaces the `_multiple` fallback in `buildEventPrompt` with a three-step pipeline: **coalesce → sort → concatenate**
- `coalesceEvents()` folds multiple `check_suite` events into a synthetic `_check_suites` event (carrying `status`, `failed[]`, `succeeded[]`) and folds `pull_request_review` + `pull_request_review_comment` events into a synthetic `_code_review` event (review state/body + inline comments array)
- After coalescing, events are sorted by priority: `issue_comment` → `_code_review` → `_check_suites` → other → `pull_request`
- Individual prompts are joined with `---` separators; when more than one event remains after coalescing, the output is prefixed with `"Multiple events have happened:\n\n"`
- Adds `_check_suites` and `_code_review` entries to `EVENT_FMT`; removes the old `_multiple` entry

## Test plan

- [x] Unit tests for `coalesceEvents`: multiple failing suites, multiple passing suites, mixed, single suite, `app.name` fallback, review+comments, review alone, mixed types
- [x] Unit tests for `buildEventPrompt` pipeline: single event (no prefix), multiple events (prefix), multiple check suites coalesce to one (no prefix), separator present, sort order verified
- [x] Unit tests for `_check_suites` and `_code_review` template entries
- [x] All 565 existing tests pass; lint and type-check clean

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)