### PR TITLE
fix: parseBodyBlockers captures all #N in comma-separated dependency lists

### DIFF
--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -12,11 +12,16 @@ export type DependencyGraph = Map<number, Set<number>>;
  * Returns a deduplicated list of blocker issue numbers.
  */
 export function parseBodyBlockers(body: string): number[] {
-  const pattern = /(?:^|\s)(?:depends\s+on|blocked\s+by)\s+#(\d+)/gi;
+  // Match a keyword clause followed by one or more comma-separated #N references.
+  const clausePattern = /(?:^|\s)(?:depends\s+on|blocked\s+by)\s+(#\d+(?:\s*,\s*#\d+)*)/gi;
   const numbers = new Set<number>();
   let m: RegExpExecArray | null;
-  while ((m = pattern.exec(body)) !== null) {
-    numbers.add(parseInt(m[1], 10));
+  while ((m = clausePattern.exec(body)) !== null) {
+    const refPattern = /#(\d+)/g;
+    let r: RegExpExecArray | null;
+    while ((r = refPattern.exec(m[1])) !== null) {
+      numbers.add(parseInt(r[1], 10));
+    }
   }
   return Array.from(numbers);
 }

--- a/tests/dependencies.test.ts
+++ b/tests/dependencies.test.ts
@@ -30,6 +30,18 @@ describe("parseBodyBlockers", () => {
   it("ignores partial matches", () => {
     expect(parseBodyBlockers("closedepends on #5")).toEqual([]);
   });
+
+  it("parses comma-separated list after depends on", () => {
+    expect(parseBodyBlockers("Depends on #181, #182, #183, #184")).toEqual([181, 182, 183, 184]);
+  });
+
+  it("parses comma-separated list after blocked by", () => {
+    expect(parseBodyBlockers("Blocked by #10, #11, #12")).toEqual([10, 11, 12]);
+  });
+
+  it("parses mixed single and comma-separated entries across lines", () => {
+    expect(parseBodyBlockers("Depends on #1\nBlocked by #2, #3, #4")).toEqual([1, 2, 3, 4]);
+  });
 });
 
 describe("setBlockers", () => {


### PR DESCRIPTION
## Summary

- Fixes `parseBodyBlockers` in `src/dependencies.ts` to extract all issue numbers from comma-separated dependency lines like `Depends on #181, #182, #183, #184`
- Replaces the single-regex approach with a two-step strategy: match the keyword clause capturing the full `#N, #N, ...` list, then extract all `#N` references from it
- Adds 3 new test cases covering comma-separated `depends on`, comma-separated `blocked by`, and mixed single + comma-separated entries across lines

## Test plan

- [x] New tests fail before the fix and pass after
- [x] All 755 tests pass (`npm test`)
- [x] Existing behavior (single numbers, multi-line, case-insensitive, partial-match rejection) unchanged

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)