### PR TITLE
fix: bump flatted to 3.4.2 to resolve prototype pollution CVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2445,9 +2445,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION
## Summary

- Bumps transitive dev dependency `flatted` from 3.4.1 → 3.4.2 via `npm audit fix`
- Fixes high-severity vulnerability [GHSA-rf6f-7fwh-wjgh](https://github.com/advisories/GHSA-rf6f-7fwh-wjgh): prototype pollution via `flatted.parse()`
- Dependency chain: `eslint → file-entry-cache → flat-cache → flatted`
- Low actual risk (dev-only, never called on untrusted input), but clean audit is clean audit

## Test plan

- [ ] `npm audit` reports 0 vulnerabilities
- [ ] CI passes (no functional changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)