### PR TITLE
feat: wrap long text in markdown table cells to fit terminal width

### DIFF
--- a/src/display.ts
+++ b/src/display.ts
@@ -286,18 +286,87 @@ export function mdInline(text: string): string {
   return text;
 }
 
-export function renderTable(tableLines: string[]): string {
+function wrapText(text: string, width: number): string[] {
+  if (width <= 0 || text.length <= width) return [text];
+  const words = text.split(" ");
+  const lines: string[] = [];
+  let current = "";
+  for (const word of words) {
+    if (current === "") {
+      if (word.length > width) {
+        let rest = word;
+        while (rest.length > width) { lines.push(rest.slice(0, width)); rest = rest.slice(width); }
+        current = rest;
+      } else {
+        current = word;
+      }
+    } else if (current.length + 1 + word.length <= width) {
+      current += " " + word;
+    } else {
+      lines.push(current);
+      if (word.length > width) {
+        let rest = word;
+        while (rest.length > width) { lines.push(rest.slice(0, width)); rest = rest.slice(width); }
+        current = rest;
+      } else {
+        current = word;
+      }
+    }
+  }
+  if (current) lines.push(current);
+  return lines.length > 0 ? lines : [""];
+}
+
+function distributeWidths(naturalWidths: number[], available: number): number[] {
+  const N = naturalWidths.length;
+  if (N === 0) return [];
+  const total = naturalWidths.reduce((a, b) => a + b, 0);
+  if (total <= available) return [...naturalWidths];
+  const allocated = new Array<number>(N).fill(0);
+  const order = [...naturalWidths.keys()].sort((a, b) => naturalWidths[a] - naturalWidths[b]);
+  let remaining = available;
+  for (let k = 0; k < N; k++) {
+    const i = order[k];
+    const fairShare = Math.floor(remaining / (N - k));
+    if (naturalWidths[i] <= fairShare) {
+      allocated[i] = naturalWidths[i];
+      remaining -= naturalWidths[i];
+    } else {
+      for (let j = k; j < N; j++) {
+        allocated[order[j]] = Math.floor(remaining / (N - k));
+      }
+      break;
+    }
+  }
+  return allocated;
+}
+
+export function renderTable(tableLines: string[], maxWidth?: number): string {
+  const termWidth = maxWidth ?? (process.stdout.columns || W);
   const rows = tableLines.map(line =>
     line.split("|").slice(1, -1).map(cell => cell.trim())
   );
   const isSep = (row: string[]) => row.every(cell => /^[-: ]+$/.test(cell));
   const dataRows = rows.filter(r => !isSep(r));
   const colCount = Math.max(...dataRows.map(r => r.length));
-  const widths = Array.from({ length: colCount }, (_, i) =>
+  const naturalWidths = Array.from({ length: colCount }, (_, i) =>
     Math.max(...dataRows.map(r => (r[i] ?? "").length))
   );
-  const renderRow = (row: string[]) =>
-    "│ " + widths.map((w, i) => mdInline((row[i] ?? "").padEnd(w))).join(" │ ") + " │";
+  // overhead: "│ " (2) + " │ " * (N-1) (3*(N-1)) + " │" (2) = 1 + 3*N
+  const overhead = 1 + 3 * colCount;
+  const available = Math.max(termWidth - overhead, colCount);
+  const widths = distributeWidths(naturalWidths, available);
+  const renderRow = (row: string[]): string => {
+    const wrapped = widths.map((w, i) => wrapText(row[i] ?? "", w));
+    const numLines = Math.max(...wrapped.map(ls => ls.length));
+    const termRows: string[] = [];
+    for (let ln = 0; ln < numLines; ln++) {
+      termRows.push(
+        "│ " + widths.map((w, i) => mdInline((wrapped[i][ln] ?? "").padEnd(w))).join(" │ ") + " │"
+      );
+    }
+    return termRows.join("\n");
+  };
   const divider = "├─" + widths.map(w => "─".repeat(w)).join("─┼─") + "─┤";
   const out: string[] = [];
   for (const row of rows) {

--- a/tests/repl.markdown.test.ts
+++ b/tests/repl.markdown.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { stripAnsi } from "./helpers.js";
-import { mdInline, renderMarkdown, s } from "../src/display.js";
+import { mdInline, renderMarkdown, renderTable, s } from "../src/display.js";
 
 describe("mdInline", () => {
   it("bold with **", () => {
@@ -215,6 +215,82 @@ describe("renderMarkdown - tables", () => {
     const result = stripAnsi(renderMarkdown("| Col |\n| --- |\n| val |"));
     expect(result).toContain("│");
     expect(result).toContain("val");
+  });
+});
+
+describe("renderTable - text wrapping", () => {
+  it("table that fits within maxWidth is not wrapped", () => {
+    const lines = [
+      "| A | B |",
+      "| --- | --- |",
+      "| short | text |",
+    ];
+    const result = stripAnsi(renderTable(lines, 80));
+    const outputLines = result.split("\n");
+    expect(outputLines).toHaveLength(3); // header, divider, data row
+  });
+
+  it("each output line fits within maxWidth when wrapping needed", () => {
+    const lines = [
+      "| Bug | Root cause | Fix |",
+      "| --- | --- | --- |",
+      "| Short | A very long root cause explanation that exceeds the column width significantly | Short fix |",
+    ];
+    const result = stripAnsi(renderTable(lines, 60));
+    for (const line of result.split("\n")) {
+      expect(line.length).toBeLessThanOrEqual(60);
+    }
+  });
+
+  it("all cell content is preserved after wrapping", () => {
+    const lines = [
+      "| Col A | Col B |",
+      "| --- | --- |",
+      "| short | this is a very long text that will need to be wrapped across multiple lines in the output |",
+    ];
+    const result = stripAnsi(renderTable(lines, 40));
+    // All words from the long cell should appear somewhere in the output
+    expect(result).toContain("short");
+    expect(result).toContain("this is a very long text");
+    expect(result).toContain("multiple lines");
+  });
+
+  it("divider line fits within maxWidth", () => {
+    const lines = [
+      "| Bug | Root cause | Fix |",
+      "| --- | --- | --- |",
+      "| Short | Very long root cause text that needs wrapping here | Short |",
+    ];
+    const result = stripAnsi(renderTable(lines, 50));
+    const dividerLine = result.split("\n").find(l => l.startsWith("├"));
+    expect(dividerLine).toBeDefined();
+    expect(dividerLine!.length).toBeLessThanOrEqual(50);
+  });
+
+  it("short columns keep natural width when only wide column wraps", () => {
+    const lines = [
+      "| Name | Description |",
+      "| ---- | ----------- |",
+      "| Alice | A very long description that should wrap to multiple lines in the output |",
+    ];
+    const result = stripAnsi(renderTable(lines, 40));
+    expect(result).toContain("Alice");
+    expect(result).toContain("A very long");
+  });
+
+  it("wrapped row has │ borders on every output line", () => {
+    const lines = [
+      "| A | B |",
+      "| - | - |",
+      "| x | this is a long cell that wraps |",
+    ];
+    const result = stripAnsi(renderTable(lines, 25));
+    const dataLines = result.split("\n").filter(l => l.startsWith("│"));
+    // There should be more than one data line because of wrapping
+    expect(dataLines.length).toBeGreaterThan(1);
+    for (const line of dataLines) {
+      expect(line).toMatch(/^│.*│$/);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- `renderTable` now accepts an optional `maxWidth` parameter (defaults to `process.stdout.columns`)
- Distributes available width across columns: short columns keep their natural width; wider columns share the remainder proportionally
- Wraps cell text across multiple output lines when needed, with proper `│` borders on every line
- Adds 6 new tests covering the wrapping behavior

## Before / After

Before: a 3-column bug-summary table would print lines 200+ chars wide.

After: all output lines stay within the terminal width, with long cells wrapped across multiple rows.

## Test plan

- [ ] Run `npm test` — all tests pass
- [ ] Visually verify a wide 3-column table wraps cleanly in a real terminal session

Closes #93