### PR TITLE
fix: use SUPABASE_PROJECT_ID env var in migrate workflow

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           version: latest
 
-      - run: supabase db push --project-ref ${{ vars.SUPABASE_PROJECT_REF }}
+      - run: supabase db push
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_ID: ${{ vars.SUPABASE_PROJECT_REF }}


### PR DESCRIPTION
## Summary
- The `supabase db push --project-ref` flag was removed in a newer CLI version, causing the migrate workflow to fail on every push
- Switch to passing the project ref via `SUPABASE_PROJECT_ID` env var, which is the current supported approach

## Test plan
- [ ] Merge and verify the `Migrate database` workflow runs successfully on the next push to main that touches `supabase/migrations/**`

🤖 Generated with [Claude Code](https://claude.com/claude-code)