### PR TITLE
Show webhook events on worker detail page

### DIFF
--- a/frontend/src/pages/WorkerDetail.tsx
+++ b/frontend/src/pages/WorkerDetail.tsx
@@ -31,6 +31,7 @@ export default function WorkerDetail() {
           <thead>
             <tr>
               <th style={th}>Time</th>
+              <th style={th}>Kind</th>
               <th style={th}>Summary</th>
               <th style={th}>Task</th>
             </tr>
@@ -39,6 +40,7 @@ export default function WorkerDetail() {
             {messages.map((e) => (
               <tr key={`${e.kind}-${e.id}`}>
                 <td style={td}>{new Date(e.timestamp).toLocaleString()}</td>
+                <td style={td}>{e.kind}</td>
                 <td style={td}>{e.summary}</td>
                 <td style={td}>{e.taskId ? <Link to={`/tasks/${e.taskId}`}>#{e.taskId}</Link> : "—"}</td>
               </tr>

--- a/src/db.ts
+++ b/src/db.ts
@@ -158,12 +158,22 @@ export function createDbLogger(supabase: SupabaseClient): DbLogger {
     },
 
     async queryWorkerMessages(workerId) {
-      const { data } = await supabase.from("foreman_messages")
-        .select("id, created_at, direction, worker_id, task_id, msg_type")
-        .eq("worker_id", workerId)
-        .order("created_at", { ascending: false })
-        .limit(500);
-      return ((data ?? []) as Record<string, unknown>[]).map(messageToEntry);
+      const [wRes, mRes] = await Promise.all([
+        supabase.from("webhook_events")
+          .select("id, received_at, event_name, action, issue_number, task_id, worker_id")
+          .eq("worker_id", workerId)
+          .order("received_at", { ascending: false })
+          .limit(500),
+        supabase.from("foreman_messages")
+          .select("id, created_at, direction, worker_id, task_id, msg_type, payload")
+          .eq("worker_id", workerId)
+          .order("created_at", { ascending: false })
+          .limit(500),
+      ]);
+      const webhooks = ((wRes.data ?? []) as Record<string, unknown>[]).map(webhookToEntry);
+      const messages = ((mRes.data ?? []) as Record<string, unknown>[]).map(messageToEntry);
+      return [...webhooks, ...messages]
+        .sort((a, b) => b.timestamp.localeCompare(a.timestamp));
     },
   };
 }

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -85,17 +85,21 @@ describe("createDbLogger", () => {
 
 describe("messageToEntry summary for worker_disconnected", () => {
   function makeSupabaseReturning(rows: Record<string, unknown>[]) {
-    const builder = {
+    const makeBuilder = (data: Record<string, unknown>[]) => ({
       insert: vi.fn().mockResolvedValue({ error: null }),
       select: vi.fn().mockReturnThis(),
       order: vi.fn().mockReturnThis(),
       limit: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
       then: vi.fn().mockImplementation((cb: (v: { data: unknown[]; error: null }) => unknown) =>
-        Promise.resolve(cb({ data: rows, error: null }))
+        Promise.resolve(cb({ data, error: null }))
+      ),
+    });
+    return {
+      from: vi.fn().mockImplementation((t: string) =>
+        t === "foreman_messages" ? makeBuilder(rows) : makeBuilder([])
       ),
     };
-    return { from: vi.fn().mockReturnValue(builder) };
   }
 
   it("includes close code in summary for worker_disconnected with no reason", async () => {
@@ -236,6 +240,83 @@ describe("queryTaskEvents ordering", () => {
     expect(entries[0].timestamp).toBe("2026-03-27T03:00:00Z");
     expect(entries[1].timestamp).toBe("2026-03-27T02:00:00Z");
     expect(entries[2].timestamp).toBe("2026-03-27T01:00:00Z");
+  });
+});
+
+describe("queryWorkerMessages includes webhook events", () => {
+  function makeSupabaseTwoTables(
+    webhookRows: Record<string, unknown>[],
+    messageRows: Record<string, unknown>[],
+  ) {
+    const makeBuilder = (rows: Record<string, unknown>[]) => ({
+      select: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      then: vi.fn().mockImplementation((cb: (v: { data: unknown[]; error: null }) => unknown) =>
+        Promise.resolve(cb({ data: rows, error: null }))
+      ),
+    });
+    return {
+      from: vi.fn().mockImplementation((t: string) =>
+        t === "webhook_events" ? makeBuilder(webhookRows) : makeBuilder(messageRows)
+      ),
+    };
+  }
+
+  it("returns webhook events for a worker alongside foreman messages", async () => {
+    const supabase = makeSupabaseTwoTables(
+      [{
+        id: 10, received_at: "2026-03-27T01:00:00Z",
+        event_name: "issues", action: "labeled", issue_number: 42,
+        task_id: "42", worker_id: "w1",
+      }],
+      [{
+        id: 20, created_at: "2026-03-27T02:00:00Z",
+        direction: "sent", worker_id: "w1", task_id: "42",
+        msg_type: "task_assigned", payload: {},
+      }],
+    );
+    const logger = createDbLogger(supabase as unknown as Parameters<typeof createDbLogger>[0]);
+    const entries = await logger.queryWorkerMessages("w1");
+    const kinds = entries.map((e) => e.kind);
+    expect(kinds).toContain("webhook");
+    expect(kinds).toContain("message");
+  });
+
+  it("returns only entries matching the given worker_id", async () => {
+    const supabase = makeSupabaseTwoTables(
+      [{
+        id: 10, received_at: "2026-03-27T01:00:00Z",
+        event_name: "push", action: null, issue_number: null,
+        task_id: null, worker_id: "w1",
+      }],
+      [],
+    );
+    const logger = createDbLogger(supabase as unknown as Parameters<typeof createDbLogger>[0]);
+    const entries = await logger.queryWorkerMessages("w1");
+    expect(entries).toHaveLength(1);
+    expect(entries[0].kind).toBe("webhook");
+    expect(entries[0].workerId).toBe("w1");
+  });
+
+  it("returns entries sorted by timestamp descending", async () => {
+    const supabase = makeSupabaseTwoTables(
+      [{
+        id: 10, received_at: "2026-03-27T01:00:00Z",
+        event_name: "issues", action: "labeled", issue_number: 1,
+        task_id: null, worker_id: "w1",
+      }],
+      [{
+        id: 20, created_at: "2026-03-27T03:00:00Z",
+        direction: "sent", worker_id: "w1", task_id: null,
+        msg_type: "standby", payload: {},
+      }],
+    );
+    const logger = createDbLogger(supabase as unknown as Parameters<typeof createDbLogger>[0]);
+    const entries = await logger.queryWorkerMessages("w1");
+    expect(entries[0].timestamp).toBe("2026-03-27T03:00:00Z");
+    expect(entries[1].timestamp).toBe("2026-03-27T01:00:00Z");
   });
 });
 


### PR DESCRIPTION
## Summary

- `queryWorkerMessages` now queries both `webhook_events` and `foreman_messages` by `worker_id`, merging and sorting by timestamp — matching the pattern used by `queryTaskEvents`
- Worker detail page gains a **Kind** column to distinguish `webhook` vs `message` entries

## Test plan

- [x] New tests verify `queryWorkerMessages` returns both webhook and message entries, filters by `worker_id`, and sorts descending by timestamp
- [x] All 992 tests pass, type check clean, lint clean

Closes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)