### PR TITLE
feat: send worker_goodbye on clean exit for immediate task reassignment

### DIFF
--- a/src/foreman.ts
+++ b/src/foreman.ts
@@ -790,6 +790,19 @@ export function createForemanWss(
       tryAssignWork(workerId);
     }
 
+    function handleWorkerGoodbye(msg: Extract<WorkerMessage, { type: "worker_goodbye" }>) {
+      log(workerId, `worker_goodbye (task=${msg.taskId ?? "none"})`);
+      if (msg.taskId) {
+        taskQueue.revertTask(msg.taskId);
+      }
+      registry.remove(workerId);
+      broadcastSnapshot();
+      // Try to assign the reverted task to any already-idle workers.
+      for (const w of registry.getIdleWorkers()) {
+        tryAssignWork(w.workerId);
+      }
+    }
+
     ws.on("message", (data) => {
       let msg: WorkerMessage;
       try { msg = JSON.parse(data.toString()); } catch { return; }
@@ -805,6 +818,7 @@ export function createForemanWss(
 
       if (msg.type === "worker_hello") handleWorkerHello(msg);
       else if (msg.type === "task_complete") handleTaskComplete(msg);
+      else if (msg.type === "worker_goodbye") handleWorkerGoodbye(msg);
       else flog(`[worker ${workerId}] unknown message type: ${(msg as R).type}`);
     });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,8 @@ export interface LabeledIssueState {
 // Worker → Foreman messages
 export type WorkerMessage =
   | { type: "worker_hello"; workerId: string; taskId?: string; status: "idle" | "busy"; workerSecret?: string }
-  | { type: "task_complete"; workerId: string; taskId: string };
+  | { type: "task_complete"; workerId: string; taskId: string }
+  | { type: "worker_goodbye"; workerId: string; taskId?: string };
 
 // Foreman → Worker messages
 export type ForemanMessage =

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -130,6 +130,21 @@ export class WorkerSession {
   }
 
   /**
+   * Send worker_goodbye to the foreman if the WebSocket is currently open.
+   * Called before clean exits (SIGTERM, /quit) so the foreman can immediately
+   * revert the task to pending without waiting for the reclaim timeout.
+   */
+  sendGoodbye(): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify({
+        type: "worker_goodbye",
+        workerId: this.workerId,
+        taskId: this.currentTaskId,
+      }));
+    }
+  }
+
+  /**
    * Process a line of stdin input: slash commands and user queries.
    */
   async handleUserInput(input: string): Promise<"exit" | undefined> {
@@ -408,8 +423,6 @@ export async function workerMain(
     if (ok) await workspace.destroy();
     process.exit(0);
   };
-  // SIGTERM is a system/orchestrator signal: force-destroy without prompting.
-  process.on("SIGTERM", () => { void workspace.destroy().then(() => process.exit(0)); });
   // SIGINT received as a signal: prompt before destroying.
   process.on("SIGINT", () => { void shutdown(); });
 
@@ -434,6 +447,12 @@ export async function workerMain(
   const session = new WorkerSession(workerId, wsFactory, runQueryFn, workerDisplay, {
     afterTask,
     workspaceCtx: { workspace, originalCwd, workspaceDir, repoUrl, confirm },
+  });
+
+  // SIGTERM is a system/orchestrator signal: send goodbye then force-destroy without prompting.
+  process.on("SIGTERM", () => {
+    session.sendGoodbye();
+    void workspace.destroy().then(() => process.exit(0));
   });
 
   process.stdout.write("\x1b[?2004h"); // enable bracketed paste mode
@@ -477,6 +496,9 @@ export async function workerMain(
       display.print(display.c.boldRed(`\nERROR: ${err}`));
     }
   }
+
+  // Send goodbye so the foreman can immediately reassign any in-progress task.
+  session.sendGoodbye();
 
   // Clean shutdown: destroy workspace if user approves.
   // Set shuttingDown so the SIGINT handler won't double-destroy.

--- a/tests/foreman.websocket.test.ts
+++ b/tests/foreman.websocket.test.ts
@@ -735,6 +735,59 @@ describe("disconnected worker state", () => {
   });
 });
 
+// ── worker_goodbye ────────────────────────────────────────────────────────────
+
+describe("worker_goodbye", () => {
+  it("removes worker from registry and reverts task to pending", async () => {
+    queue.addTask(makeTask(1));
+    const ws = await connect();
+    send(ws, { type: "worker_hello", workerId: "w1", status: "idle" });
+    await nextMsg(ws); // task_assigned
+
+    send(ws, { type: "worker_goodbye", workerId: "w1", taskId: "1" });
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(registry.get("w1")).toBeUndefined();
+    expect(queue.get("1")?.status).toBe("pending");
+  });
+
+  it("removes idle worker from registry when goodbye has no taskId", async () => {
+    const ws = await connect();
+    send(ws, { type: "worker_hello", workerId: "w1", status: "idle" });
+    await nextMsg(ws); // standby
+
+    send(ws, { type: "worker_goodbye", workerId: "w1" });
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(registry.get("w1")).toBeUndefined();
+  });
+
+  it("reverted task is immediately assigned to a waiting idle worker", async () => {
+    queue.addTask(makeTask(1));
+
+    // Worker A gets task 1
+    const wsA = await connect();
+    send(wsA, { type: "worker_hello", workerId: "worker-a", status: "idle" });
+    await nextMsg(wsA); // task_assigned
+
+    // Worker B connects and waits on standby
+    const wsB = await connect();
+    send(wsB, { type: "worker_hello", workerId: "worker-b", status: "idle" });
+    await nextMsg(wsB); // standby
+
+    // Worker A says goodbye — task should revert and be assigned to B
+    const replyB = nextMsg(wsB);
+    send(wsA, { type: "worker_goodbye", workerId: "worker-a", taskId: "1" });
+    const msg = await replyB;
+    expect(msg.type).toBe("task_assigned");
+    if (msg.type === "task_assigned") expect(msg.taskId).toBe("1");
+
+    expect(registry.get("worker-a")).toBeUndefined();
+    expect(queue.get("1")?.status).toBe("assigned");
+    expect(queue.get("1")?.assignedWorkerId).toBe("worker-b");
+  });
+});
+
 // ── Keepalive ping ─────────────────────────────────────────────────────────────
 
 describe("keepalive ping", () => {

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1061,3 +1061,36 @@ describe("afterTask callback on /task-complete", () => {
     expect(lastMsg.type).toBe("task_complete");
   });
 });
+
+describe("sendGoodbye", () => {
+  it("sends worker_goodbye with workerId and taskId when ws is open and task is active", async () => {
+    const issue = makeIssue();
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
+    await vi.waitFor(() => expect(runQuery).toHaveBeenCalled());
+
+    fakeWs.send.mockClear();
+    session.sendGoodbye();
+
+    expect(fakeWs.send).toHaveBeenCalledOnce();
+    const sent = JSON.parse(fakeWs.send.mock.calls[0][0]);
+    expect(sent).toEqual({ type: "worker_goodbye", workerId: WORKER_ID, taskId: "42" });
+  });
+
+  it("sends worker_goodbye with undefined taskId when no task is active", () => {
+    fakeWs.send.mockClear();
+    session.sendGoodbye();
+
+    expect(fakeWs.send).toHaveBeenCalledOnce();
+    const sent = JSON.parse(fakeWs.send.mock.calls[0][0]);
+    expect(sent.type).toBe("worker_goodbye");
+    expect(sent.workerId).toBe(WORKER_ID);
+    expect(sent.taskId).toBeUndefined();
+  });
+
+  it("does not send when ws is not open", () => {
+    fakeWs.readyState = 3; // CLOSED
+    fakeWs.send.mockClear();
+    session.sendGoodbye();
+    expect(fakeWs.send).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `worker_goodbye` to the `WorkerMessage` union type
- `WorkerSession.sendGoodbye()` sends the goodbye message when the WebSocket is open (no-op otherwise)
- SIGTERM handler calls `sendGoodbye()` before destroying workspace and exiting
- Clean exit via `/quit` or `^D` calls `sendGoodbye()` before workspace cleanup
- Foreman handles `worker_goodbye` by immediately removing the worker from the registry, reverting the task to pending, and reassigning it to any waiting idle workers

## Test plan

- [x] `worker_goodbye` removes worker from registry and reverts task to pending
- [x] `worker_goodbye` with no taskId removes idle worker without side effects
- [x] Reverted task is immediately assigned to a waiting idle worker after goodbye
- [x] `WorkerSession.sendGoodbye()` sends correct message when ws is open with active task
- [x] `WorkerSession.sendGoodbye()` sends message with no taskId when idle
- [x] `WorkerSession.sendGoodbye()` is a no-op when ws is not open
- [x] All 930 existing tests pass

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)