### PR TITLE
docs: update CLAUDE.md for unified config system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@ A GitHub-driven autonomous agent. Labels a GitHub issue `brunel:ready` → the f
 
 - **`src/foreman.ts`** — HTTP server + WebSocket server. Polls GitHub for `brunel:ready` issues, queues them, and assigns them to idle workers over WebSocket.
 - **`src/repl.ts`** — Interactive REPL (default) or worker process (`--worker-mode`). Workers connect to the foreman, receive tasks, run Claude Agent SDK sessions, and report completion.
+- **`src/config.ts`** — Unified config loader. Merges CLI flags, `BRUNEL_*` env vars, `brunel.config.ts` file, legacy env vars, and built-in defaults via zod schema.
 - **`src/display.ts`** — Shared display/rendering engine used by both foreman and worker.
 - **`src/types.ts`** — Shared types: `WorkerMessage`, `ForemanMessage`, `TaskIssue`, `GitHubEvent`.
 
@@ -24,13 +25,21 @@ npm start
 npm run worker
 ```
 
-Required env vars (in `.env`):
-- `GITHUB_REPO` — e.g. `owner/repo`
-- `GITHUB_TOKEN` or `GH_TOKEN` — personal access token with `repo` scope (`GH_TOKEN` is already forwarded in the devcontainer)
-- `TASK_LABEL` — label that triggers work (default: `brunel:ready`)
-- `DONE_LABEL` — label applied on completion (default: `brunel:done`)
-- `FOREMAN_URL` — WebSocket URL workers connect to (default: `ws://localhost:3000`)
+Config (in `.env` or `brunel.config.ts`; CLI flags also accepted). Precedence: CLI flags > `BRUNEL_*` env vars > config file > legacy env vars > defaults.
+
+Required:
+- `BRUNEL_GITHUB_REPO` / `GITHUB_REPO` — e.g. `owner/repo`
+- `BRUNEL_GITHUB_TOKEN` / `GITHUB_TOKEN` / `GH_TOKEN` — personal access token with `repo` scope (`GH_TOKEN` is forwarded automatically in the devcontainer)
 - `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` — for Claude Agent SDK (the OAuth token is used automatically if you're running inside Claude Code)
+
+Optional (all have defaults):
+- `BRUNEL_TASK_LABEL` / `TASK_LABEL` — label that triggers work (default: `brunel:ready`)
+- `BRUNEL_DONE_LABEL` / `DONE_LABEL` — label applied on completion (default: `brunel:done`)
+- `BRUNEL_PORT` / `PORT` — foreman HTTP/WebSocket port (default: `3000`)
+- `BRUNEL_WEBHOOK_SECRET` / `WEBHOOK_SECRET` — GitHub webhook secret for signature verification (optional)
+- `BRUNEL_FOREMAN_URL` — WebSocket URL workers connect to (default: `ws://localhost:3000`); **no legacy fallback for this one**
+- `BRUNEL_VERBOSE` — enable verbose Claude output (default: `false`)
+- `BRUNEL_PERMISSION_MODE` — Claude permission mode: `default`, `acceptEdits`, `bypassPermissions`, `plan`, `dontAsk` (default: `default`)
 
 ## Git workflow
 
@@ -50,4 +59,4 @@ All four run in CI on every PR.
 
 - TypeScript with ESM (`"type": "module"`). New dependencies must be ESM-compatible.
 - No compilation step — `tsx` runs TypeScript directly.
-- Webhook secret is optional for local dev; set `WEBHOOK_SECRET` in `.env` to enable signature verification.
+- Webhook secret is optional for local dev; set `BRUNEL_WEBHOOK_SECRET` in `.env` to enable signature verification.


### PR DESCRIPTION
## Summary
- Adds `src/config.ts` to the architecture overview
- Replaces the old flat env var list with the new `BRUNEL_*` scheme, documenting legacy fallbacks and explicitly noting that `BRUNEL_FOREMAN_URL` has **no** legacy fallback
- Documents all optional config fields (PORT, WEBHOOK_SECRET, VERBOSE, PERMISSION_MODE) that weren't listed before

Followup to #176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)