### PR TITLE
feat: add worker_id to webhook_events schema and queries

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -68,7 +68,7 @@ export function createDbLogger(supabase: SupabaseClient): DbLogger {
       id: row.id as number,
       timestamp: row.received_at as string,
       taskId: (row.task_id as string | null) ?? null,
-      workerId: null,
+      workerId: (row.worker_id as string | null) ?? null,
       summary: `${row.event_name}${action}${issue}`,
     };
   }
@@ -123,7 +123,7 @@ export function createDbLogger(supabase: SupabaseClient): DbLogger {
       const limit = opts.limit ?? 100;
       const [wRes, mRes] = await Promise.all([
         supabase.from("webhook_events")
-          .select("id, received_at, event_name, action, issue_number, task_id")
+          .select("id, received_at, event_name, action, issue_number, task_id, worker_id")
           .order("received_at", { ascending: false })
           .limit(limit),
         supabase.from("foreman_messages")
@@ -141,7 +141,7 @@ export function createDbLogger(supabase: SupabaseClient): DbLogger {
     async queryTaskEvents(taskId) {
       const [wRes, mRes] = await Promise.all([
         supabase.from("webhook_events")
-          .select("id, received_at, event_name, action, issue_number, task_id")
+          .select("id, received_at, event_name, action, issue_number, task_id, worker_id")
           .eq("task_id", taskId)
           .order("received_at", { ascending: true })
           .limit(500),

--- a/supabase/migrations/20260327000000_add_worker_id_to_webhook_events.sql
+++ b/supabase/migrations/20260327000000_add_worker_id_to_webhook_events.sql
@@ -1,0 +1,3 @@
+ALTER TABLE webhook_events ADD COLUMN worker_id text REFERENCES workers(id);
+
+CREATE INDEX ON webhook_events (worker_id);

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -133,6 +133,67 @@ describe("messageToEntry summary for worker_disconnected", () => {
   });
 });
 
+describe("webhookToEntry worker_id mapping", () => {
+  function makeSupabaseReturningWebhooks(rows: Record<string, unknown>[]) {
+    const webhookBuilder = {
+      select: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      then: vi.fn().mockImplementation((cb: (v: { data: unknown[]; error: null }) => unknown) =>
+        Promise.resolve(cb({ data: rows, error: null }))
+      ),
+    };
+    const emptyBuilder = {
+      select: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      then: vi.fn().mockImplementation((cb: (v: { data: unknown[]; error: null }) => unknown) =>
+        Promise.resolve(cb({ data: [], error: null }))
+      ),
+    };
+    return {
+      from: vi.fn().mockImplementation((t: string) =>
+        t === "webhook_events" ? webhookBuilder : emptyBuilder
+      ),
+    };
+  }
+
+  it("reads worker_id from webhook row in queryTaskEvents", async () => {
+    const supabase = makeSupabaseReturningWebhooks([{
+      id: 1, received_at: "2026-03-27T00:00:00Z",
+      event_name: "issues", action: "labeled", issue_number: 42,
+      task_id: "42", worker_id: "worker-1",
+    }]);
+    const logger = createDbLogger(supabase as unknown as Parameters<typeof createDbLogger>[0]);
+    const entries = await logger.queryTaskEvents("42");
+    expect(entries[0].workerId).toBe("worker-1");
+  });
+
+  it("reads null worker_id from webhook row when not set", async () => {
+    const supabase = makeSupabaseReturningWebhooks([{
+      id: 1, received_at: "2026-03-27T00:00:00Z",
+      event_name: "issues", action: "labeled", issue_number: 42,
+      task_id: "42", worker_id: null,
+    }]);
+    const logger = createDbLogger(supabase as unknown as Parameters<typeof createDbLogger>[0]);
+    const entries = await logger.queryTaskEvents("42");
+    expect(entries[0].workerId).toBeNull();
+  });
+
+  it("reads worker_id from webhook row in queryLog", async () => {
+    const supabase = makeSupabaseReturningWebhooks([{
+      id: 1, received_at: "2026-03-27T00:00:00Z",
+      event_name: "push", action: null, issue_number: null,
+      task_id: null, worker_id: "worker-2",
+    }]);
+    const logger = createDbLogger(supabase as unknown as Parameters<typeof createDbLogger>[0]);
+    const entries = await logger.queryLog({});
+    expect(entries[0].workerId).toBe("worker-2");
+  });
+});
+
 describe("createNullDbLogger", () => {
   it("logWebhookEvent is a no-op", () => {
     const logger = createNullDbLogger();


### PR DESCRIPTION
## Summary

- Adds a Supabase migration to add `worker_id TEXT REFERENCES workers(id)` column to the `webhook_events` table (with an index)
- Updates `webhookToEntry` in `src/db.ts` to read `worker_id` from DB rows instead of always returning `null`
- Updates `SELECT` clauses in `queryLog` and `queryTaskEvents` to include `worker_id` so webhook events appear correctly in worker history

## Test plan

- [ ] New unit tests in `tests/db.test.ts` verify `workerId` is correctly mapped from webhook rows (non-null value, null value, and via `queryLog`)
- [ ] All 899 existing tests continue to pass (`npm test`)
- [ ] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] Apply migration on Supabase project: `ALTER TABLE webhook_events ADD COLUMN worker_id text REFERENCES workers(id);`

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)