### PR TITLE
fix: workers not exiting after /exit, ^C, or ^D

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -400,7 +400,10 @@ export async function workerMain(
     }
   };
 
+  let shuttingDown = false;
   const shutdown = async () => {
+    if (shuttingDown) return;
+    shuttingDown = true;
     const ok = await confirmIfUnsafe(workspace, confirm);
     if (ok) await workspace.destroy();
     process.exit(0);
@@ -475,11 +478,14 @@ export async function workerMain(
     }
   }
 
-  // Clean shutdown: destroy workspace if user approves
+  // Clean shutdown: destroy workspace if user approves.
+  // Set shuttingDown so the SIGINT handler won't double-destroy.
+  shuttingDown = true;
   const okShutdown = await confirmIfUnsafe(workspace, confirm);
   if (okShutdown) await workspace.destroy();
 
   process.stdout.write("\x1b[?2004l\r\n");
   if (process.stdin.isTTY) process.stdin.setRawMode(false);
   process.stdin.pause();
+  process.exit(0);
 }

--- a/tests/worker.main.test.ts
+++ b/tests/worker.main.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ── Module mocks ────────────────────────────────────────────────────────────
+
+vi.mock("ws", async () => {
+  const { EventEmitter } = await import("node:events");
+  // Use a real class so `new WebSocket(...)` works correctly
+  return {
+    WebSocket: class FakeWebSocket extends EventEmitter {
+      readyState = 1;
+      send = () => {};
+      close = () => {};
+    },
+  };
+});
+
+vi.mock("../src/workspace.js", () => ({
+  Workspace: {
+    create: vi.fn().mockResolvedValue({
+      dir: "/fake/workers/test-worker",
+      destroy: vi.fn().mockResolvedValue(undefined),
+      checkSafety: vi.fn().mockResolvedValue({
+        uncommittedFiles: [],
+        unpushedCommits: [],
+        noUpstream: false,
+      }),
+      reset: vi.fn().mockResolvedValue(undefined),
+    }),
+  },
+  confirmIfUnsafe: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("../src/input.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/input.js")>();
+  return {
+    ...actual,
+    ask: vi.fn().mockResolvedValue("__eof__"),
+    pick: vi.fn().mockResolvedValue(0),
+  };
+});
+
+import { workerMain } from "../src/worker.js";
+import { Workspace, confirmIfUnsafe } from "../src/workspace.js";
+import * as inputModule from "../src/input.js";
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+const WORKER_CONFIG = {
+  foremanUrl: "ws://localhost:3000",
+  workspaceDir: "/fake/workers",
+  githubToken: "test-token",
+  githubRepo: "owner/repo",
+};
+
+async function runWorkerMain(): Promise<{ exitCalled: boolean; exitCode: number | undefined }> {
+  let exitCode: number | undefined;
+  const exitSpy = vi.spyOn(process, "exit").mockImplementation((code?: number | string) => {
+    exitCode = typeof code === "number" ? code : 0;
+    throw new Error("__process_exit__");
+  }) as unknown as ReturnType<typeof vi.spyOn>;
+
+  try {
+    await workerMain(vi.fn().mockResolvedValue(undefined), WORKER_CONFIG);
+    return { exitCalled: false, exitCode: undefined };
+  } catch (err) {
+    if (err instanceof Error && err.message === "__process_exit__") {
+      return { exitCalled: true, exitCode };
+    }
+    throw err;
+  } finally {
+    exitSpy.mockRestore();
+  }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("workerMain exit behavior", () => {
+  let chdirSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Prevent chdir to non-existent workspace dir
+    chdirSpy = vi.spyOn(process, "chdir").mockImplementation(() => {});
+    // Default: ask returns __eof__ immediately (^D pressed)
+    vi.mocked(inputModule.ask).mockResolvedValue("__eof__");
+    vi.mocked(confirmIfUnsafe).mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    chdirSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it("calls process.exit(0) when user presses ^D", async () => {
+    const { exitCalled, exitCode } = await runWorkerMain();
+    expect(exitCalled).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+
+  it("calls process.exit(0) when user types /exit", async () => {
+    // First ask() returns "/exit", which dispatchInput converts to type "exit"
+    vi.mocked(inputModule.ask).mockResolvedValue("/exit");
+    const { exitCalled, exitCode } = await runWorkerMain();
+    expect(exitCalled).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+
+  it("destroys workspace before exiting when workspace is safe", async () => {
+    const fakeWorkspace = {
+      dir: "/fake/workers/test-worker",
+      destroy: vi.fn().mockResolvedValue(undefined),
+      checkSafety: vi.fn().mockResolvedValue({ uncommittedFiles: [], unpushedCommits: [], noUpstream: false }),
+      reset: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.mocked(Workspace.create).mockResolvedValue(fakeWorkspace as any);
+
+    await runWorkerMain();
+
+    expect(fakeWorkspace.destroy).toHaveBeenCalledOnce();
+  });
+
+  it("does not call workspace.destroy a second time if SIGINT fires after loop exits", async () => {
+    const fakeWorkspace = {
+      dir: "/fake/workers/test-worker",
+      destroy: vi.fn().mockResolvedValue(undefined),
+      checkSafety: vi.fn().mockResolvedValue({ uncommittedFiles: [], unpushedCommits: [], noUpstream: false }),
+      reset: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.mocked(Workspace.create).mockResolvedValue(fakeWorkspace as any);
+
+    // Simulate: user types /exit, cleanup runs, process tries to exit.
+    // Before process.exit completes (in our mock it throws), emit SIGINT.
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((code?: number | string) => {
+      // Fire SIGINT to simulate user pressing ^C during or after cleanup
+      process.emit("SIGINT");
+      throw new Error("__process_exit__");
+    }) as unknown as ReturnType<typeof vi.spyOn>;
+
+    try {
+      await workerMain(vi.fn().mockResolvedValue(undefined), WORKER_CONFIG);
+    } catch (err) {
+      if (!(err instanceof Error && err.message === "__process_exit__")) throw err;
+    } finally {
+      exitSpy.mockRestore();
+    }
+
+    // destroy should have been called exactly once, not twice
+    expect(fakeWorkspace.destroy).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

- Workers hung after cleanup because `process.stdin.pause()` alone doesn't terminate the process when the WebSocket connection keeps the event loop alive — added `process.exit(0)` at the end of the normal exit path in `workerMain`
- Added a `shuttingDown` flag to the SIGINT handler to prevent re-entry: if the user pressed `^C` a second time after cleanup had already destroyed the workspace, the handler would try to run `git status` in the deleted directory, causing the `spawn git ENOENT` crash

## Test plan

- [ ] New test file `tests/worker.main.test.ts` covers the fix:
  - `calls process.exit(0) when user presses ^D`
  - `calls process.exit(0) when user types /exit`
  - `destroys workspace before exiting when workspace is safe`
  - `does not call workspace.destroy a second time if SIGINT fires after loop exits`
- [ ] All 900 existing tests still pass
- [ ] Type check and lint clean

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)