### PR TITLE
feat: set foremanUrl in brunel.config.ts to Railway deployment

### DIFF
--- a/brunel.config.ts
+++ b/brunel.config.ts
@@ -1,3 +1,4 @@
 export default {
   thinkOutLoud: true,
+  foremanUrl: "wss://brunel-production.up.railway.app",
 };

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -61,7 +61,7 @@ describe("VALID_PERMISSION_MODES", () => {
 describe("defaults", () => {
   it("returns correct defaults for all optional fields", async () => {
     baseEnv();
-    const cfg = await loadConfig(["node", "repl.js"]);
+    const cfg = await loadConfig(["node", "repl.js"], {});
     expect(cfg.taskLabel).toBe("brunel:ready");
     expect(cfg.doneLabel).toBe("brunel:done");
     expect(cfg.verbose).toBe(false);


### PR DESCRIPTION
## Summary
- Sets `foremanUrl: "wss://brunel-production.up.railway.app"` in `brunel.config.ts`
- Workers no longer need `BRUNEL_FOREMAN_URL` in their local `.env`
- Fixes the defaults test to use an empty config override so it tests true system defaults rather than picking up the project config file

## Test plan
- [ ] Run `npm run worker` locally without `BRUNEL_FOREMAN_URL` set and confirm it connects to the Railway foreman