### PR TITLE
feat: auto-deploy Supabase migrations on push to main

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -18,6 +18,6 @@ jobs:
         with:
           version: latest
 
-      - run: supabase db push --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
+      - run: supabase db push --project-ref ${{ vars.SUPABASE_PROJECT_REF }}
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/migrate.yml` — runs `supabase db push` whenever migration files change on `main`
- Only triggers on `supabase/migrations/**` changes to avoid unnecessary runs

## Setup required
Two secrets must be added to GitHub repo settings before this workflow will work:
- `SUPABASE_ACCESS_TOKEN` — Supabase personal access token (from supabase.com/dashboard/account/tokens)
- `SUPABASE_PROJECT_REF` — project ref from the Supabase dashboard URL

## Test plan
- [ ] Add the two secrets to GitHub repo settings
- [ ] Merge a new migration file and confirm the workflow runs and applies it