### PR TITLE
test: add dispatch tests for workspace slash commands

### DIFF
--- a/tests/repl.dispatch.test.ts
+++ b/tests/repl.dispatch.test.ts
@@ -150,4 +150,24 @@ describe("dispatchInput", () => {
     const result = await dispatchInput("/myplugin:foo bar baz", readFile);
     expect(result).toEqual({ type: "query", prompt: "Plugin skill bar baz." });
   });
+
+  it("/create-workspace returns { type: 'create-workspace' }", async () => {
+    const result = await dispatchInput("/create-workspace", () => null);
+    expect(result).toEqual({ type: "create-workspace" });
+  });
+
+  it("/reset-workspace returns { type: 'reset-workspace' }", async () => {
+    const result = await dispatchInput("/reset-workspace", () => null);
+    expect(result).toEqual({ type: "reset-workspace" });
+  });
+
+  it("/remove-workspace returns { type: 'remove-workspace' }", async () => {
+    const result = await dispatchInput("/remove-workspace", () => null);
+    expect(result).toEqual({ type: "remove-workspace" });
+  });
+
+  it("/prune returns { type: 'prune' }", async () => {
+    const result = await dispatchInput("/prune", () => null);
+    expect(result).toEqual({ type: "prune" });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds four `dispatchInput` tests in `tests/repl.dispatch.test.ts` covering `/create-workspace`, `/reset-workspace`, `/remove-workspace`, and `/prune`
- Completes test coverage for Task 7 of the worker-isolated-checkouts plan (parsing tests already existed; dispatch tests were missing)
- All 869 tests pass

## Test plan
- [ ] `npm test` passes with 4 new tests green

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)