### PR TITLE
refactor: move fmtError to shared utils module

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import { cosmiconfig } from "cosmiconfig";
 import { z } from "zod";
 import type { PermissionMode } from "@anthropic-ai/claude-agent-sdk";
+import { fmtError } from "./utils.js";
 
 // ── Permission modes ──────────────────────────────────────────────────────────
 
@@ -254,7 +255,7 @@ export async function loadConfig(
         err.issues.map((e) => `  ${e.path.join(".") || "(root)"}: ${e.message}`).join("\n") + "\n"
       );
     } else {
-      process.stderr.write(`Error: ${err}\n`);
+      process.stderr.write(`Error: ${fmtError(err)}\n`);
     }
     process.exit(1);
     // Satisfy TypeScript — process.exit never returns but TS doesn't know that

--- a/src/foreman.ts
+++ b/src/foreman.ts
@@ -14,22 +14,10 @@ import { fetchIssueStates } from "./github.js";
 import type { DependencyGraph } from "./dependencies.js";
 import { type DbLogger, type TaskAssignmentStore, createDbLogger, createTaskAssignmentStore, createNullDbLogger, createNullTaskAssignmentStore } from "./db.js";
 import type { AdminWss, TaskSnapshot, WorkerSnapshot } from "./admin-ws.js";
+import { fmtError } from "./utils.js";
 
 function flog(msg: string) {
   console.log(`${fmtTimestamp()} ${msg}`);
-}
-
-/** Serialize an unknown thrown value to a human-readable string.
- * Handles native Error, Supabase PostgrestError (plain object with `message`), strings, and fallback JSON. */
-export function fmtError(err: unknown): string {
-  if (err instanceof Error) return err.message;
-  if (typeof err === "string") return err;
-  if (err === null) return "null";
-  if (err === undefined) return "undefined";
-  if (typeof err === "object" && "message" in err && typeof (err as { message: unknown }).message === "string") {
-    return (err as { message: string }).message;
-  }
-  return JSON.stringify(err);
 }
 
 type R = Record<string, unknown>;

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -14,6 +14,7 @@ import { workerMain } from "./worker.js";
 import type { RunQuery } from "./worker.js";
 import { loadConfig } from "./config.js";
 import { Workspace, confirmIfUnsafe } from "./workspace.js";
+import { fmtError } from "./utils.js";
 export { parseSlashCommand, resolveCommandFilePath, resolveContent, dispatchInput, matchCommands, listCommandNames, listWorkerCommandNames, ask } from "./input.js";
 export type { SlashCommandResult, DispatchResult, ListDir } from "./input.js";
 
@@ -371,7 +372,7 @@ async function main(
     try {
       sessionId = await runQuery(permConfig, action.prompt, sessionId);
     } catch (err) {
-      console.error(display.c.boldRed(`\nERROR: ${err}`));
+      console.error(display.c.boldRed(`\nERROR: ${fmtError(err)}`));
       logFull("ERROR", err instanceof Error ? { message: err.message, stack: err.stack } : err);
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,12 @@
+/** Serialize an unknown thrown value to a human-readable string.
+ * Handles native Error, Supabase PostgrestError (plain object with `message`), strings, and fallback JSON. */
+export function fmtError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  if (err === null) return "null";
+  if (err === undefined) return "undefined";
+  if (typeof err === "object" && "message" in err && typeof (err as { message: unknown }).message === "string") {
+    return (err as { message: string }).message;
+  }
+  return JSON.stringify(err);
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -8,6 +8,7 @@ import { buildInitialPrompt, buildEventPrompt } from "./templates.js";
 import { ask, listWorkerCommands, dispatchInput, pick } from "./input.js";
 import type { ForemanMessage, GitHubEvent, TaskIssue } from "./types.js";
 import { Workspace, confirmIfUnsafe } from "./workspace.js";
+import { fmtError } from "./utils.js";
 
 // ── Event classification ───────────────────────────────────────────────────────
 
@@ -411,7 +412,7 @@ export async function workerMain(
     try {
       await workspace.reset();
     } catch (err) {
-      display.print(display.c.boldRed(`Workspace reset failed: ${err}. Task not marked complete.`));
+      display.print(display.c.boldRed(`Workspace reset failed: ${fmtError(err)}. Task not marked complete.`));
       throw err;
     }
   };
@@ -494,7 +495,7 @@ export async function workerMain(
       const result = await session.handleUserInput(input);
       if (result === "exit") break;
     } catch (err) {
-      display.print(display.c.boldRed(`\nERROR: ${err}`));
+      display.print(display.c.boldRed(`\nERROR: ${fmtError(err)}`));
     }
   }
 

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
 import * as display from "./display.js";
+import { fmtError } from "./utils.js";
 
 const execFileAsync = promisify(execFileCb);
 
@@ -61,13 +62,13 @@ export class Workspace {
       await this._doReset();
       return;
     } catch (err) {
-      display.print(display.c.amber(`[workspace] Reset failed, retrying: ${err}`));
+      display.print(display.c.amber(`[workspace] Reset failed, retrying: ${fmtError(err)}`));
     }
     try {
       await this._doReset();
       return;
     } catch (err) {
-      display.print(display.c.amber(`[workspace] Reset failed again, re-cloning: ${err}`));
+      display.print(display.c.amber(`[workspace] Reset failed again, re-cloning: ${fmtError(err)}`));
       fs.rmSync(this.dir, { recursive: true, force: true });
       fs.mkdirSync(path.dirname(this.dir), { recursive: true });
       display.print(display.c.sageGreen(`[workspace] Re-cloning ${this.repoUrl} → ${this.dir}`));

--- a/tests/foreman.fmterror.test.ts
+++ b/tests/foreman.fmterror.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { fmtError } from "../src/foreman.js";
+import { fmtError } from "../src/utils.js";
 
 describe("fmtError", () => {
   it("returns the message for a native Error", () => {


### PR DESCRIPTION
## Summary

- Moves `fmtError` from `src/foreman.ts` to a new `src/utils.ts` shared utility module
- Imports and uses `fmtError` in `src/repl.ts`, `src/worker.ts`, `src/workspace.ts`, and `src/config.ts` to fix `[object Object]` error logging in those files
- Updates `tests/foreman.fmterror.test.ts` to import from the new location

## Test plan

- [ ] All 980 existing unit tests pass (`npm test`)
- [ ] TypeScript type check passes (`tsc --noEmit`)
- [ ] `fmtError` test coverage unchanged — same 6 test cases, now testing from `src/utils.ts`

Closes #324