### PR TITLE
feat: add admin WebSocket broadcaster (src/admin-ws.ts)

### DIFF
--- a/src/admin-ws.ts
+++ b/src/admin-ws.ts
@@ -1,0 +1,74 @@
+import http from "http";
+import { WebSocketServer } from "ws";
+import type { WebSocket as WsSocket } from "ws";
+
+export interface LogEntry {
+  kind: string;
+  id: number;
+  timestamp: string;
+  taskId: string | null;
+  workerId: string | null;
+  summary: string;
+}
+
+export interface TaskSnapshot {
+  taskId: string;
+  issueNumber: number;
+  title: string;
+  status: "pending" | "assigned" | "complete";
+  assignedWorkerId?: string;
+}
+
+export interface WorkerSnapshot {
+  workerId: string;
+  status: "idle" | "busy";
+  currentTaskId?: string;
+}
+
+export interface AdminSnapshot {
+  tasks: TaskSnapshot[];
+  workers: WorkerSnapshot[];
+}
+
+export type AdminMessage =
+  | { type: "snapshot"; tasks: TaskSnapshot[]; workers: WorkerSnapshot[] }
+  | { type: "log_event"; entry: LogEntry };
+
+export interface AdminWss {
+  broadcastSnapshot(snapshot: AdminSnapshot): void;
+  broadcastLogEvent(entry: LogEntry): void;
+}
+
+export function createAdminWss(server: http.Server): AdminWss {
+  const clients = new Set<WsSocket>();
+  const wss = new WebSocketServer({ noServer: true });
+
+  wss.on("connection", (ws) => {
+    clients.add(ws);
+    ws.on("close", () => clients.delete(ws));
+  });
+
+  server.on("upgrade", (req, socket, head) => {
+    if (req.url === "/admin/ws") {
+      wss.handleUpgrade(req, socket, head, (ws) => wss.emit("connection", ws, req));
+    } else {
+      socket.destroy();
+    }
+  });
+
+  function broadcast(msg: AdminMessage) {
+    const json = JSON.stringify(msg);
+    for (const ws of clients) {
+      if (ws.readyState === 1 /* OPEN */) ws.send(json);
+    }
+  }
+
+  return {
+    broadcastSnapshot(snapshot) {
+      broadcast({ type: "snapshot", ...snapshot });
+    },
+    broadcastLogEvent(entry) {
+      broadcast({ type: "log_event", entry });
+    },
+  };
+}

--- a/tests/admin-ws.test.ts
+++ b/tests/admin-ws.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, afterEach } from "vitest";
+import http from "http";
+import { WebSocket } from "ws";
+import type { AddressInfo } from "net";
+import { createAdminWss } from "../src/admin-ws.js";
+import type { AdminMessage } from "../src/admin-ws.js";
+
+function startServer(): Promise<{ server: http.Server; port: number; adminWss: ReturnType<typeof createAdminWss> }> {
+  return new Promise((resolve) => {
+    const server = http.createServer();
+    const adminWss = createAdminWss(server);
+    server.listen(0, () => {
+      resolve({ server, port: (server.address() as AddressInfo).port, adminWss });
+    });
+  });
+}
+
+function connectAdmin(port: number): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://localhost:${port}/admin/ws`);
+    ws.once("open", () => resolve(ws));
+    ws.once("error", reject);
+  });
+}
+
+function nextMsg(ws: WebSocket): Promise<AdminMessage> {
+  return new Promise((resolve) => {
+    ws.once("message", (d) => resolve(JSON.parse(d.toString())));
+  });
+}
+
+function closeAll(...ws: WebSocket[]): Promise<void> {
+  return Promise.all(ws.map((w) => new Promise<void>((r) => {
+    if (w.readyState === WebSocket.CLOSED) { r(); return; }
+    w.once("close", r);
+    w.close();
+  }))).then(() => {});
+}
+
+describe("createAdminWss", () => {
+  const servers: http.Server[] = [];
+  afterEach(() => {
+    const s = servers.splice(0);
+    return Promise.all(s.map((srv) => new Promise<void>((r) => srv.close(() => r()))));
+  });
+
+  it("broadcasts snapshot to connected clients", async () => {
+    const { server, port, adminWss } = await startServer();
+    servers.push(server);
+    const ws = await connectAdmin(port);
+    const msgP = nextMsg(ws);
+    adminWss.broadcastSnapshot({ tasks: [], workers: [] });
+    const msg = await msgP;
+    expect(msg).toEqual({ type: "snapshot", tasks: [], workers: [] });
+    await closeAll(ws);
+  });
+
+  it("broadcasts log_event to connected clients", async () => {
+    const { server, port, adminWss } = await startServer();
+    servers.push(server);
+    const ws = await connectAdmin(port);
+    const msgP = nextMsg(ws);
+    adminWss.broadcastLogEvent({ kind: "webhook", id: 1, timestamp: "2026-01-01T00:00:00Z", taskId: null, workerId: null, summary: "issues/labeled #1" });
+    const msg = await msgP;
+    expect(msg).toEqual({ type: "log_event", entry: { kind: "webhook", id: 1, timestamp: "2026-01-01T00:00:00Z", taskId: null, workerId: null, summary: "issues/labeled #1" } });
+    await closeAll(ws);
+  });
+
+  it("broadcasts to multiple connected clients", async () => {
+    const { server, port, adminWss } = await startServer();
+    servers.push(server);
+    const [ws1, ws2] = await Promise.all([connectAdmin(port), connectAdmin(port)]);
+    const [p1, p2] = [nextMsg(ws1), nextMsg(ws2)];
+    adminWss.broadcastSnapshot({ tasks: [], workers: [] });
+    const [m1, m2] = await Promise.all([p1, p2]);
+    expect(m1.type).toBe("snapshot");
+    expect(m2.type).toBe("snapshot");
+    await closeAll(ws1, ws2);
+  });
+
+  it("ignores requests to /worker path (does not hijack worker upgrade)", async () => {
+    const { server, port } = await startServer();
+    servers.push(server);
+    const ws = new WebSocket(`ws://localhost:${port}/worker`);
+    await new Promise<void>((resolve) => ws.once("error", () => resolve()));
+    expect(ws.readyState).not.toBe(WebSocket.OPEN);
+  });
+});


### PR DESCRIPTION
## Summary

- Creates `src/admin-ws.ts` with `createAdminWss(server)` that attaches a `WebSocketServer` at `/admin/ws` (using `noServer: true`)
- Exposes `AdminWss` interface with `broadcastSnapshot` and `broadcastLogEvent` methods for pushing live state to browser clients
- Two wire message types: `{ type: "snapshot", tasks, workers }` and `{ type: "log_event", entry }`
- Destroys sockets for non-`/admin/ws` upgrade paths (consistent with how the existing foreman handles unrecognized paths)
- Exports `LogEntry`, `TaskSnapshot`, `WorkerSnapshot`, `AdminSnapshot`, and `AdminMessage` types
- Tests cover: snapshot broadcast, log_event broadcast, multiple simultaneous clients, and that `/worker` path is not hijacked

## Test plan

- [x] All 4 new tests in `tests/admin-ws.test.ts` pass
- [x] Full test suite passes (726 tests)

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)