### PR TITLE
feat: add supabase config.toml for CLI migrations

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,21 @@
+project_id = "brunel"
+
+[api]
+enabled = true
+port = 54321
+schemas = ["public"]
+extra_search_path = ["public", "extensions"]
+max_rows = 1000
+
+[db]
+port = 54322
+shadow_port = 54320
+major_version = 15
+
+[auth]
+enabled = true
+site_url = "http://127.0.0.1:3000"
+
+[studio]
+enabled = true
+port = 54323


### PR DESCRIPTION
## Summary
- Adds `supabase/config.toml` so the Supabase CLI can be used to manage migrations
- `supabase/migrations/` already exists with the initial schema; this makes it usable end-to-end

## Deployment flow (after merge)
```bash
supabase login
supabase projects create brunel --org-id <org-id> --db-password <password> --region us-east-1
supabase link --project-ref <ref>
supabase db push
```

## Test plan
- [ ] `supabase link` and `supabase db push` succeed against a real Supabase project