### PR TITLE
feat: add supabaseUrl, supabaseServiceRoleKey, and workerSecret config fields

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -49,6 +49,15 @@ const BrunelConfigSchema = z.object({
   foremanUrl:     z.string().default("ws://localhost:3000"),
   /** Claude permission mode for worker sessions. */
   permissionMode: z.enum(VALID_PERMISSION_MODES).default("default"),
+
+  // ── Cloud deployment ───────────────────────────────────────────────────────
+
+  /** Supabase project URL. Optional; required for cloud deployment. */
+  supabaseUrl:            z.string().optional(),
+  /** Supabase service role key. Optional; required for cloud deployment. Prefer env var over config file. */
+  supabaseServiceRoleKey: z.string().optional(),
+  /** Shared secret used to authenticate workers connecting to the foreman. Optional. Prefer env var over config file. */
+  workerSecret:           z.string().optional(),
 });
 
 export type BrunelConfig = z.infer<typeof BrunelConfigSchema> & {
@@ -70,7 +79,7 @@ const explorer = cosmiconfig("brunel", {
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 /** Config keys whose values should never be committed to source control. */
-const SECRET_KEYS = ["githubToken", "webhookSecret"] as const;
+const SECRET_KEYS = ["githubToken", "webhookSecret", "supabaseServiceRoleKey", "workerSecret"] as const;
 
 function warnIfSecretsInFile(
   config: Record<string, unknown>,

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -18,6 +18,7 @@ const ENV_KEYS = [
   "BRUNEL_TASK_LABEL", "BRUNEL_DONE_LABEL",
   "BRUNEL_VERBOSE", "BRUNEL_PORT", "BRUNEL_WEBHOOK_SECRET",
   "BRUNEL_FOREMAN_URL", "BRUNEL_PERMISSION_MODE",
+  "BRUNEL_SUPABASE_URL", "BRUNEL_SUPABASE_SERVICE_ROLE_KEY", "BRUNEL_WORKER_SECRET",
 ];
 
 beforeEach(() => {
@@ -346,5 +347,110 @@ describe("permission mode", () => {
     process.env.BRUNEL_PERMISSION_MODE = "badvalue";
     await loadConfig(["node", "repl.js"]);
     expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});
+
+// ── New optional fields: supabaseUrl, supabaseServiceRoleKey, workerSecret ────
+
+describe("supabaseUrl", () => {
+  it("is undefined by default", async () => {
+    baseEnv();
+    const cfg = await loadConfig(["node", "repl.js"]);
+    expect(cfg.supabaseUrl).toBeUndefined();
+  });
+
+  it("BRUNEL_SUPABASE_URL sets supabaseUrl", async () => {
+    baseEnv();
+    process.env.BRUNEL_SUPABASE_URL = "https://abc.supabase.co";
+    const cfg = await loadConfig(["node", "repl.js"]);
+    expect(cfg.supabaseUrl).toBe("https://abc.supabase.co");
+  });
+
+  it("--supabase-url CLI flag sets supabaseUrl", async () => {
+    baseEnv();
+    const cfg = await loadConfig(["node", "repl.js", "--supabase-url", "https://cli.supabase.co"]);
+    expect(cfg.supabaseUrl).toBe("https://cli.supabase.co");
+  });
+
+  it("CLI flag beats BRUNEL_SUPABASE_URL", async () => {
+    baseEnv();
+    process.env.BRUNEL_SUPABASE_URL = "https://env.supabase.co";
+    const cfg = await loadConfig(["node", "repl.js", "--supabase-url", "https://cli.supabase.co"]);
+    expect(cfg.supabaseUrl).toBe("https://cli.supabase.co");
+  });
+
+  it("BRUNEL_SUPABASE_URL beats file config", async () => {
+    baseEnv();
+    process.env.BRUNEL_SUPABASE_URL = "https://env.supabase.co";
+    const cfg = await loadConfig(["node", "repl.js"], { supabaseUrl: "https://file.supabase.co" });
+    expect(cfg.supabaseUrl).toBe("https://env.supabase.co");
+  });
+});
+
+describe("supabaseServiceRoleKey", () => {
+  it("is undefined by default", async () => {
+    baseEnv();
+    const cfg = await loadConfig(["node", "repl.js"]);
+    expect(cfg.supabaseServiceRoleKey).toBeUndefined();
+  });
+
+  it("BRUNEL_SUPABASE_SERVICE_ROLE_KEY sets supabaseServiceRoleKey", async () => {
+    baseEnv();
+    process.env.BRUNEL_SUPABASE_SERVICE_ROLE_KEY = "service-role-key";
+    const cfg = await loadConfig(["node", "repl.js"]);
+    expect(cfg.supabaseServiceRoleKey).toBe("service-role-key");
+  });
+
+  it("--supabase-service-role-key CLI flag sets supabaseServiceRoleKey", async () => {
+    baseEnv();
+    const cfg = await loadConfig(["node", "repl.js", "--supabase-service-role-key", "cli-key"]);
+    expect(cfg.supabaseServiceRoleKey).toBe("cli-key");
+  });
+
+  it("warns when supabaseServiceRoleKey in file config", async () => {
+    baseEnv();
+    await loadConfig(["node", "repl.js"], { supabaseServiceRoleKey: "file-key" });
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("supabaseServiceRoleKey"));
+  });
+
+  it("does NOT warn when supabaseServiceRoleKey from env var", async () => {
+    baseEnv();
+    process.env.BRUNEL_SUPABASE_SERVICE_ROLE_KEY = "env-key";
+    await loadConfig(["node", "repl.js"]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("workerSecret", () => {
+  it("is undefined by default", async () => {
+    baseEnv();
+    const cfg = await loadConfig(["node", "repl.js"]);
+    expect(cfg.workerSecret).toBeUndefined();
+  });
+
+  it("BRUNEL_WORKER_SECRET sets workerSecret", async () => {
+    baseEnv();
+    process.env.BRUNEL_WORKER_SECRET = "my-worker-secret";
+    const cfg = await loadConfig(["node", "repl.js"]);
+    expect(cfg.workerSecret).toBe("my-worker-secret");
+  });
+
+  it("--worker-secret CLI flag sets workerSecret", async () => {
+    baseEnv();
+    const cfg = await loadConfig(["node", "repl.js", "--worker-secret", "cli-secret"]);
+    expect(cfg.workerSecret).toBe("cli-secret");
+  });
+
+  it("warns when workerSecret in file config", async () => {
+    baseEnv();
+    await loadConfig(["node", "repl.js"], { workerSecret: "file-secret" });
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("workerSecret"));
+  });
+
+  it("does NOT warn when workerSecret from env var", async () => {
+    baseEnv();
+    process.env.BRUNEL_WORKER_SECRET = "env-secret";
+    await loadConfig(["node", "repl.js"]);
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Adds three new optional fields to `BrunelConfig` in `src/config.ts`: `supabaseUrl`, `supabaseServiceRoleKey`, and `workerSecret`
- All three follow the same layered config pattern (CLI flags > `BRUNEL_*` env vars > file config > defaults)
- `supabaseServiceRoleKey` and `workerSecret` are treated as secrets — they emit `console.warn` when found in a config file, matching the pattern used by `webhookSecret` and `githubToken`
- 15 new tests added covering defaults, env vars, CLI flags, secret warnings, and layer precedence

| Field | `BRUNEL_*` env var | CLI flag | Default |
|---|---|---|---|
| `supabaseUrl` | `BRUNEL_SUPABASE_URL` | `--supabase-url` | `undefined` |
| `supabaseServiceRoleKey` | `BRUNEL_SUPABASE_SERVICE_ROLE_KEY` | `--supabase-service-role-key` | `undefined` |
| `workerSecret` | `BRUNEL_WORKER_SECRET` | `--worker-secret` | `undefined` |

## Test plan

- [x] All 737 existing tests pass
- [x] 15 new tests added and passing
- [x] `npx tsc --noEmit` clean

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)