### PR TITLE
fix: remove worktree language from agent prompts (Task 1)

### DIFF
--- a/src/templates.ts
+++ b/src/templates.ts
@@ -11,7 +11,11 @@ export function formatCommentLocation(
   return `${pathStr} line ${line}`;
 }
 
-export function buildInitialPrompt(issue: TaskIssue): string {
+export function buildInitialPrompt(issue: TaskIssue, isolatedCheckout = false): string {
+  const branchInstruction = isolatedCheckout
+    ? "You are running in your own isolated git clone. Just create a branch for this task and work directly in this checkout."
+    : "Create a new branch and an isolated worktree for this task. Make no changes in the main workspace, only in the worktree.";
+
   return `Please work on GitHub issue #${issue.number}: "${issue.title}" in ${issue.repoUrl}.
 
 Issue description:
@@ -27,7 +31,7 @@ You should ask for any clarifications you need about requirements or product spe
 Use your branch-discipline skill, and remember key practices:
 
 1. Pull main to get the latest before making any edits.
-2. Create a new branch and an isolated worktree for this task. Make no changes in the main workspace, only in the worktree.
+2. ${branchInstruction}
 3. As much as possible, use test-driven development.
 4. Create a PR when done, and include the text "Closes #${issue.number}".
 
@@ -209,7 +213,7 @@ export const EVENT_FMT: EventTemplateFmtTable = {
       return `Auto-merge was enabled on PR #${prNumber}. ${BRANCH_REVIEW_PROMPT}`;
     }
     if (p.action === "closed") {
-      return `PR #${prNumber} was ${pr?.merged ? 'merged' : 'closed without merging'}. Please remove your worktree and delete the branch.
+      return `PR #${prNumber} was ${pr?.merged ? 'merged' : 'closed without merging'}. Please delete the branch.
 
 Then, before we end this session, consider:
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -257,7 +257,7 @@ export class WorkerSession {
       this.prIsClosed = false;
       this.resolveWsInput?.(WS_TASK_ASSIGNED);
       this.resolveWsInput = null;
-      const initialPrompt = buildInitialPrompt(msg.issue);
+      const initialPrompt = buildInitialPrompt(msg.issue, !!this.options.workspaceCtx);
       this.display.print(display.c.sageGreen(initialPrompt));
       void this.runQueryLoop(initialPrompt);
     } else if (msg.type === "event_notification") {

--- a/tests/templates.test.ts
+++ b/tests/templates.test.ts
@@ -64,6 +64,29 @@ describe("buildInitialPrompt", () => {
     expect(p).toContain("brunel:ready");
   });
 
+  it("isolated checkout — mentions isolated clone and omits worktree instruction", () => {
+    const p = buildInitialPrompt({
+      number: 1,
+      title: "T",
+      body: "body",
+      labels: [],
+      repoUrl: "https://github.com/x/y",
+    }, true);
+    expect(p).toContain("isolated");
+    expect(p).not.toContain("worktree");
+  });
+
+  it("shared checkout (default) — includes worktree instruction", () => {
+    const p = buildInitialPrompt({
+      number: 1,
+      title: "T",
+      body: "body",
+      labels: [],
+      repoUrl: "https://github.com/x/y",
+    });
+    expect(p).toContain("worktree");
+  });
+
 });
 
 describe("buildEventPrompt", () => {
@@ -285,14 +308,15 @@ describe("EVENT_FMT table", () => {
     expect(result).toContain("PR #5");
   });
 
-  it("pull_request/closed — instructs worker to clean up its worktree", () => {
+  it("pull_request/closed — instructs worker to delete the branch", () => {
     const evt: GitHubEvent = {
       id: "e1",
       name: "pull_request",
       payload: { action: "closed", pull_request: { number: 5, merged: true } },
     };
     const result = EVENT_FMT.pull_request(evt.payload, evt);
-    expect(result).toContain("worktree");
+    expect(result).toContain("delete the branch");
+    expect(result).not.toContain("worktree");
   });
 
   it("pull_request/closed not merged — asks how to proceed", () => {


### PR DESCRIPTION
## Summary

- `buildInitialPrompt` now accepts an `isolatedCheckout` boolean (default `false`). When `true`, the agent is told it's in its own isolated git clone and should just create a branch — no worktree setup needed.
- `worker.ts` passes `isolatedCheckout: true` since workers always have a dedicated workspace created via `Workspace.create`.
- The `pull_request/closed` event prompt now says "Please delete the branch" instead of "Please remove your worktree and delete the branch", since workspace cleanup is handled automatically.
- Tests added for both the isolated and shared checkout variants of the initial prompt, and the existing worktree-cleanup test updated to assert the new language.

## Test plan

- [ ] `npm test` — all 871 tests pass
- [ ] `npx tsc --noEmit` — no type errors
- [ ] `npm run lint` — no lint errors

Closes #273