### PR TITLE
fix(worker): ignore stale close/error events from previous WebSocket

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -260,6 +260,7 @@ export class WorkerSession {
     });
 
     ws.on("close", (code: number, reason: Buffer) => {
+      if (ws !== this.ws) return; // stale close from a previous connection
       const elapsed = connectedAt !== undefined ? Math.round((Date.now() - connectedAt) / 1000) : undefined;
       const elapsedStr = elapsed !== undefined ? `, ${elapsed}s` : "";
       const reasonStr = reason?.length > 0 ? `, ${reason.toString()}` : "";
@@ -268,6 +269,7 @@ export class WorkerSession {
     });
 
     ws.on("error", (err: Error) => {
+      if (ws !== this.ws) return; // stale error from a previous connection
       this.display.print(display.c.amber(`WebSocket error: ${err.message}`));
       /* close will fire */
     });

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -295,6 +295,56 @@ describe("reconnect", () => {
   });
 });
 
+// ── Stale WebSocket handlers ──────────────────────────────────────────────────
+
+describe("stale WebSocket handlers", () => {
+  it("ignores close event from the old WebSocket after reconnect", () => {
+    vi.useFakeTimers();
+
+    const oldWs = fakeWs;
+    // Trigger reconnect — new WS is returned by wsFactory on second call
+    const newWs = new FakeWs();
+    wsFactory.mockReturnValueOnce(newWs);
+    oldWs.emit("close", 1001, Buffer.from(""));
+    vi.advanceTimersByTime(5001);
+
+    // wsFactory called a second time (reconnect happened)
+    expect(wsFactory).toHaveBeenCalledTimes(2);
+    display.print.mockClear();
+
+    // Now the old WS fires close again (delayed TCP teardown)
+    oldWs.emit("close", 1006, Buffer.from(""));
+
+    // Should be silently ignored — no disconnect message, no third connection
+    const calls = display.print.mock.calls.map(a => stripAnsi(String(a[0])));
+    expect(calls.some(s => s.includes("Disconnected"))).toBe(false);
+    expect(wsFactory).toHaveBeenCalledTimes(2); // no third connection
+
+    vi.useRealTimers();
+  });
+
+  it("ignores error event from the old WebSocket after reconnect", () => {
+    vi.useFakeTimers();
+
+    const oldWs = fakeWs;
+    const newWs = new FakeWs();
+    wsFactory.mockReturnValueOnce(newWs);
+    oldWs.emit("close", 1001, Buffer.from(""));
+    vi.advanceTimersByTime(5001);
+
+    display.print.mockClear();
+
+    // Old WS fires error after new connection is established
+    oldWs.emit("error", new Error("stale error"));
+
+    // Should be silently ignored
+    const calls = display.print.mock.calls.map(a => stripAnsi(String(a[0])));
+    expect(calls.some(s => s.includes("stale error"))).toBe(false);
+
+    vi.useRealTimers();
+  });
+});
+
 // ── Close diagnostics ─────────────────────────────────────────────────────────
 
 describe("close diagnostics", () => {


### PR DESCRIPTION
## Summary

- Add `if (ws !== this.ws) return` guard at the top of the `close` handler in `WorkerSession.connect()`
- Add the same guard to the `error` handler
- Each handler captures `ws` in its closure; if `this.ws` has moved on to a newer connection, events from the old one are silently dropped rather than triggering a spurious disconnect message and a third connection

## Tests

Two new tests in `tests/worker.test.ts` under `"stale WebSocket handlers"`:
- Verifies that a `close` event from the old WebSocket after reconnect is ignored (no disconnect message, no third connection)
- Verifies that an `error` event from the old WebSocket after reconnect is ignored

Closes #311