### PR TITLE
chore: gitignore build artifacts and temp dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ dist/
 repl.log
 .worker-id
 coverage/
+frontend/tsconfig.tsbuildinfo
+supabase/.temp/

--- a/frontend/tsconfig.tsbuildinfo
+++ b/frontend/tsconfig.tsbuildinfo
@@ -1,1 +1,0 @@
-{"root":["./src/App.tsx","./src/main.tsx","./src/types.ts","./src/pages/Dashboard.tsx","./src/pages/EventLog.tsx","./src/pages/TaskDetail.tsx","./src/pages/WorkerDetail.tsx"],"version":"5.9.3"}


### PR DESCRIPTION
## Summary

- Remove `frontend/tsconfig.tsbuildinfo` from git tracking — it's a TypeScript incremental build artifact that changes on every build and shouldn't be checked in
- Add `frontend/tsconfig.tsbuildinfo` to `.gitignore`
- Add `supabase/.temp/` to `.gitignore`

## Test plan

- [ ] Verify `frontend/tsconfig.tsbuildinfo` no longer shows up as a modified file after building
- [ ] Verify `supabase/.temp/` is ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)