### PR TITLE
fix: parse markdown-formatted dependency references

### DIFF
--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -13,7 +13,9 @@ export type DependencyGraph = Map<number, Set<number>>;
  */
 export function parseBodyBlockers(body: string): number[] {
   // Match a keyword clause followed by one or more comma-separated #N references.
-  const clausePattern = /(?:^|\s)(?:depends\s+on|blocked\s+by)\s+(#\d+(?:\s*,\s*#\d+)*)/gi;
+  // Allow optional markdown formatting (**, :) around the keyword phrase,
+  // e.g. "**Depends on:** #257", "Depends on: #42", or plain "Depends on #N".
+  const clausePattern = /(?:^|\s)\*{0,2}(?:depends\s+on|blocked\s+by)[\s:*]+(#\d+(?:\s*,\s*#\d+)*)/gi;
   const numbers = new Set<number>();
   let m: RegExpExecArray | null;
   while ((m = clausePattern.exec(body)) !== null) {

--- a/tests/dependencies.test.ts
+++ b/tests/dependencies.test.ts
@@ -42,6 +42,18 @@ describe("parseBodyBlockers", () => {
   it("parses mixed single and comma-separated entries across lines", () => {
     expect(parseBodyBlockers("Depends on #1\nBlocked by #2, #3, #4")).toEqual([1, 2, 3, 4]);
   });
+
+  it("parses markdown bold format '**Depends on:** #N'", () => {
+    expect(parseBodyBlockers("**Depends on:** #257")).toEqual([257]);
+  });
+
+  it("parses colon separator 'Depends on: #N'", () => {
+    expect(parseBodyBlockers("Depends on: #42")).toEqual([42]);
+  });
+
+  it("parses '**Blocked by:** #N'", () => {
+    expect(parseBodyBlockers("**Blocked by:** #7")).toEqual([7]);
+  });
 });
 
 describe("setBlockers", () => {


### PR DESCRIPTION
## Summary

- `parseBodyBlockers` required plain whitespace between the keyword phrase (`Depends on`, `Blocked by`) and the issue reference `#N`
- Issue bodies use markdown formatting like `**Depends on:** #257` — the `:**` after "on" broke the match
- The foreman therefore never detected the dependency and assigned blocked issues freely (root cause of #259 being incorrectly assigned before #257 was done)

## Fix

Updated the regex to optionally allow `**` before the keyword and `:*` characters between the keyword and the `#N` reference, matching both:
- `Depends on #N` (plain)
- `Depends on: #N` (colon)
- `**Depends on:** #N` (markdown bold + colon)

## Test plan
- [ ] 3 new unit tests added for the new formats, all passing
- [ ] Full test suite: 820 tests pass
- [ ] `npx tsc --noEmit` clean
- [ ] `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)