### PR TITLE
feat: allow Railway deployment domain in devcontainer firewall

### DIFF
--- a/.devcontainer/firewall-extras.txt
+++ b/.devcontainer/firewall-extras.txt
@@ -1,1 +1,2 @@
 smee.io
+brunel-production.up.railway.app


### PR DESCRIPTION
## Summary

- Adds `brunel-production.up.railway.app` to `.devcontainer/firewall-extras.txt` so workers inside the devcontainer can connect to the cloud foreman

## Why

The devcontainer firewall allowlists specific domains at startup via `init-firewall.sh`. Railway's IP (`66.33.22.204`) was not in the list, causing `No route to host` when `npm run worker` tried to connect to `wss://brunel-production.up.railway.app`.

## Test plan

- [ ] Rebuild the devcontainer ("Dev Containers: Rebuild Container")
- [ ] Run `npm run worker` — it should connect to the cloud foreman at `wss://brunel-production.up.railway.app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)