### PR TITLE
Exclude worktree dirs from vitest

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
-    exclude: ["node_modules", "frontend/**"],
+    exclude: ["node_modules", "frontend/**", ".worktrees/**", ".claude/**"],
     coverage: {
       provider: "v8",
       reporter: ["text", "html"],


### PR DESCRIPTION
Adds `.worktrees/**` and `.claude/**` to the vitest exclude list so test runs don't pick up any test files that end up in git worktree directories.

This change has come up repeatedly and kept getting stashed/lost — committing it properly so it sticks.