### PR TITLE
fix: treat railway-bot-comment issue_comment events as log_only

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -30,8 +30,13 @@ export function classifyEvent(event: GitHubEvent): "actionable" | "log_only" {
 
     case "pull_request_review":
     case "pull_request_review_comment":
-    case "issue_comment":
       return "actionable";
+
+    case "issue_comment": {
+      const body = (event.payload.comment as Record<string, unknown> | undefined)?.body;
+      if (typeof body === "string" && body.startsWith("<!-- railway-bot-comment")) return "log_only";
+      return "actionable";
+    }
 
     default:
       return "log_only";

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -552,6 +552,16 @@ describe("classifyEvent", () => {
     it("unrecognised event with no action is log_only", () => {
       expect(classifyEvent(evt("push"))).toBe("log_only");
     });
+    it("issue_comment starting with <!-- railway-bot-comment is log_only", () => {
+      const body = "<!-- railway-bot-comment-version=2 -->\n\n<!-- railway-project-id=\"abc\" -->\n🚅 Deployed";
+      const event = { id: "e1", name: "issue_comment", payload: { action: "created", comment: { body } } };
+      expect(classifyEvent(event)).toBe("log_only");
+    });
+    it("issue_comment edited starting with <!-- railway-bot-comment is log_only", () => {
+      const body = "<!-- railway-bot-comment-version=2 -->\nsome content";
+      const event = { id: "e1", name: "issue_comment", payload: { action: "edited", comment: { body } } };
+      expect(classifyEvent(event)).toBe("log_only");
+    });
   });
 
   describe("actionable events", () => {
@@ -569,6 +579,10 @@ describe("classifyEvent", () => {
     });
     it("issue_comment/edited is actionable", () => {
       expect(classifyEvent(evt("issue_comment", "edited"))).toBe("actionable");
+    });
+    it("issue_comment with railway-bot-comment body is actionable when no railway prefix", () => {
+      const event = { id: "e1", name: "issue_comment", payload: { action: "created", comment: { body: "Normal comment" } } };
+      expect(classifyEvent(event)).toBe("actionable");
     });
     it("pull_request/closed is actionable", () => {
       expect(classifyEvent(evt("pull_request", "closed"))).toBe("actionable");


### PR DESCRIPTION
## Summary

- In `classifyEvent`, `issue_comment` events whose body starts with `<!-- railway-bot-comment` are now classified as `log_only` instead of `actionable`
- These are automated Railway deployment notifications that don't require any action from the worker
- Added two tests covering the new behavior (created and edited variants)

Closes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)