### PR TITLE
fix: remove erroneous FK to nonexistent workers table in migration

### DIFF
--- a/supabase/migrations/20260327000000_add_worker_id_to_webhook_events.sql
+++ b/supabase/migrations/20260327000000_add_worker_id_to_webhook_events.sql
@@ -1,3 +1,3 @@
-ALTER TABLE webhook_events ADD COLUMN worker_id text REFERENCES workers(id);
+ALTER TABLE webhook_events ADD COLUMN worker_id text;
 
 CREATE INDEX ON webhook_events (worker_id);


### PR DESCRIPTION
## Summary
- `20260327000000_add_worker_id_to_webhook_events.sql` had `REFERENCES workers(id)` but there is no `workers` table — worker IDs are plain text strings generated by workers and announced during the hello/handshake
- Removes the FK constraint so the migration can apply cleanly

## Test plan
- [ ] Merge, then manually trigger Actions → Migrate database → Run workflow
- [ ] Both pending migrations should apply successfully
- [ ] Foreman starts without the `task_assignments` schema cache error

🤖 Generated with [Claude Code](https://claude.com/claude-code)