### PR TITLE
devcontainer: keep firewall init script running in background

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,5 +14,6 @@
   },
   "forwardPorts": [3000, 5173],
   "postCreateCommand": "npm ci",
+  "postStartCommand": "while true; do sleep 3600; sudo /usr/local/bin/init-firewall.sh; done &",
   "waitFor": "postStartCommand"
 }


### PR DESCRIPTION
Add `postStartCommand` that runs `init-firewall.sh` in a background loop so the firewall is re-initialized periodically after container start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)