### PR TITLE
fix: respect busy status when worker reconnects with unknown task

### DIFF
--- a/src/foreman.ts
+++ b/src/foreman.ts
@@ -571,9 +571,8 @@ export function createForemanWss(
               log(workerId, `→ event_notification #${existing.issueNumber} ${evt.name} (queued)`);
             }
           } else if (!existing) {
-            log(workerId, `hello busy task=#${msg.taskId} — unknown task, treating as idle`);
-            registry.register(workerId, ws, "idle");
-            tryAssignWork(workerId);
+            log(workerId, `hello busy task=#${msg.taskId} — unknown task, respecting busy status`);
+            registry.register(workerId, ws, "busy", msg.taskId);
           } else {
             // Task is assigned to a different worker — standby
             log(workerId, `hello busy task=#${msg.taskId} — task taken by another worker`);

--- a/tests/foreman.websocket.test.ts
+++ b/tests/foreman.websocket.test.ts
@@ -185,11 +185,30 @@ describe("foreman WebSocket protocol", () => {
     expect(queue.get("1")?.status).toBe("assigned");
   });
 
-  it("worker reconnects as busy with unknown taskId gets standby", async () => {
+  it("worker reconnects as busy with unknown taskId is registered busy and not interrupted", async () => {
     const ws = await connect();
-    const reply = nextMsg(ws);
     send(ws, { type: "worker_hello", workerId: "w1", taskId: "nonexistent", status: "busy" });
-    expect(await reply).toEqual({ type: "standby" });
+    const raceResult = await Promise.race([
+      nextMsg(ws).then(() => "message" as const),
+      new Promise<"timeout">((r) => setTimeout(() => r("timeout"), 50)),
+    ]);
+    expect(raceResult).toBe("timeout"); // no message — worker continues its existing work
+    expect(registry.get("w1")?.status).toBe("busy");
+    expect(registry.get("w1")?.currentTaskId).toBe("nonexistent");
+  });
+
+  it("worker with pending tasks reconnects as busy with unknown taskId does not receive task_assigned", async () => {
+    queue.addTask(makeTask(1));
+    const ws = await connect();
+    send(ws, { type: "worker_hello", workerId: "w1", taskId: "nonexistent", status: "busy" });
+    const raceResult = await Promise.race([
+      nextMsg(ws).then(() => "message" as const),
+      new Promise<"timeout">((r) => setTimeout(() => r("timeout"), 50)),
+    ]);
+    expect(raceResult).toBe("timeout"); // must NOT receive task_assigned
+    expect(registry.get("w1")?.status).toBe("busy");
+    // pending task remains available for other workers
+    expect(queue.get("1")?.status).toBe("pending");
   });
 
   it("routeEventToWorker sends event_notification to assigned worker", async () => {


### PR DESCRIPTION
## Summary

- When a worker reconnects to a restarted foreman reporting `busy` on a task the foreman doesn't recognize, the foreman now registers the worker as busy and leaves it alone instead of treating it as idle and assigning new work.
- Updated the existing test for this path and added a new test specifically covering the case where pending tasks are in the queue (the actual bug scenario).

## Root cause

In `createForemanWss`, the `worker_hello` handler had three branches for a busy worker:
1. Task exists and belongs to this worker → reclaim ✅  
2. Task doesn't exist → **register as idle, assign new work** ❌ (the bug)  
3. Task exists but belongs to another worker → standby ✅  

Branch 2 was the problem. After a foreman restart, all in-memory tasks are gone, so every reconnecting busy worker hit this branch and got a new task assigned on top of what it was already working on.

## Fix

In the unknown-task branch, register the worker as `busy` (with the task ID preserved) and don't call `tryAssignWork`. The worker continues its existing session uninterrupted and will call `task_complete` when done, at which point the foreman releases it normally.

## Test plan

- [x] New test: worker with pending tasks reconnects as busy with unknown taskId → no `task_assigned` sent, registered as busy, pending task stays pending
- [x] Updated test: worker reconnects as busy with unknown taskId → registered busy, no message sent (was: expected `standby`, which only passed because no tasks were queued)
- [x] All 604 tests pass
- [x] TypeScript and lint clean

Closes #159