### PR TITLE
feat: add ^S stash command

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -1,6 +1,14 @@
 import fs from "fs";
 import * as display from "./display.js";
 
+// ── Stash ─────────────────────────────────────────────────────────────────────
+
+/** Buffer stashed by ^S, restored as the initial value of the next ask() call. */
+let stash: string | null = null;
+
+/** Reset the stash (exposed for testing). */
+export function _resetStash(): void { stash = null; }
+
 // ── Frontmatter parsing ────────────────────────────────────────────────────────
 
 /**
@@ -366,7 +374,7 @@ export function ask(
   abort?: Promise<string>,
 ): Promise<string> {
   return new Promise((resolve) => {
-    let buffer = "";
+    let buffer = stash ?? "";
     let pasteBuffer = "";
     let inPaste = false;
     let done = false;
@@ -377,11 +385,14 @@ export function ask(
     let commands: CommandSuggestion[] = [];
     try { commands = getCommands(); } catch { /* graceful: use empty */ }
 
-    let cursor = 0; // current cursor position within buffer
+    let cursor = buffer.length; // start cursor at end of any pre-populated stash
     // Number of rows used by the last full redraw (suggestion row is always included)
     let totalDrawnRows = 0;
+    stash = null; // consume the stash
 
     process.stdout.write(promptStr);
+    // If buffer was pre-populated from stash, render it immediately.
+    if (buffer) fullRedraw(0, computeMatches());
 
     // ── Multiline-aware screen position ──────────────────────────────────────
     //
@@ -670,6 +681,26 @@ export function ask(
       // if row+1 doesn't exist, no-op
     }
 
+    function stashBuffer() {
+      if (!buffer) return;
+      stash = buffer;
+      // Navigate from current cursor row to the top of the prompt area (row 0),
+      // then erase to end of screen, print the stash notification, and redraw
+      // an empty prompt so the user can type their next input.
+      const { row: curRow } = screenPosOf(cursor);
+      if (curRow > 0) process.stdout.write(`\x1b[${curRow}A`);
+      process.stdout.write("\r\x1b[J");
+      process.stdout.write(display.c.darkGray("✦ Prompt stashed — will be restored on next submit\r\n"));
+      buffer = "";
+      cursor = 0;
+      totalDrawnRows = 0;
+      process.stdout.write(promptLine);
+      process.stdout.write("\x1b[K\r\n\x1b[K");
+      totalDrawnRows = 1;
+      process.stdout.write(`\x1b[1A\r`);
+      if (promptLine.length > 0) process.stdout.write(`\x1b[${promptLine.length}C`);
+    }
+
     function processTyped(data: string) {
       // Substitute known sequences with placeholder chars before stripping
       data = data.replace(/\x1b\[1;3D/g, "\x1c"); // iTerm2 option+left  → 0x1C
@@ -701,6 +732,7 @@ export function ask(
         else if (ch === "\x17")                       { deleteWord(); }          // ^W
         else if (ch === "\x10")                       { moveLineUp(); }          // ↑
         else if (ch === "\x11")                       { moveLineDown(); }        // ↓
+        else if (ch === "\x13")                       { stashBuffer(); }         // ^S
         else if (ch === "\x1c")                       { moveWordLeft(); }        // option+←
         else if (ch === "\x1d")                       { moveWordRight(); }       // option+→
         else if (ch === "\x1e")                       { moveTo(cursor - 1); }    // ←

--- a/tests/repl.input.test.ts
+++ b/tests/repl.input.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { PassThrough } from "stream";
-import { ask, pick, pickMultiple, promptLine, pickQuestion } from "../src/input.js";
+import { ask, pick, pickMultiple, promptLine, pickQuestion, _resetStash } from "../src/input.js";
 import type { PickQuestionResult } from "../src/input.js";
 import * as display from "../src/display.js";
 
@@ -731,6 +731,112 @@ describe("pickMultiple() - multi-selection picker", () => {
       stdin.push("\r");
       const result = await p;
       expect(result).toEqual([0, 1]);
+    });
+  });
+});
+
+describe("ask() - stash (^S)", () => {
+  beforeEach(() => { _resetStash(); });
+  afterEach(() => { _resetStash(); });
+
+  it("^S with non-empty buffer clears buffer so ask resolves to ''", async () => {
+    await withFakeStdin(async (stdin) => {
+      const p = ask("> ", () => []);
+      stdin.push("hello world");
+      stdin.push("\x13"); // ^S — stash
+      stdin.push("\r");   // submit now-empty buffer
+      const result = await p;
+      expect(result).toBe("");
+    });
+  });
+
+  it("next ask() after stash is pre-populated with stashed text", async () => {
+    await withFakeStdin(async (stdin) => {
+      // First ask: stash then submit empty
+      const p1 = ask("> ", () => []);
+      stdin.push("hello world");
+      stdin.push("\x13");
+      stdin.push("\r");
+      await p1;
+
+      // Second ask: pre-populated with stash; Enter immediately resolves to stash
+      const p2 = ask("> ", () => []);
+      stdin.push("\r");
+      const result = await p2;
+      expect(result).toBe("hello world");
+    });
+  });
+
+  it("stash is consumed after one ask() call — third ask starts empty", async () => {
+    await withFakeStdin(async (stdin) => {
+      const p1 = ask("> ", () => []);
+      stdin.push("saved");
+      stdin.push("\x13");
+      stdin.push("\r");
+      await p1;
+
+      const p2 = ask("> ", () => []);
+      stdin.push("\r");
+      const r2 = await p2;
+      expect(r2).toBe("saved");
+
+      const p3 = ask("> ", () => []);
+      stdin.push("\r");
+      const r3 = await p3;
+      expect(r3).toBe(""); // stash was consumed
+    });
+  });
+
+  it("^S with empty buffer is a no-op — nothing stashed", async () => {
+    await withFakeStdin(async (stdin) => {
+      const p1 = ask("> ", () => []);
+      stdin.push("\x13"); // ^S with empty buffer
+      stdin.push("hi");
+      stdin.push("\r");
+      const r1 = await p1;
+      expect(r1).toBe("hi");
+
+      // No stash was set
+      const p2 = ask("> ", () => []);
+      stdin.push("\r");
+      const r2 = await p2;
+      expect(r2).toBe(""); // starts empty
+    });
+  });
+
+  it("^S writes a 'stashed' notification to stdout", async () => {
+    const writes: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((s: any) => {
+      writes.push(String(s));
+      return true;
+    });
+
+    await withFakeStdin(async (stdin) => {
+      const p = ask("> ", () => []);
+      stdin.push("test");
+      stdin.push("\x13");
+      stdin.push("\r");
+      await p;
+    });
+
+    const out = writes.join("");
+    expect(out).toContain("stashed");
+  });
+
+  it("pressing ^S twice: second stash overwrites first", async () => {
+    await withFakeStdin(async (stdin) => {
+      const p1 = ask("> ", () => []);
+      stdin.push("first");
+      stdin.push("\x13"); // stash "first"
+      stdin.push("second");
+      stdin.push("\x13"); // stash "second" (overwrites "first")
+      stdin.push("\r");
+      await p1;
+
+      const p2 = ask("> ", () => []);
+      stdin.push("\r");
+      const r2 = await p2;
+      expect(r2).toBe("second");
     });
   });
 });


### PR DESCRIPTION
## Summary

- Pressing `^S` while typing a prompt saves the current input to an in-memory stash, clears the prompt, and prints a `✦ Prompt stashed — will be restored on next submit` notification
- The next call to `ask()` pre-populates the buffer with the stashed text, so it appears ready for editing as soon as the prompt returns (after Claude finishes responding)
- `^S` on an empty buffer is a no-op
- Pressing `^S` twice overwrites the first stash with the second

## Test plan

- [ ] Type a long prompt and press `^S` — prompt clears and stash message appears
- [ ] Type a short follow-up question and submit — Claude responds
- [ ] Prompt comes back pre-filled with the original long prompt, ready to edit/submit
- [ ] `^S` on empty buffer does nothing
- All 6 new unit tests pass; full suite 801 tests green

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)