### PR TITLE
fix: broadcast snapshot when PR is registered to a task

### DIFF
--- a/src/foreman.ts
+++ b/src/foreman.ts
@@ -614,6 +614,7 @@ export function createForemanWss(
               flog(`ERROR Failed to update task PR for #${linkedTask.taskId}: ${fmtError(err)}`)
             );
             flog(`[task #${linkedIssue}] PR #${prNumber} registered`);
+            broadcastSnapshot();
             return result(linkedTask);
           }
         }

--- a/tests/foreman.admin-broadcast.test.ts
+++ b/tests/foreman.admin-broadcast.test.ts
@@ -12,7 +12,7 @@ import type { AddressInfo } from "net";
 import { TaskQueue, WorkerRegistry, createForemanWss } from "../src/foreman.js";
 import { loadDefaultConfig } from "../src/config.js";
 const defaultCfg = await loadDefaultConfig();
-import type { AdminWss, LogEntry } from "../src/admin-ws.js";
+import type { AdminWss, AdminSnapshot, LogEntry } from "../src/admin-ws.js";
 import { waitUntil } from "./helpers.js";
 
 // ── Mock AdminWss ─────────────────────────────────────────────────────────────
@@ -302,5 +302,28 @@ describe("foreman admin broadcast — unique IDs across all event types", () => 
     const uniqueIds = new Set(ids);
     expect(uniqueIds.size).toBe(ids.length);
     expect(ids.every((id) => id > 0)).toBe(true);
+  });
+});
+
+describe("foreman admin broadcast — snapshot on PR registration", () => {
+  it("broadcasts updated snapshot with prNumber when a PR is opened for a task", () => {
+    queue.addTask({ taskId: "42", issueNumber: 42, title: "Fix the bug", body: "", labels: [], repoUrl: "https://github.com/owner/repo" });
+
+    const snapshots: AdminSnapshot[] = [];
+    adminWss.broadcastSnapshot = (snapshot) => snapshots.push(snapshot);
+
+    routeEvent("evt-1", "pull_request", {
+      action: "opened",
+      pull_request: {
+        number: 101,
+        body: "Closes #42",
+        head: { ref: "fix-the-bug" },
+      },
+      repository: { html_url: "https://github.com/owner/repo" },
+    });
+
+    expect(snapshots.length).toBeGreaterThan(0);
+    const task = snapshots[snapshots.length - 1].tasks.find((t) => t.taskId === "42");
+    expect(task?.prNumber).toBe(101);
   });
 });


### PR DESCRIPTION
## Summary

- When a `pull_request/opened` event linked to a task via `Closes #N`, the foreman called `taskQueue.registerPr()` (updating `task.prNumber`) but never called `broadcastSnapshot()`
- Dashboard clients only saw the PR number after a manual page refresh
- Fix: add a single `broadcastSnapshot()` call immediately after `taskQueue.registerPr()` in the PR-opened handler

## Test plan

- [ ] New test `"broadcasts updated snapshot with prNumber when a PR is opened for a task"` in `foreman.admin-broadcast.test.ts` — verifies the snapshot sent to admin clients includes `prNumber` when a PR is opened for a tracked task
- [ ] All 1054 existing tests continue to pass

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)