### PR TITLE
feat: add Railway PR environment config for branch deployments

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -10,5 +10,16 @@
     "healthcheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10
+  },
+  "environments": {
+    "pr": {
+      "deploy": {
+        "startCommand": "npm start",
+        "healthcheckPath": "/health",
+        "healthcheckTimeout": 300,
+        "restartPolicyType": "ON_FAILURE",
+        "restartPolicyMaxRetries": 10
+      }
+    }
   }
 }


### PR DESCRIPTION
Adds a `pr` environment block to `railway.json` so Railway creates preview deployments for pull request branches.

## Changes
- Added `environments.pr` section mirroring the main deploy config (start command, healthcheck, restart policy)

## Test plan
- [ ] Verify Railway picks up the config and creates a PR environment on this PR itself