### PR TITLE
fix: link project before db push to force IPv4 connection

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -19,6 +19,10 @@ jobs:
         with:
           version: latest
 
+      - run: supabase link --project-ref ${{ vars.SUPABASE_PROJECT_REF }}
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+
       - run: supabase db push
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary
- GitHub Actions runners don't support IPv6, causing `supabase db push` to fail with "IPv6 is not supported on your current network"
- Adding a `supabase link` step before `db push` forces the CLI to cache the IPv4 connection pooler URL

## Test plan
- [ ] Merge and manually trigger the workflow from Actions → Migrate database → Run workflow
- [ ] Verify it succeeds and the `task_assignments` table is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)