### PR TITLE
diagnostics: log silently dropped events in forwardEvent when worker disconnected

### DIFF
--- a/src/foreman.ts
+++ b/src/foreman.ts
@@ -433,6 +433,10 @@ export function createForemanWss(
 
   function forwardEvent(task: Task, evt: GitHubEvent, ref: string) {
     if (task.status === "assigned" && task.assignedWorkerId) {
+      const worker = registry.get(task.assignedWorkerId);
+      if (!worker) {
+        flog(`[task ${ref}] ${evt.name} DROPPED — worker ${task.assignedWorkerId.slice(0, 8)} not in registry (disconnected?)`);
+      }
       registry.send(task.assignedWorkerId, { type: "event_notification", taskId: task.taskId, event: evt });
       log(task.assignedWorkerId, `→ event_notification ${ref} ${evt.name}`);
     } else if (task.status === "pending") {

--- a/tests/foreman.worker-logging.test.ts
+++ b/tests/foreman.worker-logging.test.ts
@@ -175,6 +175,27 @@ describe("foreman worker message logging", () => {
     expect(completeLog).not.toContain("\n");
   });
 
+  it("logs DROPPED when event arrives for assigned task with disconnected worker", () => {
+    queue.addTask({
+      taskId: "99",
+      issueNumber: 99,
+      title: "Disconnected task",
+      body: "Body",
+      labels: [],
+      repoUrl: "https://github.com/owner/repo",
+    });
+    queue.assignTask("99", "disconnected-worker-id-12345");
+
+    logLines.length = 0;
+    routeEvent("evt-1", "issue_comment", { issue: { number: 99 }, comment: { body: "hi" } });
+
+    const droppedLog = logLines.find(l => l.includes("DROPPED"));
+    expect(droppedLog).toBeDefined();
+    expect(droppedLog).toContain("issue_comment");
+    expect(droppedLog).toContain("disconne"); // first 8 chars of "disconnected-worker-id-12345"
+    expect(droppedLog).toContain("not in registry");
+  });
+
   it("logs event_notification sent to worker as a one-liner", async () => {
     queue.addTask({
       taskId: "1",


### PR DESCRIPTION
## Summary

- In `forwardEvent()`, check `registry.get(workerId)` before calling `registry.send()` 
- If the worker is not in the registry, emit a `flog()` line: `[task <ref>] <event> DROPPED — worker <id[:8]> not in registry (disconnected?)`
- Adds a test covering the dropped-event scenario with a task assigned to a non-existent worker

## Test plan
- [ ] All existing tests pass (873 tests)
- [ ] New test: `logs DROPPED when event arrives for assigned task with disconnected worker`
- [ ] `npx tsc --noEmit` clean

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)