### PR TITLE
refactor: createForemanWss returns a ForemanWss object

### DIFF
--- a/src/foreman.ts
+++ b/src/foreman.ts
@@ -447,6 +447,12 @@ export function createHttpServer(
 
 // ── WebSocket server factory ──────────────────────────────────────────────────
 
+export interface ForemanWss {
+  wss: WebSocketServer;
+  routeEvent(id: string, name: string, payload: unknown): void;
+  reconcile(): void;
+}
+
 export function createForemanWss(
   taskQueue: TaskQueue,
   registry: WorkerRegistry,
@@ -466,7 +472,7 @@ export function createForemanWss(
     assignStore?: TaskAssignmentStore;
     reclaimTimeoutMs: number;
   },
-): { wss: WebSocketServer; routeEventToWorker: (id: string, name: string, payload: unknown) => void; reconcile: () => void } {
+): ForemanWss {
   const taskLabel = options.taskLabel;
   const labelDone = options.labelDone ?? (() => Promise.resolve());
   const graph = options.graph ?? new Map<number, Set<number>>();
@@ -1032,7 +1038,7 @@ export function createForemanWss(
     assignIdleWorkers();
   }
 
-  return { wss, routeEventToWorker: routeEvent, reconcile };
+  return { wss, routeEvent, reconcile };
 }
 
 // Only start listening when run directly (not when imported by tests)
@@ -1066,9 +1072,8 @@ if (isMain) {
     assignStore = createNullTaskAssignmentStore();
   }
 
-  let routeEvent: (id: string, name: string, payload: unknown) => void = () => {};
-  let reconcile: () => void = () => {};
-  const server = createHttpServer(webhooks, (id, name, payload) => routeEvent(id, name, payload), dbLogger);
+  let foremanWss: ForemanWss;
+  const server = createHttpServer(webhooks, (id, name, payload) => foremanWss.routeEvent(id, name, payload), dbLogger);
 
   // Admin WebSocket broadcaster
   const { createAdminWss } = await import("./admin-ws.js");
@@ -1077,7 +1082,7 @@ if (isMain) {
     workers: registry.getWorkerSnapshots(),
   }));
 
-  ({ routeEventToWorker: routeEvent, reconcile } = createForemanWss(
+  foremanWss = createForemanWss(
     taskQueue, registry, server,
     {
       graph,
@@ -1098,12 +1103,12 @@ if (isMain) {
           doneLabel: config.doneLabel,
         }),
     },
-  ));
+  );
 
   if (webhooks) {
     webhooks.onAny(({ id, name, payload }) => {
       printEvent(id, name as string, payload);
-      routeEvent(id, name as string, payload);
+      foremanWss.routeEvent(id, name as string, payload);
     });
   }
 
@@ -1117,7 +1122,7 @@ if (isMain) {
       taskLabel: config.taskLabel,
       apiUrl: config.githubApiUrl,
     });
-    reconcile();
+    foremanWss.reconcile();
   } catch (err) {
     flog(`ERROR Failed to load issues from GitHub: ${fmtError(err)}`);
     process.exit(1);

--- a/tests/foreman.admin-broadcast.test.ts
+++ b/tests/foreman.admin-broadcast.test.ts
@@ -77,7 +77,7 @@ beforeEach(() => {
   registry = new WorkerRegistry();
   adminWss = makeMockAdminWss();
   httpServer = http.createServer();
-  ({ wss, routeEventToWorker: routeEvent } = createForemanWss(queue, registry, httpServer, {
+  ({ wss, routeEvent } = createForemanWss(queue, registry, httpServer, {
     taskLabel: defaultCfg.taskLabel,
     reclaimTimeoutMs: defaultCfg.workerReclaimTimeoutMs,
     adminWss,

--- a/tests/foreman.reconcile.test.ts
+++ b/tests/foreman.reconcile.test.ts
@@ -15,14 +15,14 @@ let queue: TaskQueue;
 let registry: WorkerRegistry;
 let labeledIssues: Map<number, LabeledIssueState>;
 let reconcile: () => void;
-let routeEventToWorker: (id: string, name: string, payload: unknown) => void;
+let routeEvent: (id: string, name: string, payload: unknown) => void;
 
 beforeEach(() => {
   queue = new TaskQueue();
   registry = new WorkerRegistry();
   labeledIssues = new Map();
   const server = http.createServer();
-  ({ reconcile, routeEventToWorker } = createForemanWss(queue, registry, server, {
+  ({ reconcile, routeEvent } = createForemanWss(queue, registry, server, {
     taskLabel: TASK_LABEL,
     reclaimTimeoutMs: defaultCfg.workerReclaimTimeoutMs,
     labeledIssues,
@@ -148,7 +148,7 @@ describe("startDepsLoad() error handling", () => {
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network error")));
 
     // Trigger startDepsLoad by routing a labeled event
-    routeEventToWorker("evt-1", "issues", {
+    routeEvent("evt-1", "issues", {
       action: "labeled",
       label: { name: TASK_LABEL },
       issue: {

--- a/tests/foreman.startup.test.ts
+++ b/tests/foreman.startup.test.ts
@@ -228,7 +228,7 @@ describe("PR tracking persistence", () => {
     });
     ({ wss } = result);
 
-    result.routeEventToWorker("evt-1", "pull_request", {
+    result.routeEvent("evt-1", "pull_request", {
       action: "opened",
       pull_request: {
         number: 10,
@@ -251,7 +251,7 @@ describe("PR tracking persistence", () => {
     });
     ({ wss } = result);
 
-    result.routeEventToWorker("evt-1", "pull_request", {
+    result.routeEvent("evt-1", "pull_request", {
       action: "opened",
       pull_request: {
         number: 10,

--- a/tests/foreman.timestamps.test.ts
+++ b/tests/foreman.timestamps.test.ts
@@ -62,7 +62,7 @@ beforeEach(() => {
   queue = new TaskQueue();
   registry = new WorkerRegistry();
   httpServer = http.createServer();
-  ({ wss, routeEventToWorker: routeEvent } = createForemanWss(queue, registry, httpServer, { taskLabel: defaultCfg.taskLabel, reclaimTimeoutMs: defaultCfg.workerReclaimTimeoutMs }));
+  ({ wss, routeEvent } = createForemanWss(queue, registry, httpServer, { taskLabel: defaultCfg.taskLabel, reclaimTimeoutMs: defaultCfg.workerReclaimTimeoutMs }));
 
   return new Promise<void>((resolve) => {
     httpServer.listen(0, () => {

--- a/tests/foreman.webhook-logging.test.ts
+++ b/tests/foreman.webhook-logging.test.ts
@@ -44,7 +44,7 @@ beforeEach(() => {
 
   const registry = new WorkerRegistry();
   const httpServer = http.createServer();
-  ({ routeEventToWorker: routeEvent } = createForemanWss(queue, registry, httpServer, {
+  ({ routeEvent } = createForemanWss(queue, registry, httpServer, {
     taskLabel: defaultCfg.taskLabel,
     reclaimTimeoutMs: defaultCfg.workerReclaimTimeoutMs,
     dbLogger,

--- a/tests/foreman.webhook-routing.test.ts
+++ b/tests/foreman.webhook-routing.test.ts
@@ -198,7 +198,7 @@ beforeEach(() => {
   queue = new TaskQueue();
   registry = new WorkerRegistry();
   httpServer = http.createServer();
-  ({ wss, routeEventToWorker: routeEvent } = createForemanWss(queue, registry, httpServer, { taskLabel: defaultCfg.taskLabel, reclaimTimeoutMs: defaultCfg.workerReclaimTimeoutMs }));
+  ({ wss, routeEvent } = createForemanWss(queue, registry, httpServer, { taskLabel: defaultCfg.taskLabel, reclaimTimeoutMs: defaultCfg.workerReclaimTimeoutMs }));
 
   return new Promise<void>((resolve) => {
     httpServer.listen(0, () => {

--- a/tests/foreman.websocket.test.ts
+++ b/tests/foreman.websocket.test.ts
@@ -77,7 +77,7 @@ beforeEach(() => {
   openIssues = new Set();
   labeledIssues = new Map();
   httpServer = http.createServer();
-  ({ wss, routeEventToWorker: routeEvent } = createForemanWss(queue, registry, httpServer, { taskLabel: defaultCfg.taskLabel, reclaimTimeoutMs: defaultCfg.workerReclaimTimeoutMs, labelDone, graph, openIssues, labeledIssues }));
+  ({ wss, routeEvent } = createForemanWss(queue, registry, httpServer, { taskLabel: defaultCfg.taskLabel, reclaimTimeoutMs: defaultCfg.workerReclaimTimeoutMs, labelDone, graph, openIssues, labeledIssues }));
 
   return new Promise<void>((resolve) => {
     httpServer.listen(0, () => {
@@ -216,7 +216,7 @@ describe("foreman WebSocket protocol", () => {
     expect(queue.get("1")?.status).toBe("pending");
   });
 
-  it("routeEventToWorker sends event_notification to assigned worker", async () => {
+  it("routeEvent sends event_notification to assigned worker", async () => {
     queue.addTask(makeTask(1));
     const ws = await connect();
     send(ws, { type: "worker_hello", workerId: "w1", status: "idle" });
@@ -230,7 +230,7 @@ describe("foreman WebSocket protocol", () => {
     expect(msg.event.name).toBe("issue_comment");
   });
 
-  it("routeEventToWorker queues event when no worker is assigned", () => {
+  it("routeEvent queues event when no worker is assigned", () => {
     queue.addTask(makeTask(1));
     routeEvent("evt-1", "issue_comment", { issue: { number: 1 } });
     const events = queue.drainEvents("1");

--- a/tests/foreman.worker-logging.test.ts
+++ b/tests/foreman.worker-logging.test.ts
@@ -68,7 +68,7 @@ beforeEach(() => {
   queue = new TaskQueue();
   registry = new WorkerRegistry();
   httpServer = http.createServer();
-  ({ wss, routeEventToWorker: routeEvent } = createForemanWss(queue, registry, httpServer, { taskLabel: defaultCfg.taskLabel, reclaimTimeoutMs: defaultCfg.workerReclaimTimeoutMs }));
+  ({ wss, routeEvent } = createForemanWss(queue, registry, httpServer, { taskLabel: defaultCfg.taskLabel, reclaimTimeoutMs: defaultCfg.workerReclaimTimeoutMs }));
 
   return new Promise<void>((resolve) => {
     httpServer.listen(0, () => {


### PR DESCRIPTION
## Summary

- Defines a `ForemanWss` interface (`wss`, `routeEvent`, `reconcile`) in `src/foreman.ts`
- `createForemanWss` now returns `ForemanWss` instead of a plain object with the `routeEventToWorker` closure
- The main startup block holds a single `foremanWss` reference and calls methods directly — no more mutable pre-declared closure variables
- All test files updated to use `routeEvent` instead of `routeEventToWorker`

`TaskQueue`, `WorkerRegistry`, and the HTTP server remain as separate constructor arguments (not encapsulated inside `ForemanWss`), keeping the refactor minimal and focused.

Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)