### PR TITLE
fix: only drop check_suite events when PR is closed

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -191,8 +191,8 @@ export class WorkerSession {
       } else if (event.name === "pull_request" && action === "reopened") {
         this.prIsClosed = false;
         // process normally
-      } else if (this.prIsClosed) {
-        // Post-merge event: already logged via printForemanMessage; silently drop.
+      } else if (this.prIsClosed && event.name === "check_suite") {
+        // Post-merge check suite: already logged via printForemanMessage; silently drop.
         return;
       }
 

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -722,7 +722,7 @@ describe("event-type-specific debounce timers", () => {
 // ── prIsClosed guard ──────────────────────────────────────────────────────────
 
 describe("prIsClosed guard", () => {
-  it("drops non-PR events silently when PR is closed", async () => {
+  it("drops check_suite events silently when PR is closed", async () => {
     vi.useFakeTimers();
     try {
       const issue = makeIssue();
@@ -767,6 +767,30 @@ describe("prIsClosed guard", () => {
       // check_suite event should now work normally (not dropped)
       const csEvt: GitHubEvent = { id: "e2", name: "check_suite", payload: { action: "completed", check_suite: { conclusion: "success" } } };
       sendMsg(fakeWs, { type: "event_notification", taskId: "99", event: csEvt });
+      await vi.runAllTimersAsync();
+      await vi.waitFor(() => expect(runQuery).toHaveBeenCalledOnce());
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("still processes issue_comment/created after PR is closed", async () => {
+    vi.useFakeTimers();
+    try {
+      const issue = makeIssue();
+      sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
+      await vi.waitFor(() => expect(runQuery).toHaveBeenCalledOnce());
+
+      // Close the PR — should trigger cleanup query
+      const closedEvt: GitHubEvent = { id: "e1", name: "pull_request", payload: { action: "closed", pull_request: { number: 1 } } };
+      sendMsg(fakeWs, { type: "event_notification", taskId: "42", event: closedEvt });
+      await vi.runAllTimersAsync();
+      await vi.waitFor(() => expect(runQuery).toHaveBeenCalledTimes(2));
+      runQuery.mockClear();
+
+      // issue_comment/created should NOT be dropped — still actionable after PR closed
+      const commentEvt: GitHubEvent = { id: "e2", name: "issue_comment", payload: { action: "created" } };
+      sendMsg(fakeWs, { type: "event_notification", taskId: "42", event: commentEvt });
       await vi.runAllTimersAsync();
       await vi.waitFor(() => expect(runQuery).toHaveBeenCalledOnce());
     } finally {


### PR DESCRIPTION
## Summary

- After a PR is closed, the worker was silently dropping ALL non-PR-lifecycle events
- `issue_comment/created` (and other non-check-suite events) should still be actionable after a PR is closed
- Only `check_suite` events are truly irrelevant post-merge

## Changes

- `src/worker.ts`: Changed the `prIsClosed` guard from dropping all events to only dropping `check_suite` events
- `tests/worker.test.ts`: Added test verifying `issue_comment/created` is still processed after PR closes; updated existing test description to be specific about what's dropped

## Test plan

- [x] New test: "still processes issue_comment/created after PR is closed" — was failing before fix, passes after
- [x] Existing test: "drops check_suite events silently when PR is closed" — continues to pass
- [x] All 753 tests pass

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)