### PR TITLE
fix: hide worker prompt after /task-complete

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -148,7 +148,7 @@ export class WorkerSession {
   /**
    * Process a line of stdin input: slash commands and user queries.
    */
-  async handleUserInput(input: string): Promise<"exit" | undefined> {
+  async handleUserInput(input: string): Promise<"exit" | "task-complete" | undefined> {
     if (!input || input === "__abort__") return;
     if (input === WS_TASK_ASSIGNED || input === WS_EVENT) return;
     // ^D / ^C on empty buffer resolves ask() with "__eof__" — treat as /exit
@@ -181,6 +181,7 @@ export class WorkerSession {
         this.currentIssue = undefined;
         this.currentSessionId = undefined;
         this.display.print(display.c.sageGreen("Task complete. Waiting for next task..."));
+        return "task-complete";
       }
       return;
     }
@@ -494,6 +495,7 @@ export async function workerMain(
     try {
       const result = await session.handleUserInput(input);
       if (result === "exit") break;
+      if (result === "task-complete") showPrompt = false;
     } catch (err) {
       display.print(display.c.boldRed(`\nERROR: ${fmtError(err)}`));
     }

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -182,6 +182,21 @@ describe("handleUserInput", () => {
     expect(sent).toEqual({ type: "task_complete", workerId: WORKER_ID, taskId: "42" });
   });
 
+  it("/task-complete returns 'task-complete' so workerMain can hide the prompt", async () => {
+    const issue = makeIssue();
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
+    await vi.waitFor(() => expect(runQuery).toHaveBeenCalled());
+
+    const result = await session.handleUserInput("/task-complete");
+
+    expect(result).toBe("task-complete");
+  });
+
+  it("/task-complete with no active task returns undefined (no prompt change needed)", async () => {
+    const result = await session.handleUserInput("/task-complete");
+    expect(result).toBeUndefined();
+  });
+
   it("/task-complete with no active task does not send to WS", async () => {
     await session.handleUserInput("/task-complete");
     expect(fakeWs.send).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- After `/task-complete`, the worker was still showing the `[worker] > ` prompt even though it was waiting for the foreman to assign the next task
- Root cause: `showPrompt` in `workerMain` was never reset to `false` after a task was completed
- Fix: `handleUserInput` now returns `"task-complete"` when a task is successfully sent to the foreman; `workerMain` reacts by setting `showPrompt = false`

## Test plan

- Added test: `/task-complete returns 'task-complete' so workerMain can hide the prompt`
- Added test: `/task-complete with no active task returns undefined (no prompt change needed)`
- All 1053 tests pass, type check clean, lint clean

Closes #360