### PR TITLE
feat: Railway deployment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,22 +1,52 @@
-# Optional: webhook secret configured in GitHub repo settings
-# If omitted, signature verification is skipped (fine for local dev)
-WEBHOOK_SECRET=
+# ── Required ──────────────────────────────────────────────────────────────────
 
-PORT=3000
+# GitHub repo in "owner/repo" format
+BRUNEL_GITHUB_REPO=owner/repo
+
+# GitHub personal access token with `repo` scope
+# (GH_TOKEN is forwarded automatically inside Claude Code devcontainer)
+BRUNEL_GITHUB_TOKEN=your_token_here
+
+# ── Optional ──────────────────────────────────────────────────────────────────
+
+# Port the foreman listens on (Railway sets PORT automatically; default: 3000)
+# BRUNEL_PORT=3000
+
+# Issue label that triggers work (default: brunel:ready)
+# BRUNEL_TASK_LABEL=brunel:ready
+
+# Issue label applied on completion (default: brunel:done)
+# BRUNEL_DONE_LABEL=brunel:done
+
+# GitHub webhook secret (set in GitHub repo settings; skip for local dev)
+# BRUNEL_WEBHOOK_SECRET=
+
+# WebSocket URL workers connect to (default: ws://localhost:3000)
+# For cloud: wss://<railway-url>
+# BRUNEL_FOREMAN_URL=ws://localhost:3000
+
+# Claude permission mode: default | acceptEdits | bypassPermissions | plan | dontAsk
+# BRUNEL_PERMISSION_MODE=default
+
+# Enable verbose Claude output (default: false)
+# BRUNEL_VERBOSE=false
+
+# Show full agent thinking text (defaults to BRUNEL_VERBOSE)
+# BRUNEL_THINK_OUT_LOUD=false
+
+# ── Cloud deployment (Railway + Supabase) ──────────────────────────────────────
+
+# Supabase project URL (required for cloud deployment)
+# BRUNEL_SUPABASE_URL=https://<project-ref>.supabase.co
+
+# Supabase service role key — treat as secret, never commit
+# BRUNEL_SUPABASE_SERVICE_ROLE_KEY=
+
+# Shared secret to authenticate workers with the foreman — treat as secret
+# BRUNEL_WORKER_SECRET=
+
+# ── Local dev helpers ─────────────────────────────────────────────────────────
 
 # To proxy GitHub webhooks to localhost, run in a separate terminal:
 #   npx smee-client --url https://smee.io/YOUR_CHANNEL --target http://localhost:3000/webhook
-
-# Foreman
-GITHUB_REPO=owner/repo
-GITHUB_TOKEN=your_token_here
-TASK_LABEL=brunel:ready
-DONE_LABEL=brunel:done
-
-# Worker
-FOREMAN_URL=ws://localhost:3000
-
-# Supabase (optional — logging disabled if absent)
-# For local dev: run `supabase start` and copy values from its output
-# BRUNEL_SUPABASE_URL=http://localhost:54321
-# BRUNEL_SUPABASE_SERVICE_ROLE_KEY=<service_role key from supabase start>
+# SMEE_URL=https://smee.io/YOUR_CHANNEL

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "NIXPACKS",
+    "buildCommand": "npm install && npm run build"
+  },
+  "deploy": {
+    "startCommand": "npm start",
+    "healthcheckPath": "/",
+    "healthcheckTimeout": 300,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}


### PR DESCRIPTION
## Summary

- Add `railway.json` with NIXPACKS builder, `npm install && npm run build` build command, `npm start` start command, healthcheck on `/`, and ON_FAILURE restart policy
- Update `.env.example` to use `BRUNEL_*` prefixed env vars throughout, and document all config options including cloud deployment vars (`BRUNEL_SUPABASE_URL`, `BRUNEL_SUPABASE_SERVICE_ROLE_KEY`, `BRUNEL_WORKER_SECRET`)
- Verified existing `package.json` `build` and `start` scripts are already correct for Railway (no changes needed)
- `npm run smoke` passes: foreman and worker connect successfully

## Notes

- Railway automatically sets `PORT`, which the foreman picks up via the legacy `PORT` env var fallback in `config.ts`
- The healthcheck path `/` returns a 200 text response ("GitHub webhook listener running...")
- After merge, manual deployment steps remain (create Railway project, set env vars, create Supabase project, update webhook URL) — see issue #190 for the checklist

Closes #190