### PR TITLE
Add thinkOutLoud config, fix truncation of errors and bash commands

### DIFF
--- a/brunel.config.ts
+++ b/brunel.config.ts
@@ -1,0 +1,3 @@
+export default {
+  thinkOutLoud: true,
+};

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,6 +35,8 @@ const BrunelConfigSchema = z.object({
   doneLabel:      z.string().default(DEFAULT_DONE_LABEL),
   /** Enable verbose output (shows full Claude message stream). */
   verbose:        z.preprocess(boolPreprocess, z.boolean()).default(false),
+  /** Show full agent thinking text. Defaults to the value of verbose. */
+  thinkOutLoud:   z.preprocess(boolPreprocess, z.boolean()).optional(),
 
   // ── Foreman-only ───────────────────────────────────────────────────────────
 
@@ -60,7 +62,8 @@ const BrunelConfigSchema = z.object({
   workerSecret:           z.string().optional(),
 });
 
-export type BrunelConfig = z.infer<typeof BrunelConfigSchema> & {
+export type BrunelConfig = Omit<z.infer<typeof BrunelConfigSchema>, "thinkOutLoud"> & {
+  thinkOutLoud: boolean;
   allowDangerouslySkipPermissions: boolean;
 };
 
@@ -251,6 +254,7 @@ export async function loadConfig(
 
   return {
     ...parsed,
+    thinkOutLoud: parsed.thinkOutLoud ?? parsed.verbose,
     allowDangerouslySkipPermissions: parsed.permissionMode === "bypassPermissions",
   };
 }

--- a/src/display.ts
+++ b/src/display.ts
@@ -10,6 +10,11 @@ export const hr = (ch = "─") => ch.repeat(W);
 export let verbose = false;
 export function setVerbose(v: boolean) { verbose = v; }
 
+// ── Think-out-loud flag ───────────────────────────────────────────────────────
+
+export let thinkOutLoud = false;
+export function setThinkOutLoud(v: boolean) { thinkOutLoud = v; }
+
 // ── Colors ────────────────────────────────────────────────────────────────────
 
 export const c = {
@@ -209,7 +214,7 @@ export function fmtEditResult(b: ToolResultBlock) {
 export function fmtBashOutput(text: string): string {
   const t = text.trim();
   if (!t || t === "(Bash completed with no output)") return "Success";
-  return trunc(t, 100);
+  return verbose ? t : trunc(t, 100);
 }
 
 export function fmtWriteOutput(b: ToolResultBlock & { _input?: Record<string, unknown> }): string {
@@ -360,7 +365,7 @@ export type FmtEntry = Fmt | { quiet?: Fmt; verbose?: Fmt };
 export type FmtTable = Record<string, FmtEntry>;
 
 export const ASSISTANT_BLOCK_FMT: FmtTable = {
-  thinking: (b) => c.gray(`\n${renderMarkdown(b.thinking ?? "")}`),
+  thinking: (b) => thinkOutLoud ? c.gray(`\n${renderMarkdown(b.thinking ?? "")}`) : c.gray("\nThinking..."),
   text:     (b) => c.yellow(`\n${renderMarkdown(b.text ?? "")}`),
   _default: (b) => c.darkGray(`[assistant/${b.type}]`),
 };
@@ -373,7 +378,7 @@ export const USER_BLOCK_FMT: FmtTable = {
 };
 
 export const TOOL_CALL_FMT: FmtTable = {
-  Bash:       (b) => fmtToolCall(b, `$ ${trunc(b.input?.command ?? "", 80)}`),
+  Bash:       (b) => fmtToolCall(b, `$ ${b.input?.command ?? ""}`),
   Read:       (b) => fmtToolCall(b, `• Read(${b.input?.file_path ?? "?"})`),
   Write:      (b) => fmtToolCall(b, `• Write(${b.input?.file_path ?? "?"})`),
   Edit:       (b) => fmtToolCall(b, `• Edit(${b.input?.file_path ?? "?"})`),
@@ -388,7 +393,7 @@ export const TOOL_CALL_FMT: FmtTable = {
 };
 
 export const TOOL_RESULT_FMT: FmtTable = {
-  _default:   (b) => c.darkGray(`→ ${trunc(toolResultText(b), 100)}`),
+  _default:   (b) => c.darkGray(`→ ${verbose ? toolResultText(b) : trunc(toolResultText(b), 100)}`),
   Read:       (b) => c.darkGray(`→ ${fmtCount(toolResultText(b).split("\n").length, "line")}`),
   Edit:       (b) => fmtEditResult(b),
   Skill:      (b) => c.darkGray(`→ Loaded skill`),
@@ -399,8 +404,8 @@ export const TOOL_RESULT_FMT: FmtTable = {
 };
 
 export const TOOL_ERROR_FMT: FmtTable = {
-  AskUserQuestion: (b) => c.darkGray(`→ ${trunc(toolResultText(b), 100)}`),
-  _default:        (b) => c.salmon(`! ${trunc(toolResultText(b), 100)}`),
+  AskUserQuestion: (b) => c.darkGray(`→ ${toolResultText(b)}`),
+  _default:        (b) => c.salmon(`! ${toolResultText(b)}`),
 };
 
 export const SYSTEM_FMT: FmtTable = {

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "url";
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import type { CanUseTool, PermissionMode, PermissionResult } from "@anthropic-ai/claude-agent-sdk";
 import * as display from "./display.js";
-import { setVerbose } from "./display.js";
+import { setVerbose, setThinkOutLoud } from "./display.js";
 import { ask, listCommandNames, dispatchInput, pick, pickMultiple, pickQuestion } from "./input.js";
 import type { PickQuestionResult } from "./input.js";
 import { workerMain } from "./worker.js";
@@ -253,6 +253,7 @@ async function main(
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const config = await loadConfig(process.argv);
   setVerbose(config.verbose);
+  setThinkOutLoud(config.thinkOutLoud);
   const permConfig = {
     permissionMode: config.permissionMode,
     allowDangerouslySkipPermissions: config.allowDangerouslySkipPermissions,

--- a/tests/repl.formats.test.ts
+++ b/tests/repl.formats.test.ts
@@ -3,6 +3,7 @@ import { stripAnsi } from "./helpers.js";
 import {
   resolve,
   setVerbose,
+  setThinkOutLoud,
   ASSISTANT_BLOCK_FMT,
   USER_BLOCK_FMT,
   TOOL_CALL_FMT,
@@ -76,10 +77,18 @@ describe("resolve()", () => {
 });
 
 describe("ASSISTANT_BLOCK_FMT", () => {
-  it("thinking block wraps renderMarkdown in gray", () => {
+  it("thinking block: thinkOutLoud=true shows content wrapped in gray", () => {
+    setThinkOutLoud(true);
     const result = resolve(ASSISTANT_BLOCK_FMT, "thinking", { thinking: "hello" })!;
+    setThinkOutLoud(false);
     expect(stripAnsi(result)).toContain("hello");
     // gray color: \x1b[38;5;246m
+    expect(result).toContain("\x1b[38;5;246m");
+  });
+
+  it("thinking block: thinkOutLoud=false shows 'Thinking...' placeholder in gray", () => {
+    const result = resolve(ASSISTANT_BLOCK_FMT, "thinking", { thinking: "hello" })!;
+    expect(stripAnsi(result)).toBe("\nThinking...");
     expect(result).toContain("\x1b[38;5;246m");
   });
 

--- a/tests/repl.printing.test.ts
+++ b/tests/repl.printing.test.ts
@@ -8,6 +8,7 @@ import {
   print,
   toolUseNames,
   setVerbose,
+  setThinkOutLoud,
   _statusActive,
   setInputPrintCallback,
 } from "../src/display.js";
@@ -142,11 +143,21 @@ describe("printBlock - tool_result blocks", () => {
 });
 
 describe("printBlock - assistant blocks (non-tool)", () => {
-  it("thinking type → ASSISTANT_BLOCK_FMT", () => {
+  it("thinking type → ASSISTANT_BLOCK_FMT: thinkOutLoud=true shows content", () => {
+    setThinkOutLoud(true);
     const output = captureOutput(() => {
       printBlock({ type: "thinking", thinking: "my thoughts" }, "assistant");
     });
+    setThinkOutLoud(false);
     expect(stripAnsi(output)).toContain("my thoughts");
+  });
+
+  it("thinking type → ASSISTANT_BLOCK_FMT: thinkOutLoud=false shows placeholder", () => {
+    const output = captureOutput(() => {
+      printBlock({ type: "thinking", thinking: "my thoughts" }, "assistant");
+    });
+    expect(stripAnsi(output)).toContain("Thinking...");
+    expect(stripAnsi(output)).not.toContain("my thoughts");
   });
 
   it("text type → ASSISTANT_BLOCK_FMT", () => {
@@ -272,16 +283,16 @@ describe("printMessage", () => {
         type: "assistant",
         message: {
           content: [
-            { type: "thinking", thinking: "thinking..." },
+            { type: "thinking", thinking: "my thoughts" },
             { type: "text", text: "response" },
           ],
         },
       });
     });
     const plain = stripAnsi(output);
-    expect(plain).toContain("thinking...");
+    expect(plain).toContain("Thinking...");
     expect(plain).toContain("response");
-    expect(plain.indexOf("thinking...")).toBeLessThan(plain.indexOf("response"));
+    expect(plain.indexOf("Thinking...")).toBeLessThan(plain.indexOf("response"));
   });
 
   it("result message → fmtStats output", () => {


### PR DESCRIPTION
## Summary

- **Never truncate tool error text** — full errors always shown
- **Don't truncate bash command input** — full command always shown  
- **Verbose mode: no truncation on successful tool results** — `fmtBashOutput` and `TOOL_RESULT_FMT._default` skip `trunc()` when verbose
- **New `thinkOutLoud` config option** — when `false` (default), agent thinking blocks show `"Thinking..."` placeholder; when `true`, full content is shown. Defaults to the `verbose` value. Local `brunel.config.ts` sets it to `true`.

## Test plan

- [ ] Existing thinking-block tests updated to cover both `thinkOutLoud=true` (full content) and `thinkOutLoud=false` (placeholder)
- [ ] All 663 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)