### PR TITLE
feat: include line numbers in synthetic code review prompt

### DIFF
--- a/src/templates.ts
+++ b/src/templates.ts
@@ -212,7 +212,7 @@ Please do the above if necessary. Then summarize what you did, and anything else
     `A review was submitted on PR #${p.pull_request?.number}: state=${p.review?.state}.\n\n${p.review?.body ?? ""}\n\nPlease respond in whatever way you think is most appropriate, replying and/or making code changes.`.trim(),
 
   pull_request_review_comment: (p) =>
-    `A review comment was added on PR #${p.pull_request?.number} at \`${p.comment?.path}\`:\n\n${p.comment?.body ?? ""}\n\nPlease respond in whatever way you think is most appropriate, replying and/or making code changes.`.trim(),
+    `A review comment was added on PR #${p.pull_request?.number} at ${formatCommentLocation(p.comment?.path, p.comment?.line, p.comment?.start_line)}:\n\n${p.comment?.body ?? ""}\n\nPlease respond in whatever way you think is most appropriate, replying and/or making code changes.`.trim(),
 
   issue_comment: (p) =>
     `A comment was added on issue #${p.issue?.number}:\n\n${p.comment?.body ?? ""}`.trim(),

--- a/tests/templates.test.ts
+++ b/tests/templates.test.ts
@@ -115,6 +115,22 @@ describe("buildEventPrompt", () => {
     expect(p).toContain("This line is wrong");
   });
 
+  it("pull_request_review_comment with line number → includes line in location", () => {
+    const events: GitHubEvent[] = [
+      {
+        id: "e1",
+        name: "pull_request_review_comment",
+        payload: {
+          action: "created",
+          pull_request: { number: 7 },
+          comment: { body: "Nit: rename this", path: "src/foo.ts", line: 55, start_line: null },
+        },
+      },
+    ];
+    const p = buildEventPrompt(events);
+    expect(p).toContain("`src/foo.ts` line 55");
+  });
+
   it("issue_comment — contains issue number and comment body", () => {
     const evt: GitHubEvent = {
       id: "e1",


### PR DESCRIPTION
Inline comments in the `_code_review` synthetic prompt now include line numbers or line ranges, making it clear exactly where each comment applies.

**Before:**
```
- `src/config.ts`: This line is wrong
```

**After:**
```
- `src/config.ts` line 42: This line is wrong
- `src/config.ts` lines 10-15: This range is problematic
- `src/config.ts`: This is a file-level comment (unchanged)
```

## Changes

- New `formatCommentLocation(path, line?, startLine?)` helper in `src/templates.ts`
- `coalesceEvents` extracts `line` and `start_line` from webhook payloads
- `_code_review` formatter uses the helper for each inline comment
- `pull_request_review_comment` formatter uses the helper as well

Closes #177