### PR TITLE
feat: WebSocket keepalive ping and reconnect jitter (Stage 2)

### DIFF
--- a/src/foreman.ts
+++ b/src/foreman.ts
@@ -3,7 +3,7 @@ import http from "http";
 import "dotenv/config";
 import { Hono } from "hono";
 import { getRequestListener } from "@hono/node-server";
-import { WebSocketServer } from "ws";
+import { WebSocketServer, WebSocket } from "ws";
 import type { WebSocket as WsSocket } from "ws";
 import type { WorkerMessage, ForemanMessage, GitHubEvent, TaskIssue, LabeledIssueState } from "./types.js";
 import { labelIssueDone } from "./github.js";
@@ -412,6 +412,7 @@ export function createForemanWss(
     adminWss?: AdminWss;
     workerSecret?: string;
     labeledIssues?: Map<number, LabeledIssueState>;
+    pingIntervalMs?: number;
   },
 ): { wss: WebSocketServer; routeEventToWorker: (id: string, name: string, payload: unknown) => void; reconcile: () => void } {
   const taskLabel = options.taskLabel;
@@ -693,6 +694,14 @@ export function createForemanWss(
   }
 
   const wss = new WebSocketServer({ noServer: true });
+
+  const PING_INTERVAL_MS = options.pingIntervalMs ?? 25_000;
+  const pingTimer = setInterval(() => {
+    for (const client of wss.clients) {
+      if (client.readyState === WebSocket.OPEN) client.ping();
+    }
+  }, PING_INTERVAL_MS);
+  wss.on("close", () => clearInterval(pingTimer));
 
   wss.on("connection", (ws) => {
     let workerId = "";

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -249,7 +249,7 @@ export class WorkerSession {
       const elapsedStr = elapsed !== undefined ? `, ${elapsed}s` : "";
       const reasonStr = reason?.length > 0 ? `, ${reason.toString()}` : "";
       this.display.print(display.c.amber(`Disconnected from foreman (code ${code}${reasonStr}${elapsedStr}). Reconnecting...`));
-      setTimeout(() => this.connect(), 3000);
+      setTimeout(() => this.connect(), 2000 + Math.random() * 3000);
     });
 
     ws.on("error", (err: Error) => {

--- a/tests/foreman.websocket.test.ts
+++ b/tests/foreman.websocket.test.ts
@@ -607,3 +607,33 @@ describe("worker disconnect DB logging", () => {
     await new Promise<void>((r) => testWss.close(() => server.close(r)));
   });
 });
+
+// ── Keepalive ping ─────────────────────────────────────────────────────────────
+
+describe("keepalive ping", () => {
+  it("sends WebSocket ping to connected clients on interval", async () => {
+    const q = new TaskQueue();
+    const r = new WorkerRegistry();
+    const srv = http.createServer();
+    const { wss: testWss } = createForemanWss(q, r, srv, {
+      taskLabel: DEFAULT_TASK_LABEL,
+      labelDone: vi.fn().mockResolvedValue(undefined),
+      pingIntervalMs: 50,
+    });
+    await new Promise<void>((resolve) => srv.listen(0, resolve));
+    const testPort = (srv.address() as AddressInfo).port;
+
+    const ws = new WebSocket(`ws://localhost:${testPort}/worker`);
+    await new Promise<void>((resolve, reject) => {
+      ws.once("open", resolve);
+      ws.once("error", reject);
+    });
+    send(ws, { type: "worker_hello", workerId: "w1", status: "idle" });
+
+    await new Promise<void>((resolve) => ws.once("ping", () => resolve()));
+
+    ws.close();
+    await new Promise<void>((resolve) => ws.once("close", resolve));
+    await new Promise<void>((resolve) => testWss.close(() => srv.close(resolve)));
+  });
+});

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -246,7 +246,7 @@ describe("reconnect", () => {
     expect(wsFactory).toHaveBeenCalledOnce();
 
     fakeWs.emit("close");
-    vi.advanceTimersByTime(3001);
+    vi.advanceTimersByTime(5001);
 
     expect(wsFactory).toHaveBeenCalledTimes(2);
     vi.useRealTimers();
@@ -260,11 +260,37 @@ describe("reconnect", () => {
     await Promise.resolve();
 
     fakeWs.emit("close");
-    vi.advanceTimersByTime(3001);
+    vi.advanceTimersByTime(5001);
 
     const secondCall = wsFactory.mock.calls[1];
     expect(secondCall[0]).toBe(WORKER_ID);
     expect(secondCall[1]).toBe("42");
+    vi.useRealTimers();
+  });
+
+  it("reconnect delay is at least 2 seconds (jitter lower bound)", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0);
+
+    fakeWs.emit("close");
+    vi.advanceTimersByTime(1999);
+    expect(wsFactory).toHaveBeenCalledTimes(1); // not reconnected yet
+
+    vi.advanceTimersByTime(2);
+    expect(wsFactory).toHaveBeenCalledTimes(2); // reconnected at ~2000ms
+
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("reconnect delay is at most 5 seconds (jitter upper bound)", async () => {
+    vi.useFakeTimers();
+
+    fakeWs.emit("close");
+    // Even with maximum jitter (random approaching 1.0), delay is always < 5000ms
+    vi.advanceTimersByTime(5000);
+    expect(wsFactory).toHaveBeenCalledTimes(2);
+
     vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary

Stage 1 diagnostics confirmed the hypothesis: all disconnects are code **1006** (abnormal closure — no close frame), at varying intervals (147s–789s). This is Railway's edge proxy dropping idle WebSocket connections.

Stage 2 fixes:

- **Foreman-side ping** (`src/foreman.ts`): every 25 seconds, pings all connected clients. The `ws` library handles pong automatically. This keeps Railway's proxy from seeing an idle connection. `pingIntervalMs` option added to `createForemanWss` for testability.
- **Reconnect jitter** (`src/worker.ts`): reconnect delay is now random 2–5s instead of fixed 3s, to avoid thundering-herd when multiple workers disconnect simultaneously (e.g., on foreman restart).

## Tests

- New test: foreman sends pings to connected clients on the configured interval
- New tests: reconnect jitter lower bound (fires at ~2s with `Math.random() = 0`) and upper bound (always fires within 5s)
- Existing reconnect tests updated to advance 5001ms (covers max jitter)

## Related

See `docs/superpowers/specs/2026-03-27-reconnection-hardening-design.md` — this implements Stage 2. Stage 3 (H2 event-drop fix, H3 double-assignment) to follow.