### PR TITLE
fix: run workspace cleanup on all exit paths (^D and ^C)

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -555,11 +555,10 @@ export function ask(
     }
 
     function exit() {
-      // Don't call cleanup() here — process.exit() terminates for real;
-      // in tests where exit() is mocked, the listener stays alive so tests
-      // can push "\r" to resolve the dangling promise.
-      process.stdout.write("\x1b[?2004l\r\n");
-      process.exit(0);
+      // Resolve with the EOF sentinel so callers can run workspace cleanup
+      // before process.exit().  submit() handles terminal cursor/clear output,
+      // removes the stdin listener, and resolves the promise.
+      submit("__eof__");
     }
 
     // ── Autocomplete ────────────────────────────────────────────────────────

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -309,6 +309,18 @@ async function main(
   while (true) {
     const input = await ask("\n> ");
 
+    // ^D / ^C on empty buffer resolves ask() with "__eof__" — treat as /exit.
+    if (input === "__eof__") {
+      if (workspace) {
+        const ok = await confirmIfUnsafe(workspace, confirm);
+        if (ok) await workspace.destroy();
+      }
+      process.stdout.write("\x1b[?2004l\r\n");
+      process.stdin.setRawMode(false);
+      process.stdin.pause();
+      break;
+    }
+
     const action = await dispatchInput(input);
 
     if (action.type === "skip") continue;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -135,6 +135,9 @@ export class WorkerSession {
   async handleUserInput(input: string): Promise<"exit" | undefined> {
     if (!input || input === "__abort__") return;
     if (input === WS_TASK_ASSIGNED || input === WS_EVENT) return;
+    // ^D / ^C on empty buffer resolves ask() with "__eof__" — treat as /exit
+    // so the workerMain() loop breaks and workspace cleanup runs.
+    if (input === "__eof__") return "exit";
 
     const action = await dispatchInput(input);
     if (action.type === "skip") return;

--- a/tests/repl.input.test.ts
+++ b/tests/repl.input.test.ts
@@ -281,15 +281,14 @@ describe("ask() - exit conditions", () => {
     });
   });
 
-  it("^C with empty buffer → calls process.exit(0)", async () => {
+  it("^C with empty buffer → resolves with '__eof__' (does not call process.exit)", async () => {
     const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as any);
     await withFakeStdin(async (stdin) => {
       const p = ask("> ", () => []);
       stdin.push("\x03"); // ^C with empty buffer
-      await new Promise(r => setTimeout(r, 10));
-      expect(exitSpy).toHaveBeenCalledWith(0);
-      stdin.push("\r");
-      await p.catch(() => {});
+      const result = await p;
+      expect(result).toBe("__eof__");
+      expect(exitSpy).not.toHaveBeenCalled();
     });
     exitSpy.mockRestore();
   });
@@ -310,15 +309,14 @@ describe("ask() - exit conditions", () => {
     exitSpy.mockRestore();
   });
 
-  it("^D on empty buffer → calls process.exit(0)", async () => {
+  it("^D on empty buffer → resolves with '__eof__' (does not call process.exit)", async () => {
     const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as any);
     await withFakeStdin(async (stdin) => {
       const p = ask("> ", () => []);
       stdin.push("\x04"); // ^D on empty
-      await new Promise(r => setTimeout(r, 10));
-      expect(exitSpy).toHaveBeenCalledWith(0);
-      stdin.push("\r");
-      await p.catch(() => {});
+      const result = await p;
+      expect(result).toBe("__eof__");
+      expect(exitSpy).not.toHaveBeenCalled();
     });
     exitSpy.mockRestore();
   });

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -214,6 +214,11 @@ describe("handleUserInput", () => {
     const [prompt] = runQuery.mock.calls[0];
     expect(prompt).toContain(issue.title);
   });
+
+  it("__eof__ returns 'exit' so workerMain() loop breaks and cleanup runs", async () => {
+    const result = await session.handleUserInput("__eof__");
+    expect(result).toBe("exit");
+  });
 });
 
 // ── State isolation ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `ask()` previously called `process.exit(0)` directly when `^D` (EOF) or `^C` was pressed on an empty prompt, bypassing workspace cleanup
- `ask()` now resolves with an `"__eof__"` sentinel instead
- Both the REPL (`main()`) and worker (`workerMain()`) handle `"__eof__"` the same way as `/exit` — running `confirmIfUnsafe` / `workspace.destroy()` before terminating
- Worker's `handleUserInput()` returns `"exit"` for `"__eof__"` so the cleanup-after-loop path in `workerMain()` runs
- Tests updated: `^C`/`^D` tests now assert `"__eof__"` is returned rather than `process.exit(0)` being called; new test for `handleUserInput("__eof__")` returning `"exit"`

## Test plan

- [x] `npm test` — 872 tests pass (was 871)
- [x] `npm run lint` — no issues
- [x] `npx tsc --noEmit` — no type errors
- [x] Verify `ask()` resolves `"__eof__"` on `^D`/`^C` (existing tests updated)
- [x] Verify `WorkerSession.handleUserInput("__eof__")` returns `"exit"` (new test)

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)