### PR TITLE
chore: add .brunel.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist/
 .env.local
 repl.log
 .worker-id
+.brunel.lock
 coverage/
 frontend/tsconfig.tsbuildinfo
 supabase/.temp/


### PR DESCRIPTION
## Summary
- Adds `.brunel.lock` to `.gitignore` so it no longer appears as an uncommitted change

This fixes the confusing "potential data loss" warning shown when running `/task-complete`, which flagged `.brunel.lock` as an untracked file.

Closes #282