### PR TITLE
feat: REPL workspace slash commands and session UUID

### DIFF
--- a/src/repl.ts
+++ b/src/repl.ts
@@ -197,6 +197,86 @@ export async function runQuery(
   return capturedSessionId;
 }
 
+// ── Workspace action handler ──────────────────────────────────────────────────
+
+export type WorkspaceActionType = "create-workspace" | "reset-workspace" | "remove-workspace" | "prune";
+
+export interface WorkspaceActionParams {
+  workspaceCfg: { workspaceDir: string; repoUrl: string } | undefined;
+  workspace: Workspace | undefined;
+  sessionId_: string;
+  originalCwd: string;
+  confirm: (msg: string) => Promise<boolean>;
+  print: (msg: string) => void;
+  chdir: (dir: string) => void;
+}
+
+/**
+ * Handle one workspace slash command in the REPL.
+ * Returns the (possibly updated) workspace reference.
+ * Extracted for testability.
+ */
+export async function handleWorkspaceAction(
+  type: WorkspaceActionType,
+  params: WorkspaceActionParams,
+): Promise<Workspace | undefined> {
+  const { workspaceCfg, workspace, sessionId_, originalCwd, confirm, print, chdir } = params;
+
+  if (type === "create-workspace") {
+    if (!workspaceCfg) {
+      print(display.c.boldRed("Cannot create workspace: no GitHub repo configured."));
+      return workspace;
+    }
+    if (workspace) {
+      print(display.c.amber(`Workspace already exists: ${workspace.dir}`));
+      return workspace;
+    }
+    const ws = await Workspace.create(workspaceCfg.workspaceDir, sessionId_, workspaceCfg.repoUrl);
+    chdir(ws.dir);
+    print(display.c.sageGreen(`Workspace created: ${ws.dir}`));
+    return ws;
+  }
+
+  if (type === "reset-workspace") {
+    if (!workspace) {
+      print(display.c.boldRed("No workspace. Use /create-workspace first."));
+      return workspace;
+    }
+    const ok = await confirmIfUnsafe(workspace, confirm);
+    if (!ok) return workspace;
+    await workspace.reset();
+    print(display.c.sageGreen("Workspace reset to main."));
+    return workspace;
+  }
+
+  if (type === "remove-workspace") {
+    if (!workspace) {
+      print(display.c.boldRed("No workspace in this session."));
+      return workspace;
+    }
+    const ok = await confirmIfUnsafe(workspace, confirm);
+    if (!ok) return workspace;
+    await workspace.destroy();
+    chdir(originalCwd);
+    print(display.c.sageGreen(`Workspace removed. Now in: ${originalCwd}`));
+    return undefined;
+  }
+
+  // type === "prune"
+  if (!workspaceCfg) {
+    print(display.c.boldRed("Cannot prune: no workspace directory configured."));
+    return workspace;
+  }
+  const removed = await Workspace.prune(workspaceCfg.workspaceDir);
+  if (removed.length === 0) {
+    print(display.c.sageGreen("Nothing to prune."));
+  } else {
+    for (const dir of removed) print(display.c.darkGray(`  Removed: ${dir}`));
+    print(display.c.sageGreen(`Pruned ${removed.length} orphaned workspace(s).`));
+  }
+  return workspace;
+}
+
 // ── Main ──────────────────────────────────────────────────────────────────────
 
 async function main(
@@ -260,59 +340,17 @@ async function main(
       continue;
     }
 
-    if (action.type === "create-workspace") {
-      if (!workspaceCfg) {
-        display.print(display.c.boldRed("Cannot create workspace: no GitHub repo configured."));
-        continue;
-      }
-      if (workspace) {
-        display.print(display.c.amber(`Workspace already exists: ${workspace.dir}`));
-        continue;
-      }
-      workspace = await Workspace.create(workspaceCfg.workspaceDir, sessionId_, workspaceCfg.repoUrl);
-      process.chdir(workspace.dir);
-      display.print(display.c.sageGreen(`Workspace created: ${workspace.dir}`));
-      continue;
-    }
-
-    if (action.type === "reset-workspace") {
-      if (!workspace) {
-        display.print(display.c.boldRed("No workspace. Use /create-workspace first."));
-        continue;
-      }
-      const ok = await confirmIfUnsafe(workspace, confirm);
-      if (!ok) continue;
-      await workspace.reset();
-      display.print(display.c.sageGreen("Workspace reset to main."));
-      continue;
-    }
-
-    if (action.type === "remove-workspace") {
-      if (!workspace) {
-        display.print(display.c.boldRed("No workspace in this session."));
-        continue;
-      }
-      const ok = await confirmIfUnsafe(workspace, confirm);
-      if (!ok) continue;
-      await workspace.destroy();
-      process.chdir(originalCwd);
-      workspace = undefined;
-      display.print(display.c.sageGreen(`Workspace removed. Now in: ${originalCwd}`));
-      continue;
-    }
-
-    if (action.type === "prune") {
-      if (!workspaceCfg) {
-        display.print(display.c.boldRed("Cannot prune: no workspace directory configured."));
-        continue;
-      }
-      const removed = await Workspace.prune(workspaceCfg.workspaceDir);
-      if (removed.length === 0) {
-        display.print(display.c.sageGreen("Nothing to prune."));
-      } else {
-        for (const dir of removed) display.print(display.c.darkGray(`  Removed: ${dir}`));
-        display.print(display.c.sageGreen(`Pruned ${removed.length} orphaned workspace(s).`));
-      }
+    if (
+      action.type === "create-workspace" ||
+      action.type === "reset-workspace" ||
+      action.type === "remove-workspace" ||
+      action.type === "prune"
+    ) {
+      workspace = await handleWorkspaceAction(action.type, {
+        workspaceCfg, workspace, sessionId_, originalCwd, confirm,
+        print: display.print,
+        chdir: (dir) => process.chdir(dir),
+      });
       continue;
     }
 

--- a/tests/repl.workspace.test.ts
+++ b/tests/repl.workspace.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock workspace module before importing repl
+vi.mock("../src/workspace.js", () => {
+  const mockInstance = {
+    dir: "/fake/workspace",
+    reset: vi.fn().mockResolvedValue(undefined),
+    destroy: vi.fn().mockResolvedValue(undefined),
+    checkSafety: vi.fn().mockResolvedValue({ uncommittedFiles: [], unpushedCommits: [], noUpstream: false }),
+  };
+  return {
+    Workspace: {
+      create: vi.fn().mockResolvedValue(mockInstance),
+      prune: vi.fn().mockResolvedValue([]),
+    },
+    confirmIfUnsafe: vi.fn().mockResolvedValue(true),
+  };
+});
+
+// Prevent repl.ts from writing log entries to disk
+vi.mock("fs", () => ({ default: { appendFileSync: vi.fn() } }));
+
+// Prevent SDK import side-effects
+vi.mock("@anthropic-ai/claude-agent-sdk", () => ({ query: vi.fn() }));
+
+import { handleWorkspaceAction } from "../src/repl.js";
+import { Workspace, confirmIfUnsafe } from "../src/workspace.js";
+import { stripAnsi } from "./helpers.js";
+
+const cfg = { workspaceDir: "/base", repoUrl: "https://x@github.com/owner/repo.git" };
+const SESSION_ID = "test-session-uuid";
+const ORIGINAL_CWD = "/original";
+
+function makeParams(
+  overrides: Partial<Parameters<typeof handleWorkspaceAction>[1]> = {},
+): Parameters<typeof handleWorkspaceAction>[1] {
+  return {
+    workspaceCfg: cfg,
+    workspace: undefined,
+    sessionId_: SESSION_ID,
+    originalCwd: ORIGINAL_CWD,
+    confirm: vi.fn().mockResolvedValue(true),
+    print: vi.fn(),
+    chdir: vi.fn(),
+    ...overrides,
+  };
+}
+
+// Reset mocks between tests
+beforeEach(() => {
+  vi.mocked(Workspace.create).mockResolvedValue({ dir: "/fake/workspace", reset: vi.fn(), destroy: vi.fn(), checkSafety: vi.fn() } as any);
+  vi.mocked(Workspace.prune).mockResolvedValue([]);
+  vi.mocked(confirmIfUnsafe).mockResolvedValue(true);
+});
+
+// ── /create-workspace ─────────────────────────────────────────────────────────
+
+describe("handleWorkspaceAction — create-workspace", () => {
+  it("prints error and returns undefined if no workspaceCfg", async () => {
+    const params = makeParams({ workspaceCfg: undefined });
+    const result = await handleWorkspaceAction("create-workspace", params);
+    expect(stripAnsi(vi.mocked(params.print).mock.calls[0][0])).toContain("no GitHub repo configured");
+    expect(result).toBeUndefined();
+    expect(Workspace.create).not.toHaveBeenCalled();
+  });
+
+  it("prints error and returns existing workspace if one already exists", async () => {
+    const existing = { dir: "/existing" } as any;
+    const params = makeParams({ workspace: existing });
+    const result = await handleWorkspaceAction("create-workspace", params);
+    expect(stripAnsi(vi.mocked(params.print).mock.calls[0][0])).toContain("Workspace already exists");
+    expect(result).toBe(existing);
+    expect(Workspace.create).not.toHaveBeenCalled();
+  });
+
+  it("creates workspace, calls chdir, and returns new workspace", async () => {
+    const params = makeParams();
+    const result = await handleWorkspaceAction("create-workspace", params);
+    expect(Workspace.create).toHaveBeenCalledWith(cfg.workspaceDir, SESSION_ID, cfg.repoUrl);
+    expect(vi.mocked(params.chdir)).toHaveBeenCalledWith("/fake/workspace");
+    expect(stripAnsi(vi.mocked(params.print).mock.calls[0][0])).toContain("Workspace created");
+    expect(result).toBeTruthy();
+    expect(result!.dir).toBe("/fake/workspace");
+  });
+});
+
+// ── /reset-workspace ──────────────────────────────────────────────────────────
+
+describe("handleWorkspaceAction — reset-workspace", () => {
+  it("prints error and returns undefined if no workspace exists", async () => {
+    const params = makeParams();
+    const result = await handleWorkspaceAction("reset-workspace", params);
+    expect(stripAnsi(vi.mocked(params.print).mock.calls[0][0])).toContain("No workspace");
+    expect(result).toBeUndefined();
+  });
+
+  it("resets workspace and prints success when safe", async () => {
+    const ws = { dir: "/ws", reset: vi.fn().mockResolvedValue(undefined), destroy: vi.fn(), checkSafety: vi.fn() } as any;
+    const params = makeParams({ workspace: ws });
+    const result = await handleWorkspaceAction("reset-workspace", params);
+    expect(confirmIfUnsafe).toHaveBeenCalledWith(ws, params.confirm);
+    expect(ws.reset).toHaveBeenCalled();
+    expect(stripAnsi(vi.mocked(params.print).mock.calls[0][0])).toContain("Workspace reset to main");
+    expect(result).toBe(ws);
+  });
+
+  it("skips reset if user declines confirmation", async () => {
+    const ws = { dir: "/ws", reset: vi.fn(), destroy: vi.fn(), checkSafety: vi.fn() } as any;
+    vi.mocked(confirmIfUnsafe).mockResolvedValue(false);
+    const params = makeParams({ workspace: ws });
+    const result = await handleWorkspaceAction("reset-workspace", params);
+    expect(ws.reset).not.toHaveBeenCalled();
+    expect(result).toBe(ws);
+  });
+});
+
+// ── /remove-workspace ─────────────────────────────────────────────────────────
+
+describe("handleWorkspaceAction — remove-workspace", () => {
+  it("prints error and returns undefined if no workspace exists", async () => {
+    const params = makeParams();
+    const result = await handleWorkspaceAction("remove-workspace", params);
+    expect(stripAnsi(vi.mocked(params.print).mock.calls[0][0])).toContain("No workspace in this session");
+    expect(result).toBeUndefined();
+  });
+
+  it("destroys workspace, chdir to originalCwd, and returns undefined", async () => {
+    const ws = { dir: "/ws", reset: vi.fn(), destroy: vi.fn().mockResolvedValue(undefined), checkSafety: vi.fn() } as any;
+    const params = makeParams({ workspace: ws });
+    const result = await handleWorkspaceAction("remove-workspace", params);
+    expect(confirmIfUnsafe).toHaveBeenCalledWith(ws, params.confirm);
+    expect(ws.destroy).toHaveBeenCalled();
+    expect(vi.mocked(params.chdir)).toHaveBeenCalledWith(ORIGINAL_CWD);
+    expect(stripAnsi(vi.mocked(params.print).mock.calls[0][0])).toContain("Workspace removed");
+    expect(result).toBeUndefined();
+  });
+
+  it("skips removal if user declines confirmation", async () => {
+    const ws = { dir: "/ws", reset: vi.fn(), destroy: vi.fn(), checkSafety: vi.fn() } as any;
+    vi.mocked(confirmIfUnsafe).mockResolvedValue(false);
+    const params = makeParams({ workspace: ws });
+    const result = await handleWorkspaceAction("remove-workspace", params);
+    expect(ws.destroy).not.toHaveBeenCalled();
+    expect(vi.mocked(params.chdir)).not.toHaveBeenCalled();
+    expect(result).toBe(ws);
+  });
+});
+
+// ── /prune ────────────────────────────────────────────────────────────────────
+
+describe("handleWorkspaceAction — prune", () => {
+  it("prints error if no workspaceCfg", async () => {
+    const params = makeParams({ workspaceCfg: undefined });
+    await handleWorkspaceAction("prune", params);
+    expect(stripAnsi(vi.mocked(params.print).mock.calls[0][0])).toContain("no workspace directory configured");
+  });
+
+  it("prints 'Nothing to prune' when no orphans found", async () => {
+    vi.mocked(Workspace.prune).mockResolvedValue([]);
+    const params = makeParams();
+    await handleWorkspaceAction("prune", params);
+    expect(Workspace.prune).toHaveBeenCalledWith(cfg.workspaceDir);
+    expect(stripAnsi(vi.mocked(params.print).mock.calls[0][0])).toContain("Nothing to prune");
+  });
+
+  it("lists removed dirs and prints summary when orphans are pruned", async () => {
+    vi.mocked(Workspace.prune).mockResolvedValue(["/base/abc", "/base/def"]);
+    const params = makeParams();
+    await handleWorkspaceAction("prune", params);
+    const allOutput = vi.mocked(params.print).mock.calls.map(c => stripAnsi(c[0])).join("\n");
+    expect(allOutput).toContain("/base/abc");
+    expect(allOutput).toContain("/base/def");
+    expect(allOutput).toContain("Pruned 2 orphaned workspace(s)");
+  });
+});


### PR DESCRIPTION
## Summary

- Implements Task 11 from the worker isolated checkouts plan (issue #259)
- Generates a `sessionId_` via `crypto.randomUUID()` at the start of `main()` to match the worker pattern
- Updates `main()` to accept an optional `workspaceCfg` parameter
- Replaces the placeholder "not yet implemented" message with real handlers for `/create-workspace`, `/reset-workspace`, `/remove-workspace`, and `/prune`
- Destroys the workspace on exit (with `confirmIfUnsafe` guard for uncommitted/unpushed work)
- Computes `workspaceCfg` from `config.githubRepo` + `config.githubToken` at the entry point and passes it to `main()`

## Test plan

- [x] `npm test` — all 846 tests pass
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run lint` — clean
- [x] `npm run smoke` — worker connects to foreman successfully

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)