### PR TITLE
fix: move health check from / to /health so SPA is served at root

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -6,7 +6,7 @@
   },
   "deploy": {
     "startCommand": "npm start",
-    "healthcheckPath": "/",
+    "healthcheckPath": "/health",
     "healthcheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10

--- a/src/foreman.ts
+++ b/src/foreman.ts
@@ -313,7 +313,7 @@ export function createHttpServer(
   });
 
   // ── Health check ───────────────────────────────────────────────────────────
-  app.get("/", (c) =>
+  app.get("/health", (c) =>
     c.text("GitHub webhook listener running. POST events to /webhook"),
   );
 

--- a/tests/foreman.http.test.ts
+++ b/tests/foreman.http.test.ts
@@ -109,9 +109,9 @@ describe("POST /webhook", () => {
   });
 });
 
-describe("GET /", () => {
+describe("GET /health", () => {
   it("returns 200 with a text/plain response", async () => {
-    const res = await request(port, "GET", "/");
+    const res = await request(port, "GET", "/health");
     expect(res.status).toBe(200);
     expect(res.contentType).toMatch(/text\/plain/);
   });


### PR DESCRIPTION
## Summary
- Moves `GET /` health check route to `GET /health`
- Updates `railway.json` healthcheckPath from `/` to `/health`
- The old `/` route was intercepting requests before the static file handler could serve the React admin GUI

## Test plan
- [ ] Merge and verify Railway deploys successfully (healthcheck hits `/health`)
- [ ] Visiting the Railway URL shows the admin dashboard, not the plain text health message