### PR TITLE
feat: richer detail in event log summaries

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { fmtEvent } from "./display.js";
 
 // ── Input types ────────────────────────────────────────────────────────────────
 
@@ -61,24 +62,34 @@ export function createDbLogger(supabase: SupabaseClient): DbLogger {
   }
 
   function webhookToEntry(row: Record<string, unknown>): LogEntry {
-    const action = row.action ? `/${row.action}` : "";
-    const issue = row.issue_number ? ` #${row.issue_number}` : "";
+    const storedPayload = (row.payload ?? {}) as Record<string, unknown>;
+    // Merge row-level action as fallback for old rows without stored payload
+    const payload: Record<string, unknown> = { action: row.action, ...storedPayload };
+    const summary = fmtEvent({ id: String(row.delivery_id ?? ""), name: String(row.event_name), payload });
     return {
       kind: "webhook",
       id: row.id as number,
       timestamp: row.received_at as string,
       taskId: (row.task_id as string | null) ?? null,
       workerId: (row.worker_id as string | null) ?? null,
-      summary: `${row.event_name}${action}${issue}`,
+      summary,
     };
   }
 
   function messageToEntry(row: Record<string, unknown>): LogEntry {
+    const payload = (row.payload ?? {}) as Record<string, unknown>;
     let summary: string;
     if (row.msg_type === "worker_disconnected") {
-      const payload = (row.payload ?? {}) as Record<string, unknown>;
       const reason = payload.reason ? `: ${payload.reason}` : "";
       summary = `disconnected (code ${payload.code}${reason})`;
+    } else if (row.msg_type === "worker_hello") {
+      const status = String(payload.status ?? "");
+      const taskId = payload.taskId ? ` task=#${payload.taskId}` : "";
+      summary = `${row.direction} worker_hello — ${status}${taskId}`;
+    } else if (row.msg_type === "event_notification") {
+      const event = (payload.event ?? {}) as Record<string, unknown>;
+      const eventName = event.name ? ` — ${event.name}` : "";
+      summary = `${row.direction} event_notification${eventName}`;
     } else {
       summary = `${row.direction} ${row.msg_type}`;
     }
@@ -123,7 +134,7 @@ export function createDbLogger(supabase: SupabaseClient): DbLogger {
       const limit = opts.limit ?? 100;
       const [wRes, mRes] = await Promise.all([
         supabase.from("webhook_events")
-          .select("id, received_at, event_name, action, issue_number, task_id, worker_id")
+          .select("id, received_at, delivery_id, event_name, action, issue_number, task_id, worker_id, payload")
           .order("received_at", { ascending: false })
           .limit(limit),
         supabase.from("foreman_messages")
@@ -141,7 +152,7 @@ export function createDbLogger(supabase: SupabaseClient): DbLogger {
     async queryTaskEvents(taskId) {
       const [wRes, mRes] = await Promise.all([
         supabase.from("webhook_events")
-          .select("id, received_at, event_name, action, issue_number, task_id, worker_id")
+          .select("id, received_at, delivery_id, event_name, action, issue_number, task_id, worker_id, payload")
           .eq("task_id", taskId)
           .order("received_at", { ascending: false })
           .limit(500),
@@ -160,7 +171,7 @@ export function createDbLogger(supabase: SupabaseClient): DbLogger {
     async queryWorkerMessages(workerId) {
       const [wRes, mRes] = await Promise.all([
         supabase.from("webhook_events")
-          .select("id, received_at, event_name, action, issue_number, task_id, worker_id")
+          .select("id, received_at, delivery_id, event_name, action, issue_number, task_id, worker_id, payload")
           .eq("worker_id", workerId)
           .order("received_at", { ascending: false })
           .limit(500),

--- a/src/display.ts
+++ b/src/display.ts
@@ -156,6 +156,15 @@ export function fmtEventDetails(event: GitHubEvent): string {
       const status = str(run.conclusion || run.status);
       return `"${str(run.name)}" ${status}`.trim();
     }
+    case "delete": {
+      const refType = str(p.ref_type);
+      const ref = str(p.ref);
+      return `${refType} ${ref}`.trim();
+    }
+    case "issues": {
+      const label = asObj(p.label) as { name?: string } | null;
+      return label?.name ? `label: ${label.name}` : "";
+    }
     default:
       return "";
   }

--- a/src/foreman.ts
+++ b/src/foreman.ts
@@ -7,7 +7,7 @@ import { WebSocketServer, WebSocket } from "ws";
 import type { WebSocket as WsSocket } from "ws";
 import type { WorkerMessage, ForemanMessage, GitHubEvent, TaskIssue, LabeledIssueState } from "./types.js";
 import { labelIssueDone } from "./github.js";
-import { fmtTimestamp, setVerbose } from "./display.js";
+import { fmtTimestamp, fmtEvent, setVerbose } from "./display.js";
 import { loadConfig } from "./config.js";
 import { isBlocked, setBlockers, fetchBlockers } from "./dependencies.js";
 import { fetchIssueStates } from "./github.js";
@@ -490,11 +490,19 @@ export function createForemanWss(
 
   function broadcastMessageEvent(data: { direction: string; workerId: string | null; taskId: string | null; msgType: string; payload?: Record<string, unknown> }) {
     if (!adminWss) return;
+    const payload = data.payload ?? {};
     let summary: string;
     if (data.msgType === "worker_disconnected") {
-      const payload = data.payload ?? {};
       const reason = payload.reason ? `: ${payload.reason}` : "";
       summary = `disconnected (code ${payload.code}${reason})`;
+    } else if (data.msgType === "worker_hello") {
+      const status = String(payload.status ?? "");
+      const taskId = payload.taskId ? ` task=#${payload.taskId}` : "";
+      summary = `${data.direction} worker_hello — ${status}${taskId}`;
+    } else if (data.msgType === "event_notification") {
+      const event = (payload.event ?? {}) as Record<string, unknown>;
+      const eventName = event.name ? ` — ${event.name}` : "";
+      summary = `${data.direction} event_notification${eventName}`;
     } else {
       summary = `${data.direction} ${data.msgType}`;
     }
@@ -511,8 +519,9 @@ export function createForemanWss(
   function sendMsg(workerId: string, msg: ForemanMessage): void {
     const taskId = "taskId" in msg ? msg.taskId : null;
     registry.send(workerId, msg);
-    dbLogger?.logForemanMessage({ direction: "sent", workerId, taskId, msgType: msg.type, payload: msg as unknown as Record<string, unknown> });
-    broadcastMessageEvent({ direction: "sent", workerId, taskId, msgType: msg.type });
+    const msgPayload = msg as unknown as Record<string, unknown>;
+    dbLogger?.logForemanMessage({ direction: "sent", workerId, taskId, msgType: msg.type, payload: msgPayload });
+    broadcastMessageEvent({ direction: "sent", workerId, taskId, msgType: msg.type, payload: msgPayload });
   }
 
   function log(wid: string, line: string) {
@@ -749,7 +758,7 @@ export function createForemanWss(
       timestamp: new Date().toISOString(),
       taskId,
       workerId,
-      summary: `${name}${action ? `/${action}` : ""}${webhookIssueNumber ? ` #${webhookIssueNumber}` : ""}`,
+      summary: fmtEvent(evt),
     });
   }
 
@@ -908,14 +917,15 @@ export function createForemanWss(
       // Log all received messages
       const rcvWorkerId = workerId || ((msg as { workerId?: string }).workerId ?? null);
       const rcvTaskId = (msg as { taskId?: string }).taskId ?? null;
+      const rcvPayload = msg as unknown as Record<string, unknown>;
       dbLogger?.logForemanMessage({
         direction: "received",
         workerId: rcvWorkerId,
         taskId: rcvTaskId,
         msgType: msg.type,
-        payload: msg as unknown as Record<string, unknown>,
+        payload: rcvPayload,
       });
-      broadcastMessageEvent({ direction: "received", workerId: rcvWorkerId, taskId: rcvTaskId, msgType: msg.type });
+      broadcastMessageEvent({ direction: "received", workerId: rcvWorkerId, taskId: rcvTaskId, msgType: msg.type, payload: rcvPayload });
 
       if (msg.type === "worker_hello") handleWorkerHello(msg);
       else if (msg.type === "task_complete") handleTaskComplete(msg);

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -320,6 +320,171 @@ describe("queryWorkerMessages includes webhook events", () => {
   });
 });
 
+describe("webhookToEntry richer summaries", () => {
+  function makeSupabaseWithWebhookRow(row: Record<string, unknown>) {
+    const makeBuilder = (data: Record<string, unknown>[]) => ({
+      insert: vi.fn().mockResolvedValue({ error: null }),
+      select: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      then: vi.fn().mockImplementation((cb: (v: { data: unknown[]; error: null }) => unknown) =>
+        Promise.resolve(cb({ data, error: null }))
+      ),
+    });
+    return {
+      from: vi.fn().mockImplementation((t: string) =>
+        t === "webhook_events" ? makeBuilder([row]) : makeBuilder([])
+      ),
+    };
+  }
+
+  it("includes check run name and conclusion for check_run/completed", async () => {
+    const supabase = makeSupabaseWithWebhookRow({
+      id: 1, received_at: "2026-03-27T00:00:00Z",
+      event_name: "check_run", action: "completed", issue_number: null,
+      task_id: "42", worker_id: null,
+      payload: { action: "completed", check_run: { name: "CI / build", conclusion: "success" } },
+    });
+    const logger = createDbLogger(supabase as unknown as Parameters<typeof createDbLogger>[0]);
+    const entries = await logger.queryLog({});
+    expect(entries[0].summary).toContain("CI / build");
+    expect(entries[0].summary).toContain("success");
+  });
+
+  it("includes branch ref for push events", async () => {
+    const supabase = makeSupabaseWithWebhookRow({
+      id: 1, received_at: "2026-03-27T00:00:00Z",
+      event_name: "push", action: null, issue_number: null,
+      task_id: null, worker_id: null,
+      payload: { ref: "refs/heads/main", commits: [{}, {}] },
+    });
+    const logger = createDbLogger(supabase as unknown as Parameters<typeof createDbLogger>[0]);
+    const entries = await logger.queryLog({});
+    expect(entries[0].summary).toContain("refs/heads/main");
+  });
+
+  it("includes PR number and title for pull_request events", async () => {
+    const supabase = makeSupabaseWithWebhookRow({
+      id: 1, received_at: "2026-03-27T00:00:00Z",
+      event_name: "pull_request", action: "closed", issue_number: null,
+      task_id: "42", worker_id: null,
+      payload: { action: "closed", pull_request: { number: 10, title: "Fix the bug" } },
+    });
+    const logger = createDbLogger(supabase as unknown as Parameters<typeof createDbLogger>[0]);
+    const entries = await logger.queryLog({});
+    expect(entries[0].summary).toContain("10");
+    expect(entries[0].summary).toContain("Fix the bug");
+  });
+
+  it("includes label name for issues/labeled events", async () => {
+    const supabase = makeSupabaseWithWebhookRow({
+      id: 1, received_at: "2026-03-27T00:00:00Z",
+      event_name: "issues", action: "labeled", issue_number: 42,
+      task_id: "42", worker_id: null,
+      payload: { action: "labeled", issue: { number: 42, title: "Fix" }, label: { name: "bug" } },
+    });
+    const logger = createDbLogger(supabase as unknown as Parameters<typeof createDbLogger>[0]);
+    const entries = await logger.queryLog({});
+    expect(entries[0].summary).toContain("bug");
+  });
+
+  it("includes ref_type and ref for delete events", async () => {
+    const supabase = makeSupabaseWithWebhookRow({
+      id: 1, received_at: "2026-03-27T00:00:00Z",
+      event_name: "delete", action: null, issue_number: null,
+      task_id: null, worker_id: null,
+      payload: { ref_type: "branch", ref: "feature/old" },
+    });
+    const logger = createDbLogger(supabase as unknown as Parameters<typeof createDbLogger>[0]);
+    const entries = await logger.queryLog({});
+    expect(entries[0].summary).toContain("branch");
+    expect(entries[0].summary).toContain("feature/old");
+  });
+
+  it("includes comment text for issue_comment events", async () => {
+    const supabase = makeSupabaseWithWebhookRow({
+      id: 1, received_at: "2026-03-27T00:00:00Z",
+      event_name: "issue_comment", action: "created", issue_number: 42,
+      task_id: "42", worker_id: null,
+      payload: { action: "created", comment: { body: "LGTM!" } },
+    });
+    const logger = createDbLogger(supabase as unknown as Parameters<typeof createDbLogger>[0]);
+    const entries = await logger.queryLog({});
+    expect(entries[0].summary).toContain("LGTM!");
+  });
+
+  it("falls back gracefully for rows without payload", async () => {
+    const supabase = makeSupabaseWithWebhookRow({
+      id: 1, received_at: "2026-03-27T00:00:00Z",
+      event_name: "issues", action: "labeled", issue_number: 42,
+      task_id: "42", worker_id: null,
+      payload: null,
+    });
+    const logger = createDbLogger(supabase as unknown as Parameters<typeof createDbLogger>[0]);
+    const entries = await logger.queryLog({});
+    expect(entries[0].summary).toContain("issues");
+    expect(entries[0].summary).toContain("labeled");
+  });
+});
+
+describe("messageToEntry richer summaries", () => {
+  function makeSupabaseWithMessageRow(row: Record<string, unknown>) {
+    const makeBuilder = (data: Record<string, unknown>[]) => ({
+      insert: vi.fn().mockResolvedValue({ error: null }),
+      select: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      then: vi.fn().mockImplementation((cb: (v: { data: unknown[]; error: null }) => unknown) =>
+        Promise.resolve(cb({ data, error: null }))
+      ),
+    });
+    return {
+      from: vi.fn().mockImplementation((t: string) =>
+        t === "foreman_messages" ? makeBuilder([row]) : makeBuilder([])
+      ),
+    };
+  }
+
+  it("includes 'idle' status for worker_hello when idle", async () => {
+    const supabase = makeSupabaseWithMessageRow({
+      id: 1, created_at: "2026-03-27T00:00:00Z",
+      direction: "received", worker_id: "w1", task_id: null,
+      msg_type: "worker_hello",
+      payload: { type: "worker_hello", workerId: "w1", status: "idle" },
+    });
+    const logger = createDbLogger(supabase as unknown as Parameters<typeof createDbLogger>[0]);
+    const entries = await logger.queryWorkerMessages("w1");
+    expect(entries[0].summary).toContain("idle");
+  });
+
+  it("includes 'busy' status and taskId for worker_hello when busy", async () => {
+    const supabase = makeSupabaseWithMessageRow({
+      id: 1, created_at: "2026-03-27T00:00:00Z",
+      direction: "received", worker_id: "w1", task_id: "42",
+      msg_type: "worker_hello",
+      payload: { type: "worker_hello", workerId: "w1", status: "busy", taskId: "42" },
+    });
+    const logger = createDbLogger(supabase as unknown as Parameters<typeof createDbLogger>[0]);
+    const entries = await logger.queryWorkerMessages("w1");
+    expect(entries[0].summary).toContain("busy");
+    expect(entries[0].summary).toContain("42");
+  });
+
+  it("includes the forwarded event name for event_notification", async () => {
+    const supabase = makeSupabaseWithMessageRow({
+      id: 1, created_at: "2026-03-27T00:00:00Z",
+      direction: "sent", worker_id: "w1", task_id: "42",
+      msg_type: "event_notification",
+      payload: { type: "event_notification", taskId: "42", event: { id: "e1", name: "check_run", payload: { action: "completed" } } },
+    });
+    const logger = createDbLogger(supabase as unknown as Parameters<typeof createDbLogger>[0]);
+    const entries = await logger.queryWorkerMessages("w1");
+    expect(entries[0].summary).toContain("check_run");
+  });
+});
+
 describe("createNullDbLogger", () => {
   it("logWebhookEvent is a no-op", () => {
     const logger = createNullDbLogger();

--- a/tests/display.event-details.test.ts
+++ b/tests/display.event-details.test.ts
@@ -182,10 +182,59 @@ describe("fmtEventDetails - workflow_run", () => {
   });
 });
 
+describe("fmtEventDetails - delete", () => {
+  it("includes ref_type and ref for a branch deletion", () => {
+    const event: GitHubEvent = {
+      id: "evt-12",
+      name: "delete",
+      payload: { ref_type: "branch", ref: "feature/my-branch" },
+    };
+    const result = fmtEventDetails(event);
+    expect(result).toContain("branch");
+    expect(result).toContain("feature/my-branch");
+  });
+
+  it("includes ref_type and ref for a tag deletion", () => {
+    const event: GitHubEvent = {
+      id: "evt-13",
+      name: "delete",
+      payload: { ref_type: "tag", ref: "v1.2.3" },
+    };
+    const result = fmtEventDetails(event);
+    expect(result).toContain("tag");
+    expect(result).toContain("v1.2.3");
+  });
+});
+
+describe("fmtEventDetails - issues labeled", () => {
+  it("includes label name for issues/labeled", () => {
+    const event: GitHubEvent = {
+      id: "evt-14",
+      name: "issues",
+      payload: {
+        action: "labeled",
+        label: { name: "bug" },
+        issue: { number: 42, title: "Something broken" },
+      },
+    };
+    const result = fmtEventDetails(event);
+    expect(result).toContain("bug");
+  });
+
+  it("returns empty string for issues events without a label", () => {
+    const event: GitHubEvent = {
+      id: "evt-15",
+      name: "issues",
+      payload: { action: "closed", issue: { number: 42, title: "Something" } },
+    };
+    expect(fmtEventDetails(event)).toBe("");
+  });
+});
+
 describe("fmtEventDetails - unknown event", () => {
   it("returns empty string for unknown event types", () => {
     const event: GitHubEvent = {
-      id: "evt-12",
+      id: "evt-16",
       name: "some_unknown_event",
       payload: {},
     };

--- a/tests/foreman.admin-broadcast.test.ts
+++ b/tests/foreman.admin-broadcast.test.ts
@@ -152,6 +152,62 @@ describe("foreman admin broadcast — webhook events", () => {
     expect(adminWss.logEntries[0].taskId).toBe("42");
     expect(adminWss.logEntries[0].summary).toMatch(/issue_comment/);
   });
+
+  it("broadcasts check_run event with name and conclusion", () => {
+    routeEvent("evt-1", "check_run", {
+      action: "completed",
+      check_run: { name: "CI / build", conclusion: "success", pull_requests: [] },
+      repository: { html_url: "https://github.com/owner/repo" },
+    });
+
+    expect(adminWss.logEntries[0].summary).toContain("CI / build");
+    expect(adminWss.logEntries[0].summary).toContain("success");
+  });
+
+  it("broadcasts issue_comment event with truncated comment text", () => {
+    queue.addTask({ taskId: "42", issueNumber: 42, title: "Fix", body: "", labels: [], repoUrl: "https://github.com/owner/repo" });
+
+    routeEvent("evt-1", "issue_comment", {
+      action: "created",
+      issue: { number: 42 },
+      comment: { body: "Looks good to me!" },
+      repository: { html_url: "https://github.com/owner/repo" },
+    });
+
+    expect(adminWss.logEntries[0].summary).toContain("Looks good to me!");
+  });
+
+  it("broadcasts push event with branch", () => {
+    routeEvent("evt-1", "push", {
+      ref: "refs/heads/main",
+      commits: [{}],
+      repository: { html_url: "https://github.com/owner/repo" },
+    });
+
+    expect(adminWss.logEntries[0].summary).toContain("refs/heads/main");
+  });
+
+  it("broadcasts delete event with ref_type and ref", () => {
+    routeEvent("evt-1", "delete", {
+      ref_type: "branch",
+      ref: "feature/old",
+      repository: { html_url: "https://github.com/owner/repo" },
+    });
+
+    expect(adminWss.logEntries[0].summary).toContain("branch");
+    expect(adminWss.logEntries[0].summary).toContain("feature/old");
+  });
+
+  it("broadcasts issues/labeled event with label name", () => {
+    routeEvent("evt-1", "issues", {
+      action: "labeled",
+      label: { name: "wontfix" },
+      issue: { number: 5, title: "Minor thing", body: "", labels: [] },
+      repository: { html_url: "https://github.com/owner/repo" },
+    });
+
+    expect(adminWss.logEntries[0].summary).toContain("wontfix");
+  });
 });
 
 describe("foreman admin broadcast — sent messages", () => {
@@ -193,6 +249,18 @@ describe("foreman admin broadcast — received messages", () => {
       (e) => e.kind === "message" && e.summary.includes("received") && e.summary.includes("worker_hello"),
     );
     expect(received.length).toBeGreaterThan(0);
+  });
+
+  it("broadcasts worker_hello with 'idle' status in summary", async () => {
+    const ws = await connect();
+    const reply = nextMsg(ws);
+    send(ws, { type: "worker_hello", workerId: "worker-abc", status: "idle" });
+    await reply;
+
+    const hello = adminWss.logEntries.find(
+      (e) => e.kind === "message" && e.summary.includes("worker_hello"),
+    );
+    expect(hello?.summary).toContain("idle");
   });
 
   it("broadcasts received task_complete as kind='message'", async () => {

--- a/tests/foreman.event-forwarding-logging.test.ts
+++ b/tests/foreman.event-forwarding-logging.test.ts
@@ -200,6 +200,24 @@ describe("forwardEvent — admin broadcast of event_notification messages", () =
     expect(evtEntry?.taskId).toBe("42");
     expect(evtEntry?.workerId).toBe("worker-abc");
   });
+
+  it("includes the forwarded event name in the event_notification summary", () => {
+    setupAssignedWorker("42", "worker-abc");
+
+    adminWss.logEntries.length = 0;
+
+    routeEvent("evt-1", "issue_comment", {
+      action: "created",
+      issue: { number: 42, title: "Fix the bug" },
+      comment: { body: "LGTM" },
+      repository: { html_url: "https://github.com/owner/repo" },
+    });
+
+    const evtEntry = adminWss.logEntries.find(
+      (e) => e.kind === "message" && e.summary.includes("event_notification"),
+    );
+    expect(evtEntry?.summary).toContain("issue_comment");
+  });
 });
 
 // ── Reconnect path tests (real WebSocket needed) ──────────────────────────────


### PR DESCRIPTION
## Summary

- **Webhook events**: check_run/suite shows name+conclusion; push shows branch; delete shows ref_type+ref; issues/labeled shows label name; pull_request shows PR number+title; issue/PR comments show truncated text; PR reviews show state+body
- **Foreman messages**: `worker_hello` shows idle/busy status (with task ID if busy); `event_notification` shows the forwarded event name
- Uses the existing `fmtEvent()` formatting engine for consistent output across real-time broadcasts and DB-backed queries

## Test plan

- [ ] New test cases in `tests/display.event-details.test.ts` for `delete` and `issues` event types
- [ ] New test cases in `tests/db.test.ts` for richer webhook and message summaries from DB rows
- [ ] New test cases in `tests/foreman.admin-broadcast.test.ts` for richer broadcast summaries
- [ ] New test case in `tests/foreman.event-forwarding-logging.test.ts` for event_notification summary content
- [ ] All 1025 tests pass; type-check clean
- [ ] Verify in the admin UI that event log entries show meaningful detail (check_run names, comment excerpts, label names, etc.)

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)