### PR TITLE
fix: send recent events to new dashboard clients via WebSocket buffer

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useCallback } from "react";
 import { Link } from "react-router-dom";
 import { useAdminWs } from "../hooks/useAdminWs.ts";
 import type { TaskSnapshot, WorkerSnapshot, LogEntry, AdminMessage } from "../types.ts";
@@ -8,17 +8,12 @@ export default function Dashboard() {
   const [workers, setWorkers] = useState<WorkerSnapshot[]>([]);
   const [recentLog, setRecentLog] = useState<LogEntry[]>([]);
 
-  useEffect(() => {
-    fetch("/api/log")
-      .then((r) => r.json() as Promise<LogEntry[]>)
-      .then(setRecentLog)
-      .catch(console.error);
-  }, []);
-
   const handleMessage = useCallback((msg: AdminMessage) => {
     if (msg.type === "snapshot") {
       setTasks(msg.tasks);
       setWorkers(msg.workers);
+    } else if (msg.type === "initial_log") {
+      setRecentLog(msg.entries.slice(0, 50));
     } else if (msg.type === "log_event") {
       setRecentLog((prev) => [msg.entry, ...prev].slice(0, 50));
     }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -23,4 +23,5 @@ export interface LogEntry {
 
 export type AdminMessage =
   | { type: "snapshot"; tasks: TaskSnapshot[]; workers: WorkerSnapshot[] }
+  | { type: "initial_log"; entries: LogEntry[] }
   | { type: "log_event"; entry: LogEntry };

--- a/frontend/tests/Dashboard.test.tsx
+++ b/frontend/tests/Dashboard.test.tsx
@@ -48,37 +48,37 @@ describe("Dashboard", () => {
     vi.restoreAllMocks();
   });
 
-  it("fetches from /api/log on mount", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([]) }));
+  it("shows empty state when no events", () => {
     renderDashboard();
-    await waitFor(() => expect(fetch).toHaveBeenCalledWith("/api/log"));
+    expect(screen.getByText("No events yet.")).toBeInTheDocument();
   });
 
-  it("shows empty state when no events", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([]) }));
+  it("renders events from initial_log WebSocket message", async () => {
     renderDashboard();
-    await waitFor(() => expect(screen.getByText("No events yet.")).toBeInTheDocument());
-  });
-
-  it("renders historical events loaded from the API", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([webhookEntry, messageEntry]) }));
-    renderDashboard();
-    await waitFor(() => expect(screen.getByText("issues/labeled #42")).toBeInTheDocument());
+    act(() => {
+      capturedHandler!({ type: "initial_log", entries: [webhookEntry, messageEntry] });
+    });
+    expect(screen.getByText("issues/labeled #42")).toBeInTheDocument();
     expect(screen.getByText("sent task_assigned")).toBeInTheDocument();
   });
 
-  it("shows both webhook and message kinds from API", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([webhookEntry, messageEntry]) }));
+  it("shows both webhook and message kinds from initial_log", async () => {
     renderDashboard();
-    await waitFor(() => expect(screen.getByText("webhook")).toBeInTheDocument());
+    act(() => {
+      capturedHandler!({ type: "initial_log", entries: [webhookEntry, messageEntry] });
+    });
+    expect(screen.getByText("webhook")).toBeInTheDocument();
     expect(screen.getByText("message")).toBeInTheDocument();
   });
 
-  it("prepends new log_event messages from WebSocket to historical events", async () => {
+  it("prepends new log_event messages to events from initial_log", async () => {
     const newEntry: LogEntry = { kind: "message", id: 3, timestamp: "2026-01-01T10:02:00.000Z", taskId: null, workerId: "worker-abc-123", summary: "received worker_hello" };
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([webhookEntry]) }));
     renderDashboard();
-    await waitFor(() => expect(screen.getByText("issues/labeled #42")).toBeInTheDocument());
+
+    act(() => {
+      capturedHandler!({ type: "initial_log", entries: [webhookEntry] });
+    });
+    expect(screen.getByText("issues/labeled #42")).toBeInTheDocument();
 
     act(() => {
       capturedHandler!({ type: "log_event", entry: newEntry });
@@ -89,14 +89,33 @@ describe("Dashboard", () => {
   });
 
   it("does not add events to log on snapshot messages", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([]) }));
     renderDashboard();
-    await waitFor(() => expect(screen.getByText("No events yet.")).toBeInTheDocument());
-
     act(() => {
       capturedHandler!({ type: "snapshot", tasks: [], workers: [] });
     });
-
     expect(screen.getByText("No events yet.")).toBeInTheDocument();
+  });
+
+  it("replaces existing events when a new initial_log arrives (reconnect)", async () => {
+    const freshEntry: LogEntry = { kind: "webhook", id: 10, timestamp: "2026-01-02T00:00:00.000Z", taskId: null, workerId: null, summary: "new event after reconnect" };
+    renderDashboard();
+
+    act(() => {
+      capturedHandler!({ type: "initial_log", entries: [webhookEntry] });
+    });
+    expect(screen.getByText("issues/labeled #42")).toBeInTheDocument();
+
+    act(() => {
+      capturedHandler!({ type: "initial_log", entries: [freshEntry] });
+    });
+    expect(screen.getByText("new event after reconnect")).toBeInTheDocument();
+    expect(screen.queryByText("issues/labeled #42")).not.toBeInTheDocument();
+  });
+
+  it("does not fetch from /api/log on mount", () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    renderDashboard();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/src/admin-ws.ts
+++ b/src/admin-ws.ts
@@ -32,6 +32,7 @@ export interface AdminSnapshot {
 
 export type AdminMessage =
   | { type: "snapshot"; tasks: TaskSnapshot[]; workers: WorkerSnapshot[] }
+  | { type: "initial_log"; entries: LogEntry[] }
   | { type: "log_event"; entry: LogEntry };
 
 export interface AdminWss {
@@ -39,8 +40,11 @@ export interface AdminWss {
   broadcastLogEvent(entry: LogEntry): void;
 }
 
+const MAX_RECENT_LOG = 30;
+
 export function createAdminWss(server: http.Server, getSnapshot?: () => AdminSnapshot): AdminWss {
   const clients = new Set<WsSocket>();
+  const recentLog: LogEntry[] = []; // newest first, capped at MAX_RECENT_LOG
   const wss = new WebSocketServer({ noServer: true });
 
   wss.on("connection", (ws) => {
@@ -49,6 +53,7 @@ export function createAdminWss(server: http.Server, getSnapshot?: () => AdminSna
       const snapshot = getSnapshot();
       ws.send(JSON.stringify({ type: "snapshot", ...snapshot } satisfies AdminMessage));
     }
+    ws.send(JSON.stringify({ type: "initial_log", entries: recentLog.slice() } satisfies AdminMessage));
     ws.on("close", () => clients.delete(ws));
   });
 
@@ -71,6 +76,8 @@ export function createAdminWss(server: http.Server, getSnapshot?: () => AdminSna
       broadcast({ type: "snapshot", ...snapshot });
     },
     broadcastLogEvent(entry) {
+      recentLog.unshift(entry);
+      if (recentLog.length > MAX_RECENT_LOG) recentLog.pop();
       broadcast({ type: "log_event", entry });
     },
   };

--- a/tests/admin-ws.test.ts
+++ b/tests/admin-ws.test.ts
@@ -4,7 +4,7 @@ import net from "net";
 import { WebSocket } from "ws";
 import type { AddressInfo } from "net";
 import { createAdminWss } from "../src/admin-ws.js";
-import type { AdminMessage } from "../src/admin-ws.js";
+import type { AdminMessage, LogEntry } from "../src/admin-ws.js";
 
 function startServer(): Promise<{ server: http.Server; port: number; adminWss: ReturnType<typeof createAdminWss> }> {
   return new Promise((resolve) => {
@@ -40,6 +40,37 @@ function nextMsg(ws: WebSocket): Promise<AdminMessage> {
   });
 }
 
+/** Collects all messages until one matching `type` is found, then resolves with it.
+ *  Must be registered BEFORE the connection opens to avoid missing early messages. */
+function waitForMsgType<T extends AdminMessage["type"]>(ws: WebSocket, type: T): Promise<Extract<AdminMessage, { type: T }>> {
+  return new Promise((resolve) => {
+    function handler(d: Buffer | string) {
+      const msg = JSON.parse(d.toString()) as AdminMessage;
+      if (msg.type === type) {
+        ws.off("message", handler);
+        resolve(msg as Extract<AdminMessage, { type: T }>);
+      }
+    }
+    ws.on("message", handler);
+  });
+}
+
+/** Collects the first N messages.
+ *  Must be registered BEFORE the connection opens to avoid missing early messages. */
+function collectFirstN(ws: WebSocket, n: number): Promise<AdminMessage[]> {
+  return new Promise((resolve) => {
+    const msgs: AdminMessage[] = [];
+    function handler(d: Buffer | string) {
+      msgs.push(JSON.parse(d.toString()) as AdminMessage);
+      if (msgs.length >= n) {
+        ws.off("message", handler);
+        resolve(msgs);
+      }
+    }
+    ws.on("message", handler);
+  });
+}
+
 function closeAll(...ws: WebSocket[]): Promise<void> {
   return Promise.all(ws.map((w) => new Promise<void>((r) => {
     if (w.readyState === WebSocket.CLOSED) { r(); return; }
@@ -47,6 +78,11 @@ function closeAll(...ws: WebSocket[]): Promise<void> {
     w.close();
   }))).then(() => {});
 }
+
+const sampleEntry: LogEntry = {
+  kind: "webhook", id: 1, timestamp: "2026-01-01T00:00:00Z",
+  taskId: null, workerId: null, summary: "issues/labeled #1",
+};
 
 describe("createAdminWss", () => {
   const servers: http.Server[] = [];
@@ -59,7 +95,7 @@ describe("createAdminWss", () => {
     const { server, port, adminWss } = await startServer();
     servers.push(server);
     const ws = await connectAdmin(port);
-    const msgP = nextMsg(ws);
+    const msgP = waitForMsgType(ws, "snapshot");
     adminWss.broadcastSnapshot({ tasks: [], workers: [] });
     const msg = await msgP;
     expect(msg).toEqual({ type: "snapshot", tasks: [], workers: [] });
@@ -70,10 +106,10 @@ describe("createAdminWss", () => {
     const { server, port, adminWss } = await startServer();
     servers.push(server);
     const ws = await connectAdmin(port);
-    const msgP = nextMsg(ws);
-    adminWss.broadcastLogEvent({ kind: "webhook", id: 1, timestamp: "2026-01-01T00:00:00Z", taskId: null, workerId: null, summary: "issues/labeled #1" });
+    const msgP = waitForMsgType(ws, "log_event");
+    adminWss.broadcastLogEvent(sampleEntry);
     const msg = await msgP;
-    expect(msg).toEqual({ type: "log_event", entry: { kind: "webhook", id: 1, timestamp: "2026-01-01T00:00:00Z", taskId: null, workerId: null, summary: "issues/labeled #1" } });
+    expect(msg).toEqual({ type: "log_event", entry: sampleEntry });
     await closeAll(ws);
   });
 
@@ -81,7 +117,7 @@ describe("createAdminWss", () => {
     const { server, port, adminWss } = await startServer();
     servers.push(server);
     const [ws1, ws2] = await Promise.all([connectAdmin(port), connectAdmin(port)]);
-    const [p1, p2] = [nextMsg(ws1), nextMsg(ws2)];
+    const [p1, p2] = [waitForMsgType(ws1, "snapshot"), waitForMsgType(ws2, "snapshot")];
     adminWss.broadcastSnapshot({ tasks: [], workers: [] });
     const [m1, m2] = await Promise.all([p1, p2]);
     expect(m1.type).toBe("snapshot");
@@ -99,6 +135,62 @@ describe("createAdminWss", () => {
     await new Promise<void>((resolve, reject) => { ws.once("open", resolve); ws.once("error", reject); });
     const msg = await msgP;
     expect(msg).toEqual({ type: "snapshot", ...snapshot });
+    await closeAll(ws);
+  });
+
+  it("sends initial_log with empty entries to a newly connected client when no events have been broadcast", async () => {
+    const { server, port } = await startServer();
+    servers.push(server);
+    const ws = new WebSocket(`ws://localhost:${port}/admin/ws`);
+    const msgP = waitForMsgType(ws, "initial_log");
+    await new Promise<void>((resolve, reject) => { ws.once("open", resolve); ws.once("error", reject); });
+    const msg = await msgP;
+    expect(msg).toEqual({ type: "initial_log", entries: [] });
+    await closeAll(ws);
+  });
+
+  it("sends initial_log with recently broadcast events to a newly connected client", async () => {
+    const { server, port, adminWss } = await startServer();
+    servers.push(server);
+    // Broadcast events before any client connects — they go into the buffer
+    adminWss.broadcastLogEvent(sampleEntry);
+    const ws = new WebSocket(`ws://localhost:${port}/admin/ws`);
+    const msgP = waitForMsgType(ws, "initial_log");
+    await new Promise<void>((resolve, reject) => { ws.once("open", resolve); ws.once("error", reject); });
+    const msg = await msgP;
+    expect(msg).toEqual({ type: "initial_log", entries: [sampleEntry] });
+    await closeAll(ws);
+  });
+
+  it("initial_log buffer is capped at 30 entries (newest first)", async () => {
+    const { server, port, adminWss } = await startServer();
+    servers.push(server);
+    // Broadcast 35 events — only last 30 should appear in initial_log
+    for (let i = 1; i <= 35; i++) {
+      adminWss.broadcastLogEvent({ kind: "webhook", id: i, timestamp: `2026-01-01T00:00:${String(i).padStart(2, "0")}Z`, taskId: null, workerId: null, summary: `event ${i}` });
+    }
+    const ws = new WebSocket(`ws://localhost:${port}/admin/ws`);
+    const msgP = waitForMsgType(ws, "initial_log");
+    await new Promise<void>((resolve, reject) => { ws.once("open", resolve); ws.once("error", reject); });
+    const msg = await msgP;
+    expect(msg.entries).toHaveLength(30);
+    // Newest event (id 35) should be first
+    expect(msg.entries[0].id).toBe(35);
+    // Oldest in buffer (id 6) should be last
+    expect(msg.entries[29].id).toBe(6);
+    await closeAll(ws);
+  });
+
+  it("sends initial_log after snapshot when getSnapshot is provided", async () => {
+    const snapshot = { tasks: [], workers: [] };
+    const { server, port } = await startServerWithSnapshot(() => snapshot);
+    servers.push(server);
+    const ws = new WebSocket(`ws://localhost:${port}/admin/ws`);
+    const msgsP = collectFirstN(ws, 2);
+    await new Promise<void>((resolve, reject) => { ws.once("open", resolve); ws.once("error", reject); });
+    const msgs = await msgsP;
+    expect(msgs[0]).toEqual({ type: "snapshot", ...snapshot });
+    expect(msgs[1]).toEqual({ type: "initial_log", entries: [] });
     await closeAll(ws);
   });
 


### PR DESCRIPTION
## Summary

- The dashboard's Recent Events section was empty on load because it relied on a separate `/api/log` HTTP fetch that fails silently when the DB is not configured
- Added an in-memory ring buffer (last 30 entries) to `createAdminWss` in `src/admin-ws.ts`
- When a new WebSocket client connects, it now receives an `initial_log` message with buffered recent events (after the snapshot)
- Dashboard handles the new `initial_log` message type to populate Recent Events, replacing the unreliable fetch

## Test plan

- [ ] All 993 tests pass (`npm test`)
- [ ] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] `tests/admin-ws.test.ts`: 4 new tests verify buffer behavior (cap at 30, newest-first, sent on connect, ordering after snapshot)
- [ ] `frontend/tests/Dashboard.test.tsx`: updated to test `initial_log` handling instead of `/api/log` fetch

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)