### PR TITLE
fix: dequeue pending tasks when brunel:ready label is removed

### DIFF
--- a/src/foreman.ts
+++ b/src/foreman.ts
@@ -183,6 +183,12 @@ export class TaskQueue {
     return taskId ? this.tasks.get(taskId) : undefined;
   }
 
+  removeTask(taskId: string) {
+    const t = this.tasks.get(taskId);
+    if (!t || t.status !== "pending") return;
+    this.tasks.delete(taskId);
+  }
+
   markDepsLoaded(issueNumbers: number[]) {
     for (const n of issueNumbers) {
       const t = this.tasks.get(String(n));
@@ -584,6 +590,20 @@ export function createForemanWss(
 
     if (name === "issues" && issue) {
       const action = p.action as string | undefined;
+
+      if (
+        action === "unlabeled" &&
+        (p.label as Record<string, unknown> | undefined)?.name === taskLabel
+      ) {
+        const existingTask = taskQueue.getTaskForIssue(issueNumber);
+        if (existingTask?.status === "pending") {
+          taskQueue.removeTask(existingTask.taskId);
+          openIssues.delete(issueNumber);
+          broadcastSnapshot();
+          flog(`[task #${issueNumber}] dequeued (label removed)`);
+        }
+        return;
+      }
 
       if (action === "closed") {
         openIssues.delete(issueNumber);

--- a/tests/foreman.taskqueue.test.ts
+++ b/tests/foreman.taskqueue.test.ts
@@ -93,6 +93,30 @@ describe("TaskQueue", () => {
   });
 });
 
+describe("removeTask", () => {
+  let q: TaskQueue;
+  beforeEach(() => { q = new TaskQueue(); });
+
+  it("removes a pending task so it is no longer retrievable", () => {
+    q.addTask(baseTask);
+    q.removeTask("42");
+    expect(q.get("42")).toBeUndefined();
+    expect(q.getTaskForIssue(42)).toBeUndefined();
+    expect(q.nextPending()).toBeNull();
+  });
+
+  it("does not remove an assigned task", () => {
+    q.addTask(baseTask);
+    q.assignTask("42", "w1");
+    q.removeTask("42");
+    expect(q.get("42")).toBeDefined();
+  });
+
+  it("is a no-op for unknown taskId", () => {
+    expect(() => q.removeTask("nonexistent")).not.toThrow();
+  });
+});
+
 describe("nextPending with predicate", () => {
   let q: TaskQueue;
   beforeEach(() => { q = new TaskQueue(); });

--- a/tests/foreman.webhook-routing.test.ts
+++ b/tests/foreman.webhook-routing.test.ts
@@ -622,4 +622,56 @@ describe("foreman event filtering", () => {
     ]);
     expect(raceResult).toBe("timeout");
   });
+
+  it('issues/unlabeled with task label removes a pending task from the queue', async () => {
+    // Enqueue task via webhook (no worker connected, so it stays pending)
+    routeEvent("evt-labeled", "issues", labeledPayload(42, "brunel:ready"));
+    expect(queue.getTaskForIssue(42)?.status).toBe("pending");
+
+    // Remove the label — pending task should be dequeued
+    routeEvent("evt-unlabeled", "issues", {
+      action: "unlabeled",
+      label: { name: "brunel:ready" },
+      issue: { number: 42, title: "Issue 42", body: "Body", labels: [] },
+      repository: { html_url: "https://github.com/owner/repo" },
+    });
+
+    expect(queue.getTaskForIssue(42)).toBeUndefined();
+  });
+
+  it('issues/unlabeled with task label does not remove an already-assigned task', async () => {
+    const ws = await connect();
+    send(ws, { type: "worker_hello", workerId: "w1", status: "idle" });
+    await nextMsg(ws); // standby
+
+    const reply = nextMsg(ws);
+    routeEvent("evt-labeled", "issues", labeledPayload(42, "brunel:ready"));
+    await reply; // task_assigned
+
+    expect(queue.getTaskForIssue(42)?.status).toBe("assigned");
+
+    // Removing the label should leave the assigned task intact
+    routeEvent("evt-unlabeled", "issues", {
+      action: "unlabeled",
+      label: { name: "brunel:ready" },
+      issue: { number: 42, title: "Issue 42", body: "Body", labels: [] },
+      repository: { html_url: "https://github.com/owner/repo" },
+    });
+
+    expect(queue.getTaskForIssue(42)?.status).toBe("assigned");
+  });
+
+  it('issues/unlabeled with non-task label does not remove a pending task', async () => {
+    routeEvent("evt-labeled", "issues", labeledPayload(42, "brunel:ready"));
+    expect(queue.getTaskForIssue(42)?.status).toBe("pending");
+
+    routeEvent("evt-unlabeled", "issues", {
+      action: "unlabeled",
+      label: { name: "some-other-label" },
+      issue: { number: 42, title: "Issue 42", body: "Body", labels: [{ name: "brunel:ready" }] },
+      repository: { html_url: "https://github.com/owner/repo" },
+    });
+
+    expect(queue.getTaskForIssue(42)).toBeDefined();
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `TaskQueue.removeTask()` that only removes tasks in `pending` status (guards against removing assigned tasks)
- Handles `issues/unlabeled` webhook events: when the task label is removed from an issue with a pending task, that task is dequeued
- Assigned tasks are intentionally left untouched (as noted in the issue, cancellation is a separate concern)

## Test plan

- [ ] `issues/unlabeled` with task label removes a pending task from the queue
- [ ] `issues/unlabeled` with task label does NOT remove an already-assigned task
- [ ] `issues/unlabeled` with a non-task label does not affect a pending task
- [ ] `TaskQueue.removeTask` only removes pending tasks, is a no-op for unknown ids
- [ ] All 758 existing tests continue to pass

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)