### PR TITLE
fix: preserve task status on foreman restart (upsertTask)

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -290,7 +290,7 @@ export interface ListTasksOpts {
 }
 
 export interface TaskStore {
-  /** Insert task with status=pending; on conflict update title only. */
+  /** Insert task with status=pending; on conflict (duplicate task_id) do nothing. */
   upsertTask(taskId: string, issueNumber: number, repo: string, title: string): Promise<void>;
   /** Mark task as assigned to a worker. */
   markAssigned(taskId: string, workerId: string): Promise<void>;
@@ -325,7 +325,7 @@ export function createTaskStore(supabase: SupabaseClient): TaskStore {
     async upsertTask(taskId, issueNumber, repo, title) {
       const { error } = await supabase.from("tasks").upsert(
         { task_id: taskId, issue_number: issueNumber, repo, title, status: "pending" },
-        { onConflict: "task_id", ignoreDuplicates: false },
+        { onConflict: "task_id", ignoreDuplicates: true },
       );
       if (error) throw error;
     },

--- a/tests/db.tasks.test.ts
+++ b/tests/db.tasks.test.ts
@@ -56,7 +56,7 @@ describe("createTaskStore", () => {
         title: "Fix the bug",
         status: "pending",
       }),
-      expect.objectContaining({ onConflict: "task_id", ignoreDuplicates: false }),
+      expect.objectContaining({ onConflict: "task_id", ignoreDuplicates: true }),
     );
   });
 


### PR DESCRIPTION
## Summary

- Changes `ignoreDuplicates: false` → `ignoreDuplicates: true` in `createTaskStore.upsertTask`
- This generates `ON CONFLICT DO NOTHING` instead of `ON CONFLICT DO UPDATE SET ...`, so a foreman restart no longer resets `tasks.status` back to `"pending"` for already-assigned tasks
- Updates the JSDoc comment on `TaskStore.upsertTask` to reflect the actual behavior

## Test plan

- [ ] Existing `upsertTask calls supabase upsert on tasks table` test updated to assert `ignoreDuplicates: true` — confirmed RED before fix, GREEN after
- [ ] Full test suite passes (1048 tests)

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)