### PR TITLE
fix: broadcast foreman messages to admin and load dashboard history

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Link } from "react-router-dom";
 import { useAdminWs } from "../hooks/useAdminWs.ts";
 import type { TaskSnapshot, WorkerSnapshot, LogEntry, AdminMessage } from "../types.ts";
@@ -7,6 +7,13 @@ export default function Dashboard() {
   const [tasks, setTasks] = useState<TaskSnapshot[]>([]);
   const [workers, setWorkers] = useState<WorkerSnapshot[]>([]);
   const [recentLog, setRecentLog] = useState<LogEntry[]>([]);
+
+  useEffect(() => {
+    fetch("/api/log")
+      .then((r) => r.json() as Promise<LogEntry[]>)
+      .then(setRecentLog)
+      .catch(console.error);
+  }, []);
 
   const handleMessage = useCallback((msg: AdminMessage) => {
     if (msg.type === "snapshot") {

--- a/frontend/tests/Dashboard.test.tsx
+++ b/frontend/tests/Dashboard.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, waitFor, act } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import Dashboard from "../src/pages/Dashboard.tsx";
+import type { LogEntry, AdminMessage } from "../src/types.ts";
+
+// Capture useAdminWs callback so tests can trigger fake WS messages
+let capturedHandler: ((msg: AdminMessage) => void) | null = null;
+
+vi.mock("../src/hooks/useAdminWs.ts", () => ({
+  useAdminWs: (handler: (msg: AdminMessage) => void) => {
+    capturedHandler = handler;
+  },
+}));
+
+function renderDashboard() {
+  return render(
+    <MemoryRouter>
+      <Dashboard />
+    </MemoryRouter>
+  );
+}
+
+const webhookEntry: LogEntry = {
+  kind: "webhook",
+  id: 1,
+  timestamp: "2026-01-01T10:00:00.000Z",
+  taskId: "42",
+  workerId: null,
+  summary: "issues/labeled #42",
+};
+
+const messageEntry: LogEntry = {
+  kind: "message",
+  id: 2,
+  timestamp: "2026-01-01T10:01:00.000Z",
+  taskId: "42",
+  workerId: "worker-abc-123",
+  summary: "sent task_assigned",
+};
+
+describe("Dashboard", () => {
+  beforeEach(() => {
+    capturedHandler = null;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches from /api/log on mount", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([]) }));
+    renderDashboard();
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith("/api/log"));
+  });
+
+  it("shows empty state when no events", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([]) }));
+    renderDashboard();
+    await waitFor(() => expect(screen.getByText("No events yet.")).toBeInTheDocument());
+  });
+
+  it("renders historical events loaded from the API", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([webhookEntry, messageEntry]) }));
+    renderDashboard();
+    await waitFor(() => expect(screen.getByText("issues/labeled #42")).toBeInTheDocument());
+    expect(screen.getByText("sent task_assigned")).toBeInTheDocument();
+  });
+
+  it("shows both webhook and message kinds from API", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([webhookEntry, messageEntry]) }));
+    renderDashboard();
+    await waitFor(() => expect(screen.getByText("webhook")).toBeInTheDocument());
+    expect(screen.getByText("message")).toBeInTheDocument();
+  });
+
+  it("prepends new log_event messages from WebSocket to historical events", async () => {
+    const newEntry: LogEntry = { kind: "message", id: 3, timestamp: "2026-01-01T10:02:00.000Z", taskId: null, workerId: "worker-abc-123", summary: "received worker_hello" };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([webhookEntry]) }));
+    renderDashboard();
+    await waitFor(() => expect(screen.getByText("issues/labeled #42")).toBeInTheDocument());
+
+    act(() => {
+      capturedHandler!({ type: "log_event", entry: newEntry });
+    });
+
+    expect(screen.getByText("received worker_hello")).toBeInTheDocument();
+    expect(screen.getByText("issues/labeled #42")).toBeInTheDocument();
+  });
+
+  it("does not add events to log on snapshot messages", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([]) }));
+    renderDashboard();
+    await waitFor(() => expect(screen.getByText("No events yet.")).toBeInTheDocument());
+
+    act(() => {
+      capturedHandler!({ type: "snapshot", tasks: [], workers: [] });
+    });
+
+    expect(screen.getByText("No events yet.")).toBeInTheDocument();
+  });
+});

--- a/src/foreman.ts
+++ b/src/foreman.ts
@@ -473,6 +473,29 @@ export function createForemanWss(
   };
   const reclaimTimeoutMs = options.reclaimTimeoutMs;
 
+  // Incrementing counter for unique broadcast IDs (React uses these as keys).
+  let nextBroadcastId = 1;
+
+  function broadcastMessageEvent(data: { direction: string; workerId: string | null; taskId: string | null; msgType: string; payload?: Record<string, unknown> }) {
+    if (!adminWss) return;
+    let summary: string;
+    if (data.msgType === "worker_disconnected") {
+      const payload = data.payload ?? {};
+      const reason = payload.reason ? `: ${payload.reason}` : "";
+      summary = `disconnected (code ${payload.code}${reason})`;
+    } else {
+      summary = `${data.direction} ${data.msgType}`;
+    }
+    adminWss.broadcastLogEvent({
+      kind: "message",
+      id: nextBroadcastId++,
+      timestamp: new Date().toISOString(),
+      taskId: data.taskId,
+      workerId: data.workerId,
+      summary,
+    });
+  }
+
   function log(wid: string, line: string) {
     flog(`[worker ${wid.slice(0, 8)}] ${line}`);
   }
@@ -702,7 +725,7 @@ export function createForemanWss(
     });
     adminWss?.broadcastLogEvent({
       kind: "webhook",
-      id: 0,
+      id: nextBroadcastId++,
       timestamp: new Date().toISOString(),
       taskId,
       workerId,
@@ -739,6 +762,7 @@ export function createForemanWss(
         const standbyMsg: ForemanMessage = { type: "standby" };
         registry.send(workerId, standbyMsg);
         dbLogger?.logForemanMessage({ direction: "sent", workerId, taskId: null, msgType: standbyMsg.type, payload: standbyMsg as unknown as Record<string, unknown> });
+        broadcastMessageEvent({ direction: "sent", workerId, taskId: null, msgType: standbyMsg.type });
         log(workerId, "→ standby (DB write failed)");
         return;
       }
@@ -757,17 +781,20 @@ export function createForemanWss(
       };
       registry.send(workerId, assignMsg);
       dbLogger?.logForemanMessage({ direction: "sent", workerId, taskId: task.taskId, msgType: assignMsg.type, payload: assignMsg as unknown as Record<string, unknown> });
+      broadcastMessageEvent({ direction: "sent", workerId, taskId: task.taskId, msgType: assignMsg.type });
       log(workerId, `→ task_assigned #${task.issueNumber} "${task.title}"`);
       for (const evt of queued) {
         const evtMsg: ForemanMessage = { type: "event_notification", taskId: task.taskId, event: evt };
         registry.send(workerId, evtMsg);
         dbLogger?.logForemanMessage({ direction: "sent", workerId, taskId: task.taskId, msgType: evtMsg.type, payload: evtMsg as unknown as Record<string, unknown> });
+        broadcastMessageEvent({ direction: "sent", workerId, taskId: task.taskId, msgType: evtMsg.type });
         log(workerId, `→ event_notification #${task.issueNumber} ${evt.name} (queued)`);
       }
     } else {
       const standbyMsg: ForemanMessage = { type: "standby" };
       registry.send(workerId, standbyMsg);
       dbLogger?.logForemanMessage({ direction: "sent", workerId, taskId: null, msgType: standbyMsg.type, payload: standbyMsg as unknown as Record<string, unknown> });
+      broadcastMessageEvent({ direction: "sent", workerId, taskId: null, msgType: standbyMsg.type });
       log(workerId, "→ standby");
     }
   }
@@ -822,6 +849,7 @@ export function createForemanWss(
           const standbyMsg: ForemanMessage = { type: "standby" };
           registry.send(workerId, standbyMsg);
           dbLogger?.logForemanMessage({ direction: "sent", workerId, taskId: null, msgType: standbyMsg.type, payload: standbyMsg as unknown as Record<string, unknown> });
+          broadcastMessageEvent({ direction: "sent", workerId, taskId: null, msgType: standbyMsg.type });
           log(workerId, "→ standby");
         }
       } else {
@@ -878,13 +906,16 @@ export function createForemanWss(
       try { msg = JSON.parse(data.toString()); } catch { return; }
 
       // Log all received messages
+      const rcvWorkerId = workerId || ((msg as { workerId?: string }).workerId ?? null);
+      const rcvTaskId = (msg as { taskId?: string }).taskId ?? null;
       dbLogger?.logForemanMessage({
         direction: "received",
-        workerId: workerId || ((msg as { workerId?: string }).workerId ?? null),
-        taskId: (msg as { taskId?: string }).taskId ?? null,
+        workerId: rcvWorkerId,
+        taskId: rcvTaskId,
         msgType: msg.type,
         payload: msg as unknown as Record<string, unknown>,
       });
+      broadcastMessageEvent({ direction: "received", workerId: rcvWorkerId, taskId: rcvTaskId, msgType: msg.type });
 
       if (msg.type === "worker_hello") handleWorkerHello(msg);
       else if (msg.type === "task_complete") handleTaskComplete(msg);
@@ -897,13 +928,15 @@ export function createForemanWss(
         const reasonStr = reason?.length ? `: ${reason}` : "";
         log(workerId, `disconnected (code ${code}${reasonStr})`);
         const taskId = registry.get(workerId)?.currentTaskId ?? null;
+        const disconnPayload = { code, reason: reason?.toString() ?? null };
         dbLogger?.logForemanMessage({
           direction: "received",
           workerId,
           taskId,
           msgType: "worker_disconnected",
-          payload: { code, reason: reason?.toString() ?? null },
+          payload: disconnPayload,
         });
+        broadcastMessageEvent({ direction: "received", workerId, taskId, msgType: "worker_disconnected", payload: disconnPayload });
         if (taskId) {
           // Keep registry entry so queued events can be delivered on reconnect.
           registry.markDisconnected(workerId);

--- a/tests/foreman.admin-broadcast.test.ts
+++ b/tests/foreman.admin-broadcast.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Tests that verify the foreman broadcasts BOTH webhook events AND foreman
+ * messages to the admin dashboard via adminWss.broadcastLogEvent().
+ *
+ * Covers the bug in issue #249: only webhooks were broadcast; messages were
+ * silently dropped from the real-time admin event log.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import http from "http";
+import { WebSocket, WebSocketServer } from "ws";
+import type { AddressInfo } from "net";
+import { TaskQueue, WorkerRegistry, createForemanWss } from "../src/foreman.js";
+import { loadDefaultConfig } from "../src/config.js";
+const defaultCfg = await loadDefaultConfig();
+import type { AdminWss, LogEntry } from "../src/admin-ws.js";
+
+// ── Mock AdminWss ─────────────────────────────────────────────────────────────
+
+function makeMockAdminWss(): AdminWss & { logEntries: LogEntry[] } {
+  const logEntries: LogEntry[] = [];
+  return {
+    logEntries,
+    broadcastSnapshot() {},
+    broadcastLogEvent(entry) { logEntries.push({ ...entry }); },
+  };
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function connectWorker(port: number): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://localhost:${port}/worker`);
+    ws.once("open", () => resolve(ws));
+    ws.once("error", reject);
+  });
+}
+
+function nextMsg(ws: WebSocket): Promise<unknown> {
+  return new Promise((resolve) => {
+    ws.once("message", (data) => resolve(JSON.parse(data.toString())));
+  });
+}
+
+function send(ws: WebSocket, msg: object) {
+  ws.send(JSON.stringify(msg));
+}
+
+function closeClient(ws: WebSocket): Promise<void> {
+  return new Promise((resolve) => {
+    if (ws.readyState === WebSocket.CLOSED) { resolve(); return; }
+    ws.once("close", resolve);
+    ws.close();
+  });
+}
+
+// ── Test harness ──────────────────────────────────────────────────────────────
+
+let queue: TaskQueue;
+let registry: WorkerRegistry;
+let httpServer: http.Server;
+let wss: WebSocketServer;
+let adminWss: ReturnType<typeof makeMockAdminWss>;
+let routeEvent: (id: string, name: string, payload: unknown) => void;
+let port: number;
+const openClients: WebSocket[] = [];
+
+function connect(): Promise<WebSocket> {
+  return connectWorker(port).then((ws) => { openClients.push(ws); return ws; });
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
+  process.env.GITHUB_REPO = "owner/repo";
+  process.env.GITHUB_TOKEN = "token";
+
+  queue = new TaskQueue();
+  registry = new WorkerRegistry();
+  adminWss = makeMockAdminWss();
+  httpServer = http.createServer();
+  ({ wss, routeEventToWorker: routeEvent } = createForemanWss(queue, registry, httpServer, {
+    taskLabel: defaultCfg.taskLabel,
+    reclaimTimeoutMs: defaultCfg.workerReclaimTimeoutMs,
+    adminWss,
+  }));
+
+  return new Promise<void>((resolve) => {
+    httpServer.listen(0, () => {
+      port = (httpServer.address() as AddressInfo).port;
+      resolve();
+    });
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.GITHUB_REPO;
+  delete process.env.GITHUB_TOKEN;
+
+  return new Promise<void>((resolve) => {
+    const clients = openClients.splice(0);
+    const alive = clients.filter((c) => c.readyState !== WebSocket.CLOSED);
+    if (alive.length === 0) {
+      wss.close(() => httpServer.close(resolve));
+      return;
+    }
+    let pending = alive.length;
+    for (const c of alive) {
+      c.once("close", () => {
+        if (--pending === 0) wss.close(() => httpServer.close(resolve));
+      });
+      c.close();
+    }
+  });
+});
+
+// ── Scenarios ─────────────────────────────────────────────────────────────────
+
+describe("foreman admin broadcast — webhook events", () => {
+  it("broadcasts a webhook event as kind='webhook'", () => {
+    routeEvent("evt-1", "issues", {
+      action: "labeled",
+      label: { name: defaultCfg.taskLabel },
+      issue: { number: 42, title: "Fix the bug", body: "", labels: [] },
+      repository: { html_url: "https://github.com/owner/repo" },
+    });
+
+    expect(adminWss.logEntries).toHaveLength(1);
+    expect(adminWss.logEntries[0].kind).toBe("webhook");
+  });
+
+  it("broadcasts webhook event with a non-zero unique id", () => {
+    routeEvent("evt-1", "issues", { action: "labeled", label: { name: defaultCfg.taskLabel }, issue: { number: 1, title: "T", body: "", labels: [] }, repository: { html_url: "https://github.com/owner/repo" } });
+    routeEvent("evt-2", "issues", { action: "labeled", label: { name: defaultCfg.taskLabel }, issue: { number: 2, title: "T", body: "", labels: [] }, repository: { html_url: "https://github.com/owner/repo" } });
+
+    expect(adminWss.logEntries).toHaveLength(2);
+    const [e1, e2] = adminWss.logEntries;
+    expect(e1.id).toBeGreaterThan(0);
+    expect(e2.id).toBeGreaterThan(0);
+    expect(e1.id).not.toBe(e2.id);
+  });
+
+  it("broadcasts webhook event with summary and taskId", () => {
+    queue.addTask({ taskId: "42", issueNumber: 42, title: "Fix", body: "", labels: [], repoUrl: "https://github.com/owner/repo" });
+
+    routeEvent("evt-1", "issue_comment", {
+      action: "created",
+      issue: { number: 42 },
+      comment: { body: "LGTM" },
+      repository: { html_url: "https://github.com/owner/repo" },
+    });
+
+    expect(adminWss.logEntries[0].taskId).toBe("42");
+    expect(adminWss.logEntries[0].summary).toMatch(/issue_comment/);
+  });
+});
+
+describe("foreman admin broadcast — sent messages", () => {
+  it("broadcasts standby sent to worker as kind='message'", async () => {
+    const ws = await connect();
+    const reply = nextMsg(ws);
+    send(ws, { type: "worker_hello", workerId: "worker-abc", status: "idle" });
+    await reply; // standby
+
+    const msgEntries = adminWss.logEntries.filter((e) => e.kind === "message");
+    expect(msgEntries.length).toBeGreaterThan(0);
+    const standby = msgEntries.find((e) => e.summary.includes("standby"));
+    expect(standby).toBeDefined();
+  });
+
+  it("broadcasts task_assigned sent to worker as kind='message'", async () => {
+    queue.addTask({ taskId: "1", issueNumber: 1, title: "Fix", body: "", labels: [], repoUrl: "https://github.com/owner/repo" });
+
+    const ws = await connect();
+    const reply = nextMsg(ws);
+    send(ws, { type: "worker_hello", workerId: "worker-abc", status: "idle" });
+    await reply; // task_assigned
+
+    const msgEntries = adminWss.logEntries.filter((e) => e.kind === "message");
+    const assigned = msgEntries.find((e) => e.summary.includes("task_assigned"));
+    expect(assigned).toBeDefined();
+    expect(assigned!.taskId).toBe("1");
+  });
+});
+
+describe("foreman admin broadcast — received messages", () => {
+  it("broadcasts received worker_hello as kind='message'", async () => {
+    const ws = await connect();
+    const reply = nextMsg(ws);
+    send(ws, { type: "worker_hello", workerId: "worker-abc", status: "idle" });
+    await reply;
+
+    const received = adminWss.logEntries.filter(
+      (e) => e.kind === "message" && e.summary.includes("received") && e.summary.includes("worker_hello"),
+    );
+    expect(received.length).toBeGreaterThan(0);
+  });
+
+  it("broadcasts received task_complete as kind='message'", async () => {
+    queue.addTask({ taskId: "1", issueNumber: 1, title: "Fix", body: "", labels: [], repoUrl: "https://github.com/owner/repo" });
+
+    const ws = await connect();
+    send(ws, { type: "worker_hello", workerId: "worker-abc", status: "idle" });
+    await nextMsg(ws); // task_assigned
+
+    adminWss.logEntries.length = 0; // reset
+    send(ws, { type: "task_complete", workerId: "worker-abc", taskId: "1" });
+    await nextMsg(ws); // standby
+
+    const received = adminWss.logEntries.filter(
+      (e) => e.kind === "message" && e.summary.includes("task_complete"),
+    );
+    expect(received.length).toBeGreaterThan(0);
+  });
+
+  it("broadcasts disconnect event as kind='message'", async () => {
+    const ws = await connect();
+    send(ws, { type: "worker_hello", workerId: "worker-abc", status: "idle" });
+    await nextMsg(ws); // standby
+
+    adminWss.logEntries.length = 0;
+    await closeClient(ws);
+    await new Promise((r) => setTimeout(r, 20)); // let close handler run
+
+    const disconnected = adminWss.logEntries.find(
+      (e) => e.kind === "message" && e.summary.includes("disconnected"),
+    );
+    expect(disconnected).toBeDefined();
+  });
+});
+
+describe("foreman admin broadcast — unique IDs across all event types", () => {
+  it("assigns unique IDs to webhook and message broadcasts", async () => {
+    const ws = await connect();
+    const reply = nextMsg(ws);
+    send(ws, { type: "worker_hello", workerId: "worker-abc", status: "idle" });
+    await reply;
+
+    routeEvent("evt-1", "issues", {
+      action: "labeled",
+      label: { name: defaultCfg.taskLabel },
+      issue: { number: 99, title: "T", body: "", labels: [] },
+      repository: { html_url: "https://github.com/owner/repo" },
+    });
+
+    const ids = adminWss.logEntries.map((e) => e.id);
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(ids.length);
+    expect(ids.every((id) => id > 0)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- **Dashboard shows no events after navigation**: The Dashboard component had no initial fetch from `/api/log`, so navigating away and back left the Recent Events panel empty (component remounts with empty state, only accumulates new real-time events)
- **Dashboard shows only webhooks**: `adminWss.broadcastLogEvent()` was only called for webhook events — foreman messages (task_assigned, standby, worker_hello, etc.) were never broadcast, so the real-time event log was missing them entirely
- **React key collisions**: Webhook broadcasts used a hardcoded `id: 0`, so all webhook entries had `key="webhook-0"`, causing React reconciliation issues

## Changes

- `src/foreman.ts`: Added `broadcastMessageEvent()` helper that mirrors `dbLogger.logForemanMessage()` but broadcasts to admin WebSocket; called alongside every `logForemanMessage()` call (sent + received + disconnect). Also added `nextBroadcastId` counter to generate unique IDs for all broadcasts (webhooks and messages).
- `frontend/src/pages/Dashboard.tsx`: Added `useEffect` to fetch from `/api/log` on mount, so historical events are shown when the page first loads or after navigation.

## Test plan

- [ ] All 969 backend tests pass (`npm test`)
- [ ] All 36 frontend tests pass (including 6 new Dashboard tests, 9 new admin-broadcast tests)
- [ ] `npm run lint` clean
- [ ] `npx tsc --noEmit` clean

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)