### PR TITLE
Refactor createHttpServer to use Hono routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.76",
+        "@hono/node-server": "^1.19.11",
         "@octokit/webhooks": "^13.0.0",
         "@supabase/supabase-js": "^2.99.3",
         "cosmiconfig": "^9.0.1",
         "dotenv": "^16.0.0",
+        "hono": "^4.12.8",
         "tsx": "^4.0.0",
         "ws": "^8.19.0",
         "zod": "^4.3.6"
@@ -675,6 +677,18 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2583,6 +2597,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.8",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
+      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/html-escaper": {

--- a/package.json
+++ b/package.json
@@ -19,10 +19,12 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.76",
+    "@hono/node-server": "^1.19.11",
     "@octokit/webhooks": "^13.0.0",
     "@supabase/supabase-js": "^2.99.3",
     "cosmiconfig": "^9.0.1",
     "dotenv": "^16.0.0",
+    "hono": "^4.12.8",
     "tsx": "^4.0.0",
     "ws": "^8.19.0",
     "zod": "^4.3.6"

--- a/src/foreman.ts
+++ b/src/foreman.ts
@@ -1,6 +1,8 @@
 import { Webhooks } from "@octokit/webhooks";
 import http from "http";
 import "dotenv/config";
+import { Hono } from "hono";
+import { getRequestListener } from "@hono/node-server";
 import { WebSocketServer } from "ws";
 import type { WebSocket as WsSocket } from "ws";
 import type { WorkerMessage, ForemanMessage, GitHubEvent, TaskIssue, LabeledIssueState } from "./types.js";
@@ -269,112 +271,116 @@ function printEvent(id: string, name: string, payload: unknown) {
 
 // ── HTTP server factory ───────────────────────────────────────────────────────
 
-function createHttpServer(
+export function createHttpServer(
   webhooks: InstanceType<typeof Webhooks> | null,
   routeEvent: (id: string, name: string, payload: unknown) => void,
   dbLogger?: DbLogger,
 ): http.Server {
-  return http.createServer(async (req, res) => {
-    if (req.method === "POST" && req.url === "/webhook") {
-      const chunks: Buffer[] = [];
-      for await (const chunk of req) {
-        chunks.push(chunk as Buffer);
-      }
-      const rawBody = Buffer.concat(chunks).toString();
+  const app = new Hono();
 
-      const id = (req.headers["x-github-delivery"] as string) ?? "unknown";
-      const name = req.headers["x-github-event"] as string;
-      const signature = req.headers["x-hub-signature-256"] as string;
+  // ── Webhook ────────────────────────────────────────────────────────────────
+  app.post("/webhook", async (c) => {
+    const rawBody = await c.req.text();
+    const id = c.req.header("x-github-delivery") ?? "unknown";
+    const name = c.req.header("x-github-event");
+    const signature = c.req.header("x-hub-signature-256");
 
-      if (!name) {
-        res.writeHead(400);
-        res.end("Missing x-github-event header");
-        return;
-      }
-
-      try {
-        if (webhooks) {
-          if (!signature) {
-            res.writeHead(401);
-            res.end("Missing signature");
-            return;
-          }
-          await webhooks.verifyAndReceive({
-            id,
-            name: name as Parameters<typeof webhooks.verifyAndReceive>[0]["name"],
-            signature,
-            payload: rawBody,
-          });
-        } else {
-          const parsed = JSON.parse(rawBody);
-          printEvent(id, name, parsed);
-          routeEvent(id, name, parsed);
-        }
-        res.writeHead(200);
-        res.end("OK");
-      } catch (err) {
-        flog(`ERROR Webhook processing error: ${err}`);
-        res.writeHead(400);
-        res.end("Bad Request");
-      }
-      return;
+    if (!name) {
+      return c.text("Missing x-github-event header", 400);
     }
 
-    if (req.url === "/") {
-      res.writeHead(200, { "Content-Type": "text/plain" });
-      res.end("GitHub webhook listener running. POST events to /webhook");
-      return;
-    }
-
-    // ── REST API ──────────────────────────────────────────────────────────────
-    if (req.method === "GET" && req.url?.startsWith("/api/")) {
-      res.setHeader("Content-Type", "application/json");
-      try {
-        if (req.url === "/api/log" || req.url?.startsWith("/api/log?")) {
-          const entries = dbLogger ? await dbLogger.queryLog({ limit: 100 }) : [];
-          res.writeHead(200); res.end(JSON.stringify(entries)); return;
+    try {
+      if (webhooks) {
+        if (!signature) {
+          return c.text("Missing signature", 401);
         }
-        const taskMatch = /^\/api\/tasks\/([^/]+)\/events$/.exec(req.url ?? "");
-        if (taskMatch) {
-          const entries = dbLogger ? await dbLogger.queryTaskEvents(taskMatch[1]) : [];
-          res.writeHead(200); res.end(JSON.stringify(entries)); return;
-        }
-        const workerMatch = /^\/api\/workers\/([^/]+)\/messages$/.exec(req.url ?? "");
-        if (workerMatch) {
-          const entries = dbLogger ? await dbLogger.queryWorkerMessages(workerMatch[1]) : [];
-          res.writeHead(200); res.end(JSON.stringify(entries)); return;
-        }
-      } catch (err) {
-        flog(`ERROR API query failed: ${err}`);
-        res.writeHead(500); res.end(JSON.stringify({ error: "internal error" })); return;
+        await webhooks.verifyAndReceive({
+          id,
+          name: name as Parameters<typeof webhooks.verifyAndReceive>[0]["name"],
+          signature,
+          payload: rawBody,
+        });
+      } else {
+        const parsed = JSON.parse(rawBody) as unknown;
+        printEvent(id, name, parsed);
+        routeEvent(id, name, parsed);
       }
+      return c.text("OK", 200);
+    } catch (err) {
+      flog(`ERROR Webhook processing error: ${err}`);
+      return c.text("Bad Request", 400);
     }
+  });
 
-    // ── Static files (React SPA) ──────────────────────────────────────────────
-    // Serve dist/ for all other routes. Falls back to index.html for SPA routing.
-    // Only active when dist/ exists (production build); in dev, Vite serves the frontend.
+  // ── Health check ───────────────────────────────────────────────────────────
+  app.get("/", (c) =>
+    c.text("GitHub webhook listener running. POST events to /webhook"),
+  );
+
+  // ── REST API ───────────────────────────────────────────────────────────────
+  app.get("/api/log", async (c) => {
+    try {
+      const entries = dbLogger ? await dbLogger.queryLog({ limit: 100 }) : [];
+      return c.json(entries);
+    } catch (err) {
+      flog(`ERROR API query failed: ${err}`);
+      return c.json({ error: "internal error" }, 500);
+    }
+  });
+
+  app.get("/api/tasks/:id/events", async (c) => {
+    try {
+      const entries = dbLogger ? await dbLogger.queryTaskEvents(c.req.param("id")) : [];
+      return c.json(entries);
+    } catch (err) {
+      flog(`ERROR API query failed: ${err}`);
+      return c.json({ error: "internal error" }, 500);
+    }
+  });
+
+  app.get("/api/workers/:id/messages", async (c) => {
+    try {
+      const entries = dbLogger ? await dbLogger.queryWorkerMessages(c.req.param("id")) : [];
+      return c.json(entries);
+    } catch (err) {
+      flog(`ERROR API query failed: ${err}`);
+      return c.json({ error: "internal error" }, 500);
+    }
+  });
+
+  // ── Static files (React SPA) ───────────────────────────────────────────────
+  // Serve dist/ for all other routes. Falls back to index.html for SPA routing.
+  // Only active when dist/ exists (production build); in dev, Vite serves the frontend.
+  app.use("*", async (c) => {
     const { createReadStream, existsSync } = await import("fs");
     const { join, extname } = await import("path");
     const { fileURLToPath } = await import("url");
     const root = join(fileURLToPath(import.meta.url), "../../dist");
 
-    if (existsSync(root)) {
-      const safePath = (req.url ?? "/").split("?")[0];
-      const filePath = join(root, safePath);
-      const target = existsSync(filePath) && !safePath.endsWith("/")
-        ? filePath : join(root, "index.html");
-      const mime: Record<string, string> = {
-        ".html": "text/html", ".js": "application/javascript",
-        ".css": "text/css", ".svg": "image/svg+xml", ".ico": "image/x-icon",
-      };
-      res.writeHead(200, { "Content-Type": mime[extname(target)] ?? "application/octet-stream" });
-      createReadStream(target).pipe(res);
-      return;
+    if (!existsSync(root)) {
+      return c.text("Not Found", 404);
     }
 
-    res.writeHead(404);
-    res.end("Not Found");
+    const safePath = c.req.path;
+    const filePath = join(root, safePath);
+    const target =
+      existsSync(filePath) && !safePath.endsWith("/")
+        ? filePath
+        : join(root, "index.html");
+    const mime: Record<string, string> = {
+      ".html": "text/html",
+      ".js": "application/javascript",
+      ".css": "text/css",
+      ".svg": "image/svg+xml",
+      ".ico": "image/x-icon",
+    };
+    const stream = createReadStream(target);
+    return new Response(stream as unknown as ReadableStream, {
+      headers: { "Content-Type": mime[extname(target)] ?? "application/octet-stream" },
+    });
   });
+
+  return http.createServer(getRequestListener(app.fetch));
 }
 
 // ── WebSocket server factory ──────────────────────────────────────────────────

--- a/tests/foreman.http.test.ts
+++ b/tests/foreman.http.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for the HTTP routes in createHttpServer.
+ *
+ * Verifies that Hono routing correctly handles:
+ * - POST /webhook: GitHub webhook ingestion
+ * - GET /: health check
+ * - GET /api/log: log query
+ * - GET /api/tasks/:id/events: task events query
+ * - GET /api/workers/:id/messages: worker messages query
+ * - 404 fallback when no static dist/ exists
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import http from "http";
+import type { AddressInfo } from "net";
+import { createHttpServer } from "../src/foreman.js";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function startServer(server: http.Server): Promise<number> {
+  return new Promise((resolve) => {
+    server.listen(0, () => {
+      resolve((server.address() as AddressInfo).port);
+    });
+  });
+}
+
+function stopServer(server: http.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+async function request(
+  port: number,
+  method: string,
+  path: string,
+  options: { body?: string; headers?: Record<string, string> } = {},
+): Promise<{ status: number; body: string; contentType: string | undefined }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { hostname: "localhost", port, method, path, headers: options.headers ?? {} },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c) => chunks.push(c as Buffer));
+        res.on("end", () =>
+          resolve({
+            status: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString(),
+            contentType: res.headers["content-type"],
+          }),
+        );
+      },
+    );
+    req.on("error", reject);
+    if (options.body) req.write(options.body);
+    req.end();
+  });
+}
+
+// ── Test harness ───────────────────────────────────────────────────────────────
+
+let server: http.Server;
+let port: number;
+let routeEvent: ReturnType<typeof vi.fn>;
+
+beforeEach(async () => {
+  routeEvent = vi.fn();
+  server = createHttpServer(null, routeEvent);
+  port = await startServer(server);
+});
+
+afterEach(async () => {
+  await stopServer(server);
+});
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("POST /webhook", () => {
+  it("returns 400 when x-github-event header is missing", async () => {
+    const res = await request(port, "POST", "/webhook", {
+      body: JSON.stringify({ action: "labeled" }),
+      headers: { "content-type": "application/json" },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 and calls routeEvent when x-github-event is present (no webhooks secret)", async () => {
+    const payload = { action: "labeled", issue: { number: 1 } };
+    const res = await request(port, "POST", "/webhook", {
+      body: JSON.stringify(payload),
+      headers: {
+        "content-type": "application/json",
+        "x-github-event": "issues",
+        "x-github-delivery": "abc123",
+      },
+    });
+    expect(res.status).toBe(200);
+    expect(routeEvent).toHaveBeenCalledOnce();
+    expect(routeEvent).toHaveBeenCalledWith("abc123", "issues", payload);
+  });
+
+  it("uses 'unknown' as delivery id when header is absent", async () => {
+    const payload = { action: "opened" };
+    await request(port, "POST", "/webhook", {
+      body: JSON.stringify(payload),
+      headers: { "x-github-event": "issues" },
+    });
+    expect(routeEvent).toHaveBeenCalledWith("unknown", "issues", payload);
+  });
+});
+
+describe("GET /", () => {
+  it("returns 200 with a text/plain response", async () => {
+    const res = await request(port, "GET", "/");
+    expect(res.status).toBe(200);
+    expect(res.contentType).toMatch(/text\/plain/);
+  });
+});
+
+describe("GET /api/log", () => {
+  it("returns 200 with an empty JSON array when no dbLogger is provided", async () => {
+    const res = await request(port, "GET", "/api/log");
+    expect(res.status).toBe(200);
+    expect(JSON.parse(res.body)).toEqual([]);
+  });
+
+  it("returns log entries from dbLogger", async () => {
+    const entries = [{ id: 1, summary: "test" }];
+    const dbLogger = { queryLog: vi.fn().mockResolvedValue(entries) } as never;
+    const s = createHttpServer(null, vi.fn(), dbLogger);
+    const p = await startServer(s);
+    try {
+      const res = await request(p, "GET", "/api/log");
+      expect(res.status).toBe(200);
+      expect(JSON.parse(res.body)).toEqual(entries);
+    } finally {
+      await stopServer(s);
+    }
+  });
+});
+
+describe("GET /api/tasks/:id/events", () => {
+  it("returns 200 with an empty JSON array when no dbLogger is provided", async () => {
+    const res = await request(port, "GET", "/api/tasks/42/events");
+    expect(res.status).toBe(200);
+    expect(JSON.parse(res.body)).toEqual([]);
+  });
+
+  it("returns task events from dbLogger", async () => {
+    const entries = [{ id: 1, taskId: "42" }];
+    const dbLogger = { queryTaskEvents: vi.fn().mockResolvedValue(entries) } as never;
+    const s = createHttpServer(null, vi.fn(), dbLogger);
+    const p = await startServer(s);
+    try {
+      const res = await request(p, "GET", "/api/tasks/42/events");
+      expect(res.status).toBe(200);
+      expect(JSON.parse(res.body)).toEqual(entries);
+      expect(dbLogger.queryTaskEvents).toHaveBeenCalledWith("42");
+    } finally {
+      await stopServer(s);
+    }
+  });
+});
+
+describe("GET /api/workers/:id/messages", () => {
+  it("returns 200 with an empty JSON array when no dbLogger is provided", async () => {
+    const res = await request(port, "GET", "/api/workers/w1/messages");
+    expect(res.status).toBe(200);
+    expect(JSON.parse(res.body)).toEqual([]);
+  });
+
+  it("returns worker messages from dbLogger", async () => {
+    const entries = [{ id: 1, workerId: "w1" }];
+    const dbLogger = { queryWorkerMessages: vi.fn().mockResolvedValue(entries) } as never;
+    const s = createHttpServer(null, vi.fn(), dbLogger);
+    const p = await startServer(s);
+    try {
+      const res = await request(p, "GET", "/api/workers/w1/messages");
+      expect(res.status).toBe(200);
+      expect(JSON.parse(res.body)).toEqual(entries);
+      expect(dbLogger.queryWorkerMessages).toHaveBeenCalledWith("w1");
+    } finally {
+      await stopServer(s);
+    }
+  });
+});
+
+describe("404 fallback", () => {
+  it("returns 404 for unknown routes when no static dist/ exists", async () => {
+    const res = await request(port, "GET", "/nonexistent-route");
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces the manual if-cascade in `createHttpServer` with [Hono](https://hono.dev/) routes using `@hono/node-server`
- Clean route definitions for `POST /webhook`, `GET /`, `GET /api/log`, `GET /api/tasks/:id/events`, `GET /api/workers/:id/messages`, and SPA static file fallback
- Proper path param extraction via `:id` — no more manual regex matching
- WebSocket upgrade handler is untouched (remains separate from HTTP routing)
- Exports `createHttpServer` and adds `tests/foreman.http.test.ts` covering all HTTP routes (11 new tests)

## Test plan

- [ ] All 792 existing tests pass (`npm test`)
- [ ] New HTTP route tests pass (`npx vitest run tests/foreman.http.test.ts`)
- [ ] Lint clean (`npm run lint`)
- [ ] Type check clean (`npx tsc --noEmit`)
- [ ] Smoke test passes (`npm run smoke`)

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)