### PR TITLE
fix: show task events in reverse-chronological order

### DIFF
--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -16,7 +16,7 @@ export default function TaskDetail() {
 
   const handleMessage = useCallback((msg: AdminMessage) => {
     if (msg.type === "log_event" && msg.entry.taskId === id) {
-      setEvents((prev) => [...prev, msg.entry]);
+      setEvents((prev) => [msg.entry, ...prev]);
     }
   }, [id]);
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -143,18 +143,18 @@ export function createDbLogger(supabase: SupabaseClient): DbLogger {
         supabase.from("webhook_events")
           .select("id, received_at, event_name, action, issue_number, task_id, worker_id")
           .eq("task_id", taskId)
-          .order("received_at", { ascending: true })
+          .order("received_at", { ascending: false })
           .limit(500),
         supabase.from("foreman_messages")
           .select("id, created_at, direction, worker_id, task_id, msg_type, payload")
           .eq("task_id", taskId)
-          .order("created_at", { ascending: true })
+          .order("created_at", { ascending: false })
           .limit(500),
       ]);
       const webhooks = ((wRes.data ?? []) as Record<string, unknown>[]).map(webhookToEntry);
       const messages = ((mRes.data ?? []) as Record<string, unknown>[]).map(messageToEntry);
       return [...webhooks, ...messages]
-        .sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+        .sort((a, b) => b.timestamp.localeCompare(a.timestamp));
     },
 
     async queryWorkerMessages(workerId) {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -194,6 +194,51 @@ describe("webhookToEntry worker_id mapping", () => {
   });
 });
 
+describe("queryTaskEvents ordering", () => {
+  function makeSupabaseReturningTaskRows(webhookRows: Record<string, unknown>[], messageRows: Record<string, unknown>[]) {
+    const webhookBuilder = {
+      select: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      then: vi.fn().mockImplementation((cb: (v: { data: unknown[]; error: null }) => unknown) =>
+        Promise.resolve(cb({ data: webhookRows, error: null }))
+      ),
+    };
+    const messageBuilder = {
+      select: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      then: vi.fn().mockImplementation((cb: (v: { data: unknown[]; error: null }) => unknown) =>
+        Promise.resolve(cb({ data: messageRows, error: null }))
+      ),
+    };
+    return {
+      from: vi.fn().mockImplementation((t: string) =>
+        t === "webhook_events" ? webhookBuilder : messageBuilder
+      ),
+    };
+  }
+
+  it("returns events in reverse-chronological order (newest first)", async () => {
+    const supabase = makeSupabaseReturningTaskRows(
+      [
+        { id: 1, received_at: "2026-03-27T01:00:00Z", event_name: "issues", action: "labeled", issue_number: 42, task_id: "42", worker_id: null },
+        { id: 2, received_at: "2026-03-27T03:00:00Z", event_name: "issues", action: "unlabeled", issue_number: 42, task_id: "42", worker_id: null },
+      ],
+      [
+        { id: 10, created_at: "2026-03-27T02:00:00Z", direction: "sent", worker_id: "w1", task_id: "42", msg_type: "task_assigned", payload: {} },
+      ]
+    );
+    const logger = createDbLogger(supabase as unknown as Parameters<typeof createDbLogger>[0]);
+    const entries = await logger.queryTaskEvents("42");
+    expect(entries[0].timestamp).toBe("2026-03-27T03:00:00Z");
+    expect(entries[1].timestamp).toBe("2026-03-27T02:00:00Z");
+    expect(entries[2].timestamp).toBe("2026-03-27T01:00:00Z");
+  });
+});
+
 describe("createNullDbLogger", () => {
   it("logWebhookEvent is a no-op", () => {
     const logger = createNullDbLogger();


### PR DESCRIPTION
## Summary

- `queryTaskEvents` in `src/db.ts` was sorting events ascending (oldest first), unlike `queryLog` and `queryWorkerMessages` which sort descending (newest first)
- `TaskDetail.tsx` was appending new WebSocket events to the end instead of prepending them to the top

## Changes

- Changed `queryTaskEvents` to use `ascending: false` and sort descending, matching the other query methods
- Changed `TaskDetail.tsx` to prepend new live events (`[msg.entry, ...prev]`) instead of appending
- Added a test asserting `queryTaskEvents` returns events in reverse-chronological order

## Test plan

- [ ] `npm test` passes (990 tests)
- [ ] Task detail page shows newest events at the top

Closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)