### PR TITLE
docs: document BRUNEL_WORKER_RECLAIM_TIMEOUT_MS in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,27 +26,7 @@ npm start
 npm run worker
 ```
 
-Config (in `.env` or `brunel.config.ts`; CLI flags also accepted). Precedence: CLI flags > `BRUNEL_*` env vars > config file > legacy env vars > defaults.
-
-Required:
-- `BRUNEL_GITHUB_REPO` / `GITHUB_REPO` — e.g. `owner/repo`
-- `BRUNEL_GITHUB_TOKEN` / `GITHUB_TOKEN` / `GH_TOKEN` — personal access token with `repo` scope (`GH_TOKEN` is forwarded automatically in the devcontainer)
-- `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` — for Claude Agent SDK (the OAuth token is used automatically if you're running inside Claude Code)
-
-Optional (all have defaults):
-- `BRUNEL_TASK_LABEL` / `TASK_LABEL` — label that triggers work (default: `brunel:ready`)
-- `BRUNEL_DONE_LABEL` / `DONE_LABEL` — label applied on completion (default: `brunel:done`)
-- `BRUNEL_PORT` / `PORT` — foreman HTTP/WebSocket port (default: `3000`)
-- `BRUNEL_WEBHOOK_SECRET` / `WEBHOOK_SECRET` — GitHub webhook secret for signature verification (optional)
-- `BRUNEL_FOREMAN_URL` — WebSocket URL workers connect to (default: `ws://localhost:3000`); **no legacy fallback for this one**
-- `BRUNEL_VERBOSE` — enable verbose Claude output (default: `false`)
-- `BRUNEL_THINK_OUT_LOUD` — show full agent thinking text; defaults to `BRUNEL_VERBOSE`; also settable in `brunel.config.ts` as `thinkOutLoud`
-- `BRUNEL_PERMISSION_MODE` — Claude permission mode: `default`, `acceptEdits`, `bypassPermissions`, `plan`, `dontAsk` (default: `default`)
-- `BRUNEL_WORKSPACE_DIR` — base directory for worker checkout directories (default: `~/.brunel/workers`)
-- `BRUNEL_WORKER_RECLAIM_TIMEOUT_MS` — ms to wait before reclaiming a task from a disconnected worker (default: `300000` / 5 min)
-- `BRUNEL_SUPABASE_URL` — Supabase project URL (for cloud deployment)
-- `BRUNEL_SUPABASE_SECRET_KEY` — Supabase secret key (for cloud deployment; treat as secret)
-- `BRUNEL_WORKER_SECRET` — shared secret to authenticate workers with the foreman (treat as secret)
+Config (in `.env` or `brunel.config.ts`; CLI flags also accepted). Precedence: CLI flags > `BRUNEL_*` env vars > config file > legacy env vars > defaults. See `src/config.ts` for the full list of options, env var names, legacy fallbacks, and defaults.
 
 ## Useful scripts
 


### PR DESCRIPTION
Adds the `BRUNEL_WORKER_RECLAIM_TIMEOUT_MS` config option introduced in #314 to the optional config section of CLAUDE.md.