### PR TITLE
refactor: rename BRUNEL_SUPABASE_SERVICE_ROLE_KEY to BRUNEL_SUPABASE_SECRET_KEY

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Optional (all have defaults):
 - `BRUNEL_THINK_OUT_LOUD` — show full agent thinking text; defaults to `BRUNEL_VERBOSE`; also settable in `brunel.config.ts` as `thinkOutLoud`
 - `BRUNEL_PERMISSION_MODE` — Claude permission mode: `default`, `acceptEdits`, `bypassPermissions`, `plan`, `dontAsk` (default: `default`)
 - `BRUNEL_SUPABASE_URL` — Supabase project URL (for cloud deployment)
-- `BRUNEL_SUPABASE_SERVICE_ROLE_KEY` — Supabase service role key (for cloud deployment; treat as secret)
+- `BRUNEL_SUPABASE_SECRET_KEY` — Supabase secret key (for cloud deployment; treat as secret)
 - `BRUNEL_WORKER_SECRET` — shared secret to authenticate workers with the foreman (treat as secret)
 
 ## Useful scripts

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,8 +56,8 @@ const BrunelConfigSchema = z.object({
 
   /** Supabase project URL. Optional; required for cloud deployment. */
   supabaseUrl:            z.string().optional(),
-  /** Supabase service role key. Optional; required for cloud deployment. Prefer env var over config file. */
-  supabaseServiceRoleKey: z.string().optional(),
+  /** Supabase secret key. Optional; required for cloud deployment. Prefer env var over config file. */
+  supabaseSecretKey: z.string().optional(),
   /** Shared secret used to authenticate workers connecting to the foreman. Optional. Prefer env var over config file. */
   workerSecret:           z.string().optional(),
 });
@@ -82,7 +82,7 @@ const explorer = cosmiconfig("brunel", {
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 /** Config keys whose values should never be committed to source control. */
-const SECRET_KEYS = ["githubToken", "webhookSecret", "supabaseServiceRoleKey", "workerSecret"] as const;
+const SECRET_KEYS = ["githubToken", "webhookSecret", "supabaseSecretKey", "workerSecret"] as const;
 
 function warnIfSecretsInFile(
   config: Record<string, unknown>,

--- a/src/foreman.ts
+++ b/src/foreman.ts
@@ -838,10 +838,10 @@ if (isMain) {
 
   // DB logger
   let dbLogger: DbLogger;
-  if (config.supabaseUrl && config.supabaseServiceRoleKey) {
+  if (config.supabaseUrl && config.supabaseSecretKey) {
     const { createClient } = await import("@supabase/supabase-js");
     const { createDbLogger } = await import("./db.js");
-    dbLogger = createDbLogger(createClient(config.supabaseUrl, config.supabaseServiceRoleKey));
+    dbLogger = createDbLogger(createClient(config.supabaseUrl, config.supabaseSecretKey));
     flog("Supabase logging enabled");
   } else {
     const { createNullDbLogger } = await import("./db.js");

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -18,7 +18,7 @@ const ENV_KEYS = [
   "BRUNEL_TASK_LABEL", "BRUNEL_DONE_LABEL",
   "BRUNEL_VERBOSE", "BRUNEL_PORT", "BRUNEL_WEBHOOK_SECRET",
   "BRUNEL_FOREMAN_URL", "BRUNEL_PERMISSION_MODE",
-  "BRUNEL_SUPABASE_URL", "BRUNEL_SUPABASE_SERVICE_ROLE_KEY", "BRUNEL_WORKER_SECRET",
+  "BRUNEL_SUPABASE_URL", "BRUNEL_SUPABASE_SECRET_KEY", "BRUNEL_WORKER_SECRET",
 ];
 
 beforeEach(() => {
@@ -350,7 +350,7 @@ describe("permission mode", () => {
   });
 });
 
-// ── New optional fields: supabaseUrl, supabaseServiceRoleKey, workerSecret ────
+// ── New optional fields: supabaseUrl, supabaseSecretKey, workerSecret ────
 
 describe("supabaseUrl", () => {
   it("is undefined by default", async () => {
@@ -387,35 +387,35 @@ describe("supabaseUrl", () => {
   });
 });
 
-describe("supabaseServiceRoleKey", () => {
+describe("supabaseSecretKey", () => {
   it("is undefined by default", async () => {
     baseEnv();
     const cfg = await loadConfig(["node", "repl.js"]);
-    expect(cfg.supabaseServiceRoleKey).toBeUndefined();
+    expect(cfg.supabaseSecretKey).toBeUndefined();
   });
 
-  it("BRUNEL_SUPABASE_SERVICE_ROLE_KEY sets supabaseServiceRoleKey", async () => {
+  it("BRUNEL_SUPABASE_SECRET_KEY sets supabaseSecretKey", async () => {
     baseEnv();
-    process.env.BRUNEL_SUPABASE_SERVICE_ROLE_KEY = "service-role-key";
+    process.env.BRUNEL_SUPABASE_SECRET_KEY = "service-role-key";
     const cfg = await loadConfig(["node", "repl.js"]);
-    expect(cfg.supabaseServiceRoleKey).toBe("service-role-key");
+    expect(cfg.supabaseSecretKey).toBe("service-role-key");
   });
 
-  it("--supabase-service-role-key CLI flag sets supabaseServiceRoleKey", async () => {
+  it("--supabase-secret-key CLI flag sets supabaseSecretKey", async () => {
     baseEnv();
-    const cfg = await loadConfig(["node", "repl.js", "--supabase-service-role-key", "cli-key"]);
-    expect(cfg.supabaseServiceRoleKey).toBe("cli-key");
+    const cfg = await loadConfig(["node", "repl.js", "--supabase-secret-key", "cli-key"]);
+    expect(cfg.supabaseSecretKey).toBe("cli-key");
   });
 
-  it("warns when supabaseServiceRoleKey in file config", async () => {
+  it("warns when supabaseSecretKey in file config", async () => {
     baseEnv();
-    await loadConfig(["node", "repl.js"], { supabaseServiceRoleKey: "file-key" });
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("supabaseServiceRoleKey"));
+    await loadConfig(["node", "repl.js"], { supabaseSecretKey: "file-key" });
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("supabaseSecretKey"));
   });
 
-  it("does NOT warn when supabaseServiceRoleKey from env var", async () => {
+  it("does NOT warn when supabaseSecretKey from env var", async () => {
     baseEnv();
-    process.env.BRUNEL_SUPABASE_SERVICE_ROLE_KEY = "env-key";
+    process.env.BRUNEL_SUPABASE_SECRET_KEY = "env-key";
     await loadConfig(["node", "repl.js"]);
     expect(warnSpy).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- Renames `supabaseServiceRoleKey` → `supabaseSecretKey` throughout
- Env var: `BRUNEL_SUPABASE_SERVICE_ROLE_KEY` → `BRUNEL_SUPABASE_SECRET_KEY`
- CLI flag: `--supabase-service-role-key` → `--supabase-secret-key`

Reflects Supabase's updated naming convention (publishable vs. secret keys, with service role key now called "secret key").

## Test plan
- [ ] Update `BRUNEL_SUPABASE_SECRET_KEY` in Railway env vars (remove old `BRUNEL_SUPABASE_SERVICE_ROLE_KEY`)