### PR TITLE
fix: add workflow_dispatch to migrate workflow

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'supabase/migrations/**'
+  workflow_dispatch:
 
 jobs:
   migrate:


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger so the migration workflow can be run manually from the Actions tab
- Needed now because the previous fix PR didn't touch `supabase/migrations/**`, so the workflow never ran for the pending `task_assignments` migration

## Test plan
- [ ] Merge this PR
- [ ] Go to Actions → Migrate database → Run workflow to apply the pending migration
- [ ] Verify foreman starts without the `task_assignments` schema cache error

🤖 Generated with [Claude Code](https://claude.com/claude-code)