### PR TITLE
fix: return to prompt after ^C interrupt in worker mode

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -229,31 +229,34 @@ export class WorkerSession {
       this.debounceTimer = null;
     }
 
-    const ac = new AbortController();
-    this.isRunningQuery = true;
+    // Always notify waitUntilIdle() callers when this loop exits, even on ^C interrupt.
     try {
-      this.currentSessionId = await this.runQuery(initialPrompt, this.currentSessionId, ac) ?? this.currentSessionId;
-    } finally {
-      this.isRunningQuery = false;
-    }
-
-    // If the user interrupted (^C), skip the event drain and foreman notification.
-    if (ac.signal.aborted) return;
-
-    while (this.pendingEvents.length > 0 && this.currentTaskId && this.currentIssue) {
-      const eventAc = new AbortController();
-      const events = this.pendingEvents.splice(0);
-      const prompt = this.buildAndLogEventPrompt(events);
+      const ac = new AbortController();
       this.isRunningQuery = true;
       try {
-        this.currentSessionId = await this.runQuery(prompt, this.currentSessionId, eventAc) ?? this.currentSessionId;
+        this.currentSessionId = await this.runQuery(initialPrompt, this.currentSessionId, ac) ?? this.currentSessionId;
       } finally {
         this.isRunningQuery = false;
       }
-      if (eventAc.signal.aborted) return;
-    }
 
-    this.notifyQueryDone();
+      // If the user interrupted (^C), skip the event drain and foreman notification.
+      if (ac.signal.aborted) return;
+
+      while (this.pendingEvents.length > 0 && this.currentTaskId && this.currentIssue) {
+        const eventAc = new AbortController();
+        const events = this.pendingEvents.splice(0);
+        const prompt = this.buildAndLogEventPrompt(events);
+        this.isRunningQuery = true;
+        try {
+          this.currentSessionId = await this.runQuery(prompt, this.currentSessionId, eventAc) ?? this.currentSessionId;
+        } finally {
+          this.isRunningQuery = false;
+        }
+        if (eventAc.signal.aborted) return;
+      }
+    } finally {
+      this.notifyQueryDone();
+    }
   }
 
   private buildAndLogEventPrompt(events: GitHubEvent[]): string {

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -342,6 +342,33 @@ describe("waitUntilIdle", () => {
     await expect(p1).resolves.toBeUndefined();
     await expect(p2).resolves.toBeUndefined();
   });
+
+  it("resolves after runQuery is aborted (^C interrupt)", async () => {
+    let resolveQuery!: (v: string | undefined) => void;
+    let capturedAc!: AbortController;
+    runQuery.mockImplementationOnce(
+      (_prompt: string, _sessionId: string | undefined, ac: AbortController) => {
+        capturedAc = ac;
+        return new Promise<string | undefined>((r) => { resolveQuery = r; });
+      }
+    );
+
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "1", issue: makeIssue() });
+    await vi.waitFor(() => expect(runQuery).toHaveBeenCalledOnce());
+
+    const idlePromise = session.waitUntilIdle();
+
+    // Simulate ^C: abort the controller and let the mock resolve
+    capturedAc.abort();
+    resolveQuery(undefined);
+
+    // waitUntilIdle should resolve even though the query was aborted
+    const result = await Promise.race([
+      idlePromise.then(() => "idle"),
+      new Promise<"timeout">((r) => setTimeout(() => r("timeout"), 100)),
+    ]);
+    expect(result).toBe("idle");
+  });
 });
 
 // ── classifyEvent ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Fixes a bug where pressing Ctrl-C during a worker task left the worker stuck with no prompt
- Root cause: `runQueryLoop()` returned early on interrupt without calling `notifyQueryDone()`, leaving `waitUntilIdle()` blocked on a promise that would never resolve
- Fix: wrap the loop body in a `try/finally` so `notifyQueryDone()` is always called on exit, regardless of whether the query completed normally or was interrupted

## Test plan

- [x] New test: `waitUntilIdle resolves after runQuery is aborted (^C interrupt)` — was failing before the fix, passes after
- [x] All 753 existing tests continue to pass

Closes #202