### PR TITLE
feat: log WebSocket close code, reason, and lifetime on disconnect

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -231,8 +231,10 @@ export class WorkerSession {
   private connect(): void {
     const ws = this.wsFactory(this.workerId, this.currentTaskId);
     this.ws = ws;
+    let connectedAt: number | undefined;
 
     ws.on("open", () => {
+      connectedAt = Date.now();
       this.display.print(display.c.sageGreen("Connected to foreman"));
     });
 
@@ -242,12 +244,18 @@ export class WorkerSession {
       this.handleMessage(msg);
     });
 
-    ws.on("close", () => {
-      this.display.print(display.c.amber("Disconnected from foreman. Reconnecting..."));
+    ws.on("close", (code: number, reason: Buffer) => {
+      const elapsed = connectedAt !== undefined ? Math.round((Date.now() - connectedAt) / 1000) : undefined;
+      const elapsedStr = elapsed !== undefined ? `, ${elapsed}s` : "";
+      const reasonStr = reason?.length > 0 ? `, ${reason.toString()}` : "";
+      this.display.print(display.c.amber(`Disconnected from foreman (code ${code}${reasonStr}${elapsedStr}). Reconnecting...`));
       setTimeout(() => this.connect(), 3000);
     });
 
-    ws.on("error", () => { /* close will fire */ });
+    ws.on("error", (err: Error) => {
+      this.display.print(display.c.amber(`WebSocket error: ${err.message}`));
+      /* close will fire */
+    });
   }
 
   private handleMessage(msg: ForemanMessage): void {

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -269,6 +269,52 @@ describe("reconnect", () => {
   });
 });
 
+// ── Close diagnostics ─────────────────────────────────────────────────────────
+
+describe("close diagnostics", () => {
+  it("logs close code in disconnect message", () => {
+    vi.useFakeTimers();
+    fakeWs.emit("close", 1006, Buffer.from(""));
+    const calls = display.print.mock.calls.map(a => stripAnsi(String(a[0])));
+    expect(calls.some(s => s.includes("code 1006"))).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it("logs elapsed seconds in disconnect message when connection was open", () => {
+    vi.useFakeTimers();
+    fakeWs.emit("open");
+    vi.advanceTimersByTime(47000);
+    fakeWs.emit("close", 1006, Buffer.from(""));
+    const calls = display.print.mock.calls.map(a => stripAnsi(String(a[0])));
+    expect(calls.some(s => s.includes("47s"))).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it("omits elapsed seconds when connection never opened", () => {
+    vi.useFakeTimers();
+    fakeWs.emit("close", 1006, Buffer.from(""));
+    const calls = display.print.mock.calls.map(a => stripAnsi(String(a[0])));
+    const msg = calls.find(s => s.includes("Disconnected"));
+    expect(msg).toBeDefined();
+    expect(msg).not.toMatch(/\d+s/);
+    vi.useRealTimers();
+  });
+
+  it("includes non-empty reason in disconnect message", () => {
+    vi.useFakeTimers();
+    fakeWs.emit("close", 1001, Buffer.from("Going Away"));
+    const calls = display.print.mock.calls.map(a => stripAnsi(String(a[0])));
+    expect(calls.some(s => s.includes("Going Away"))).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it("logs error message on ws error event", () => {
+    fakeWs.emit("error", new Error("connection reset"));
+    const calls = display.print.mock.calls.map(a => stripAnsi(String(a[0])));
+    expect(calls.some(s => s.includes("connection reset"))).toBe(true);
+  });
+});
+
 // ── createWsInputPromise ──────────────────────────────────────────────────────
 
 describe("createWsInputPromise", () => {


### PR DESCRIPTION
## Summary

- Records `connectedAt` timestamp on `ws.on("open")` 
- Logs close code, reason (if non-empty), and elapsed seconds in `ws.on("close", (code, reason) => ...)`
- Logs the error message in `ws.on("error", (err) => ...)` before close fires

Example output: `Disconnected from foreman (code 1006, 47s). Reconnecting...`

## Test plan

- [x] Added 5 new tests covering: code in message, elapsed seconds, no elapsed when connection never opened, non-empty reason, and error logging
- [x] All 877 tests pass
- [x] Type check clean

Closes #276