### PR TITLE
feat: add Supabase migration and env config for logging tables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,8 @@ DONE_LABEL=brunel:done
 
 # Worker
 FOREMAN_URL=ws://localhost:3000
+
+# Supabase (optional — logging disabled if absent)
+# For local dev: run `supabase start` and copy values from its output
+# BRUNEL_SUPABASE_URL=http://localhost:54321
+# BRUNEL_SUPABASE_SERVICE_ROLE_KEY=<service_role key from supabase start>

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,6 @@
+# .env.test — test environment config
+# Copy all vars from .env, then override as needed:
+# - Leave BRUNEL_SUPABASE_URL unset to skip DB logging in tests (recommended)
+# - If testing DB paths, use a separate schema:
+#   BRUNEL_SUPABASE_URL=http://localhost:54321
+#   BRUNEL_SUPABASE_SERVICE_ROLE_KEY=<service_role key from supabase start>

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 node_modules/
 dist/
 .env
+.env.local
 repl.log
 .worker-id
 coverage/

--- a/supabase/migrations/20260321000000_create_logging_tables.sql
+++ b/supabase/migrations/20260321000000_create_logging_tables.sql
@@ -1,0 +1,31 @@
+create table webhook_events (
+  id            bigint generated always as identity primary key,
+  received_at   timestamptz not null default now(),
+  delivery_id   text,
+  event_name    text not null,
+  action        text,
+  repo          text,
+  sender        text,
+  issue_number  int,
+  pr_number     int,
+  branch        text,
+  task_id       text,
+  payload       jsonb not null
+);
+
+create index on webhook_events (task_id);
+create index on webhook_events (received_at desc);
+
+create table foreman_messages (
+  id          bigint generated always as identity primary key,
+  created_at  timestamptz not null default now(),
+  direction   text not null,
+  worker_id   text,
+  task_id     text,
+  msg_type    text not null,
+  payload     jsonb not null
+);
+
+create index on foreman_messages (task_id);
+create index on foreman_messages (worker_id);
+create index on foreman_messages (created_at desc);


### PR DESCRIPTION
## Summary

- Creates `supabase/migrations/20260321000000_create_logging_tables.sql` with `webhook_events` and `foreman_messages` tables and their indexes
- Adds optional `BRUNEL_SUPABASE_URL` / `BRUNEL_SUPABASE_SERVICE_ROLE_KEY` comments to `.env.example`
- Creates `.env.test` with test environment guidance
- Adds `.env.local` to `.gitignore`

Part of the Cloud Deployment plan — Chunk 1, Task 3.

## Test plan

- [x] All 741 existing tests pass
- [ ] Verify migration can be applied: `supabase db reset` or `supabase migration up`
- [ ] Confirm `.env.local` is properly ignored by git
- [ ] Confirm `.env.test` is committed and present in repo

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)