### PR TITLE
feat: display task dependencies in dashboard and task detail

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -3,6 +3,11 @@ import { Link } from "react-router-dom";
 import { useAdminWs } from "../hooks/useAdminWs.ts";
 import type { TaskSnapshot, WorkerSnapshot, LogEntry, AdminMessage } from "../types.ts";
 
+function effectiveStatus(t: TaskSnapshot): string {
+  if (t.status === "pending" && t.blockers?.some((b) => b.isOpen)) return "blocked";
+  return t.status;
+}
+
 export default function Dashboard() {
   const [tasks, setTasks] = useState<TaskSnapshot[]>([]);
   const [workers, setWorkers] = useState<WorkerSnapshot[]>([]);
@@ -21,7 +26,8 @@ export default function Dashboard() {
 
   useAdminWs(handleMessage);
 
-  const pending = tasks.filter((t) => t.status === "pending").length;
+  const blocked = tasks.filter((t) => t.status === "pending" && t.blockers?.some((b) => b.isOpen)).length;
+  const pending = tasks.filter((t) => t.status === "pending" && !t.blockers?.some((b) => b.isOpen)).length;
   const assigned = tasks.filter((t) => t.status === "assigned").length;
   const done = tasks.filter((t) => t.status === "complete").length;
 
@@ -30,7 +36,7 @@ export default function Dashboard() {
       <h2>Dashboard</h2>
 
       <section>
-        <h3>Tasks ({pending} pending · {assigned} assigned · {done} done)</h3>
+        <h3>Tasks ({blocked} blocked · {pending} pending · {assigned} assigned · {done} done)</h3>
         {tasks.length === 0 ? <p>No tasks.</p> : (
           <table style={{ width: "100%", borderCollapse: "collapse" }}>
             <thead>
@@ -47,7 +53,7 @@ export default function Dashboard() {
                 <tr key={t.taskId}>
                   <td style={td}><Link to={`/tasks/${t.taskId}`}>#{t.issueNumber}</Link></td>
                   <td style={td}>{t.title}</td>
-                  <td style={td}>{t.status}</td>
+                  <td style={td}>{effectiveStatus(t)}</td>
                   <td style={td}>{t.assignedWorkerId
                     ? <Link to={`/workers/${t.assignedWorkerId}`}>{t.assignedWorkerId.slice(0, 8)}</Link>
                     : "—"}</td>

--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams, Link } from "react-router-dom";
 import { useAdminWs } from "../hooks/useAdminWs.ts";
-import type { LogEntry, AdminMessage } from "../types.ts";
+import type { LogEntry, AdminMessage, TaskSnapshot } from "../types.ts";
 
 export default function TaskDetail() {
   const { id } = useParams<{ id: string }>();
   const [events, setEvents] = useState<LogEntry[]>([]);
+  const [task, setTask] = useState<TaskSnapshot | null>(null);
 
   useEffect(() => {
     fetch(`/api/tasks/${id}/events`)
@@ -15,7 +16,10 @@ export default function TaskDetail() {
   }, [id]);
 
   const handleMessage = useCallback((msg: AdminMessage) => {
-    if (msg.type === "log_event" && msg.entry.taskId === id) {
+    if (msg.type === "snapshot") {
+      const found = msg.tasks.find((t) => t.taskId === id);
+      if (found) setTask(found);
+    } else if (msg.type === "log_event" && msg.entry.taskId === id) {
       setEvents((prev) => [msg.entry, ...prev]);
     }
   }, [id]);
@@ -26,6 +30,20 @@ export default function TaskDetail() {
     <div>
       <h2>Task #{id}</h2>
       <p><Link to="/">← Dashboard</Link></p>
+
+      {task?.blockers && task.blockers.length > 0 && (
+        <section style={{ marginBottom: "1.5rem" }}>
+          <h3>Dependencies</h3>
+          <ul style={{ margin: 0, paddingLeft: "1.5rem" }}>
+            {task.blockers.map((b) => (
+              <li key={b.issueNumber} style={b.isOpen ? blockerOpen : blockerClosed}>
+                #{b.issueNumber}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
       {events.length === 0 ? <p>No events for this task.</p> : (
         <table style={{ width: "100%", borderCollapse: "collapse", fontFamily: "monospace", fontSize: "0.85em" }}>
           <thead>
@@ -54,3 +72,5 @@ export default function TaskDetail() {
 
 const th: React.CSSProperties = { textAlign: "left", borderBottom: "1px solid #ccc", padding: "4px 8px" };
 const td: React.CSSProperties = { padding: "4px 8px", borderBottom: "1px solid #eee" };
+const blockerOpen: React.CSSProperties = { color: "#c00" };
+const blockerClosed: React.CSSProperties = { color: "#999", textDecoration: "line-through" };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,3 +1,8 @@
+export interface BlockerInfo {
+  issueNumber: number;
+  isOpen: boolean;
+}
+
 export interface TaskSnapshot {
   taskId: string;
   issueNumber: number;
@@ -6,6 +11,7 @@ export interface TaskSnapshot {
   assignedWorkerId?: string;
   prNumber?: number;
   prUrl?: string;
+  blockers?: BlockerInfo[];
 }
 
 export interface WorkerSnapshot {

--- a/src/admin-ws.ts
+++ b/src/admin-ws.ts
@@ -11,6 +11,11 @@ export interface LogEntry {
   summary: string;
 }
 
+export interface BlockerInfo {
+  issueNumber: number;
+  isOpen: boolean;
+}
+
 export interface TaskSnapshot {
   taskId: string;
   issueNumber: number;
@@ -19,6 +24,7 @@ export interface TaskSnapshot {
   assignedWorkerId?: string;
   prNumber?: number;
   prUrl?: string;
+  blockers?: BlockerInfo[];
 }
 
 export interface WorkerSnapshot {

--- a/src/foreman.ts
+++ b/src/foreman.ts
@@ -243,16 +243,26 @@ export class TaskQueue {
     return undefined;
   }
 
-  getTaskSnapshots(): TaskSnapshot[] {
-    return [...this.tasks.values()].map((t) => ({
-      taskId: t.taskId,
-      issueNumber: t.issueNumber,
-      title: t.title,
-      status: t.status,
-      assignedWorkerId: t.assignedWorkerId,
-      prNumber: t.prNumber,
-      prUrl: t.prNumber !== undefined ? `${t.repoUrl}/pull/${t.prNumber}` : undefined,
-    }));
+  getTaskSnapshots(graph?: DependencyGraph, openIssues?: Set<number>): TaskSnapshot[] {
+    return [...this.tasks.values()].map((t) => {
+      const snapshot: TaskSnapshot = {
+        taskId: t.taskId,
+        issueNumber: t.issueNumber,
+        title: t.title,
+        status: t.status,
+        assignedWorkerId: t.assignedWorkerId,
+        prNumber: t.prNumber,
+        prUrl: t.prNumber !== undefined ? `${t.repoUrl}/pull/${t.prNumber}` : undefined,
+      };
+      if (graph !== undefined && openIssues !== undefined) {
+        const blockerSet = graph.get(t.issueNumber) ?? new Set<number>();
+        snapshot.blockers = Array.from(blockerSet).map((n) => ({
+          issueNumber: n,
+          isOpen: openIssues.has(n),
+        }));
+      }
+      return snapshot;
+    });
   }
 }
 
@@ -547,7 +557,7 @@ export function createForemanWss(
   function broadcastSnapshot() {
     if (!adminWss) return;
     adminWss.broadcastSnapshot({
-      tasks: taskQueue.getTaskSnapshots(),
+      tasks: taskQueue.getTaskSnapshots(graph, openIssues),
       workers: registry.getWorkerSnapshots(),
     });
   }
@@ -1113,7 +1123,7 @@ if (isMain) {
   // Admin WebSocket broadcaster
   const { createAdminWss } = await import("./admin-ws.js");
   const adminWss = createAdminWss(server, () => ({
-    tasks: taskQueue.getTaskSnapshots(),
+    tasks: taskQueue.getTaskSnapshots(graph, openIssues),
     workers: registry.getWorkerSnapshots(),
   }));
 

--- a/tests/foreman.taskqueue.test.ts
+++ b/tests/foreman.taskqueue.test.ts
@@ -110,6 +110,31 @@ describe("TaskQueue", () => {
     const snapshots = q.getTaskSnapshots();
     expect(snapshots[0].prUrl).toBeUndefined();
   });
+
+  it("getTaskSnapshots with no graph/openIssues omits blockers field", () => {
+    q.addTask(baseTask);
+    const snapshots = q.getTaskSnapshots();
+    expect(snapshots[0].blockers).toBeUndefined();
+  });
+
+  it("getTaskSnapshots with graph includes blockers with isOpen status", () => {
+    q.addTask(baseTask); // issueNumber: 42
+    const graph = new Map([[42, new Set([10, 11])]]);
+    const openIssues = new Set([10]); // 10 is open, 11 is closed
+    const snapshots = q.getTaskSnapshots(graph, openIssues);
+    expect(snapshots[0].blockers).toEqual([
+      { issueNumber: 10, isOpen: true },
+      { issueNumber: 11, isOpen: false },
+    ]);
+  });
+
+  it("getTaskSnapshots with graph shows empty blockers array when no deps", () => {
+    q.addTask(baseTask); // issueNumber: 42, no entry in graph
+    const graph = new Map<number, Set<number>>();
+    const openIssues = new Set<number>();
+    const snapshots = q.getTaskSnapshots(graph, openIssues);
+    expect(snapshots[0].blockers).toEqual([]);
+  });
 });
 
 describe("removeTask", () => {


### PR DESCRIPTION
## Summary

- Tasks with open blockers now show as **blocked** instead of **pending** in the Dashboard, with a dedicated blocked count in the header
- The Task Detail view shows a **Dependencies** section listing all blocker issues — open ones in red, closed ones in grey with strikethrough
- `TaskSnapshot` now carries a `blockers` field (`BlockerInfo[]`) populated from the dependency graph on every broadcast

## Implementation notes

- `getTaskSnapshots()` on `TaskQueue` now accepts optional `graph` and `openIssues` params; when provided, each snapshot includes the full blocker list with open/closed status
- Both `broadcastSnapshot` (inside `createForemanWss`) and the initial `getSnapshot` closure (in `startForeman`) pass through `graph` and `openIssues`
- `TaskDetail` subscribes to the snapshot WebSocket message to get live task info including blockers (previously it only handled `log_event` messages)

## Test plan

- [ ] Run `npm test` — all 1054 tests pass
- [ ] Run `npm run lint` — no errors
- [ ] Run `npx tsc --noEmit` — no errors
- [ ] In the live UI, label an issue `brunel:ready` where the body has `Depends on #N` for an open issue — confirm Dashboard shows it as "blocked"
- [ ] Close the blocker issue — confirm task moves to "pending" and becomes assignable
- [ ] Open task detail — confirm dependencies section appears with correct open/closed styling

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)