### PR TITLE
feat: reactive pipeline for admin dashboard WebSocket updates

### DIFF
--- a/src/foreman.ts
+++ b/src/foreman.ts
@@ -5,6 +5,7 @@ import { Hono } from "hono";
 import { getRequestListener } from "@hono/node-server";
 import { WebSocketServer, WebSocket } from "ws";
 import type { WebSocket as WsSocket } from "ws";
+import { EventEmitter } from "events";
 import type { WorkerMessage, ForemanMessage, GitHubEvent, TaskIssue, LabeledIssueState } from "./types.js";
 import { labelIssueDone } from "./github.js";
 import { fmtTimestamp, fmtEvent, setVerbose } from "./display.js";
@@ -34,11 +35,12 @@ interface WorkerState {
   disconnectTimer?: ReturnType<typeof setTimeout>;
 }
 
-export class WorkerRegistry {
+export class WorkerRegistry extends EventEmitter {
   private workers = new Map<string, WorkerState>();
 
   register(workerId: string, ws: WsSocket, status: "idle" | "busy", taskId?: string): void {
     this.workers.set(workerId, { workerId, ws, status, currentTaskId: taskId });
+    this.emit("changed");
   }
 
   get(workerId: string): WorkerState | undefined {
@@ -47,6 +49,7 @@ export class WorkerRegistry {
 
   remove(workerId: string) {
     this.workers.delete(workerId);
+    this.emit("changed");
   }
 
   markDisconnected(workerId: string) {
@@ -54,6 +57,7 @@ export class WorkerRegistry {
     if (!w) return;
     w.status = "disconnected";
     w.disconnectedAt = new Date();
+    this.emit("changed");
   }
 
   getIdleWorker(): WorkerState | null {
@@ -79,6 +83,7 @@ export class WorkerRegistry {
     if (!w) return;
     w.status = "busy";
     w.currentTaskId = taskId;
+    this.emit("changed");
   }
 
   releaseWorker(workerId: string) {
@@ -86,6 +91,7 @@ export class WorkerRegistry {
     if (!w) return;
     w.status = "idle";
     w.currentTaskId = undefined;
+    this.emit("changed");
   }
 
   startReclaimTimer(workerId: string, timeoutMs: number, onReclaim: () => void): void {
@@ -135,7 +141,7 @@ interface Task {
   depsLoaded: boolean;
 }
 
-export class TaskQueue {
+export class TaskQueue extends EventEmitter {
   private tasks = new Map<string, Task>();
   private prToTaskId = new Map<number, string>();
   private branchToTaskId = new Map<string, string>();
@@ -147,6 +153,7 @@ export class TaskQueue {
       eventQueue: t.eventQueue ?? [],
       depsLoaded: t.depsLoaded ?? true,
     });
+    this.emit("changed");
   }
 
   get(taskId: string): Task | undefined {
@@ -172,11 +179,15 @@ export class TaskQueue {
     if (!t) return;
     t.status = "assigned";
     t.assignedWorkerId = workerId;
+    this.emit("changed");
   }
 
   completeTask(taskId: string) {
     const t = this.tasks.get(taskId);
-    if (t) t.status = "complete";
+    if (t) {
+      t.status = "complete";
+      this.emit("changed");
+    }
   }
 
   revertTask(taskId: string) {
@@ -184,6 +195,7 @@ export class TaskQueue {
     if (!t || t.status !== "assigned") return;
     t.status = "pending";
     t.assignedWorkerId = undefined;
+    this.emit("changed");
   }
 
   queueEvent(taskId: string, event: GitHubEvent) {
@@ -203,6 +215,7 @@ export class TaskQueue {
     this.prToTaskId.set(prNumber, taskId);
     const t = this.tasks.get(taskId);
     if (t) t.prNumber = prNumber;
+    this.emit("changed");
   }
 
   getTaskForPr(prNumber: number): Task | undefined {
@@ -223,6 +236,7 @@ export class TaskQueue {
     const t = this.tasks.get(taskId);
     if (!t || t.status !== "pending") return;
     this.tasks.delete(taskId);
+    this.emit("changed");
   }
 
   getPendingTasks(): Task[] {
@@ -234,6 +248,7 @@ export class TaskQueue {
       const t = this.tasks.get(String(n));
       if (t) t.depsLoaded = true;
     }
+    this.emit("changed");
   }
 
   getAssignedTaskForWorker(workerId: string): Task | undefined {
@@ -266,6 +281,14 @@ export class TaskQueue {
   }
 }
 
+
+function debounce(fn: () => void, delayMs: number): () => void {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  return () => {
+    if (timer !== null) clearTimeout(timer);
+    timer = setTimeout(() => { timer = null; fn(); }, delayMs);
+  };
+}
 
 function strProp(obj: unknown, key: string): string | null {
   if (typeof obj !== "object" || obj === null) return null;
@@ -562,6 +585,10 @@ export function createForemanWss(
     });
   }
 
+  const debouncedBroadcast = debounce(broadcastSnapshot, 10);
+  taskQueue.on("changed", debouncedBroadcast);
+  registry.on("changed", debouncedBroadcast);
+
   function extractLinkedIssueNumber(body: string): number | null {
     const match = /(?:closes|fixes|resolves)\s+#(\d+)/i.exec(body);
     return match ? parseInt(match[1], 10) : null;
@@ -624,7 +651,6 @@ export function createForemanWss(
               flog(`ERROR Failed to update task PR for #${linkedTask.taskId}: ${fmtError(err)}`)
             );
             flog(`[task #${linkedIssue}] PR #${prNumber} registered`);
-            broadcastSnapshot();
             return result(linkedTask);
           }
         }
@@ -796,7 +822,6 @@ export function createForemanWss(
     for (const w of registry.getIdleWorkers()) {
       tryAssignWork(w.workerId).catch(err => flog(`ERROR tryAssignWork: ${fmtError(err)}`));
     }
-    broadcastSnapshot();
   }
 
   async function tryAssignWork(workerId: string): Promise<void> {
@@ -807,7 +832,6 @@ export function createForemanWss(
       // Reserve in memory first to prevent concurrent double-assignment in the reconcile loop.
       taskQueue.assignTask(task.taskId, workerId);
       registry.assignTask(workerId, task.taskId);
-      broadcastSnapshot();
 
       // Persist to DB before sending task_assigned to the worker.
       try {
@@ -817,7 +841,6 @@ export function createForemanWss(
         // Revert in-memory state — worker returns to idle.
         taskQueue.revertTask(task.taskId);
         registry.releaseWorker(workerId);
-        broadcastSnapshot();
         log(workerId, "→ idle (DB write failed)");
         return;
       }
@@ -880,7 +903,6 @@ export function createForemanWss(
           log(workerId, `hello busy task=#${msg.taskId} — reclaimed`);
           registry.register(workerId, ws, "busy", msg.taskId);
           taskQueue.assignTask(msg.taskId, workerId);
-          broadcastSnapshot();
           const queued = taskQueue.drainEvents(msg.taskId);
           for (const evt of queued) {
             const evtMsg: ForemanMessage = { type: "event_notification", taskId: msg.taskId, event: evt };
@@ -998,7 +1020,6 @@ export function createForemanWss(
         } else {
           registry.remove(workerId);
         }
-        broadcastSnapshot();
       }
     });
   });

--- a/tests/foreman.admin-broadcast.test.ts
+++ b/tests/foreman.admin-broadcast.test.ts
@@ -306,7 +306,7 @@ describe("foreman admin broadcast — unique IDs across all event types", () => 
 });
 
 describe("foreman admin broadcast — snapshot on PR registration", () => {
-  it("broadcasts updated snapshot with prNumber when a PR is opened for a task", () => {
+  it("broadcasts updated snapshot with prNumber when a PR is opened for a task", async () => {
     queue.addTask({ taskId: "42", issueNumber: 42, title: "Fix the bug", body: "", labels: [], repoUrl: "https://github.com/owner/repo" });
 
     const snapshots: AdminSnapshot[] = [];
@@ -322,8 +322,36 @@ describe("foreman admin broadcast — snapshot on PR registration", () => {
       repository: { html_url: "https://github.com/owner/repo" },
     });
 
-    expect(snapshots.length).toBeGreaterThan(0);
+    await waitUntil(() => snapshots.length > 0);
     const task = snapshots[snapshots.length - 1].tasks.find((t) => t.taskId === "42");
     expect(task?.prNumber).toBe(101);
+  });
+});
+
+describe("foreman admin broadcast — reactive snapshot pipeline", () => {
+  it("broadcasts snapshot when a worker connects (reactive, not manual callsite)", async () => {
+    const snapshots: AdminSnapshot[] = [];
+    adminWss.broadcastSnapshot = (snapshot) => snapshots.push(snapshot);
+
+    const ws = await connect();
+    send(ws, { type: "worker_hello", workerId: "worker-abc", status: "idle" });
+    await waitUntil(() => snapshots.some((s) => s.workers.some((w) => w.workerId === "worker-abc")));
+
+    const last = snapshots[snapshots.length - 1];
+    expect(last.workers.find((w) => w.workerId === "worker-abc")).toBeDefined();
+  });
+
+  it("collapses burst mutations into a single snapshot broadcast", async () => {
+    const snapshots: AdminSnapshot[] = [];
+    adminWss.broadcastSnapshot = (snapshot) => snapshots.push(snapshot);
+
+    queue.addTask({ taskId: "1", issueNumber: 1, title: "T1", body: "", labels: [], repoUrl: "https://github.com/owner/repo" });
+    queue.addTask({ taskId: "2", issueNumber: 2, title: "T2", body: "", labels: [], repoUrl: "https://github.com/owner/repo" });
+    queue.addTask({ taskId: "3", issueNumber: 3, title: "T3", body: "", labels: [], repoUrl: "https://github.com/owner/repo" });
+
+    await waitUntil(() => snapshots.length > 0);
+    // All three addTask calls are within the same tick, so debounce collapses them
+    expect(snapshots.length).toBe(1);
+    expect(snapshots[0].tasks).toHaveLength(3);
   });
 });

--- a/tests/foreman.registry.test.ts
+++ b/tests/foreman.registry.test.ts
@@ -156,3 +156,48 @@ describe("reclaim timer", () => {
     expect(() => reg.cancelReclaimTimer("w1")).not.toThrow();
   });
 });
+
+describe("WorkerRegistry changed events", () => {
+  let reg: WorkerRegistry;
+  beforeEach(() => { reg = new WorkerRegistry(); });
+
+  it("register emits changed", () => {
+    const changed = vi.fn();
+    reg.on("changed", changed);
+    reg.register("w1", fakeWs(), "idle");
+    expect(changed).toHaveBeenCalledOnce();
+  });
+
+  it("remove emits changed", () => {
+    reg.register("w1", fakeWs(), "idle");
+    const changed = vi.fn();
+    reg.on("changed", changed);
+    reg.remove("w1");
+    expect(changed).toHaveBeenCalledOnce();
+  });
+
+  it("markDisconnected emits changed", () => {
+    reg.register("w1", fakeWs(), "busy");
+    const changed = vi.fn();
+    reg.on("changed", changed);
+    reg.markDisconnected("w1");
+    expect(changed).toHaveBeenCalledOnce();
+  });
+
+  it("assignTask emits changed", () => {
+    reg.register("w1", fakeWs(), "idle");
+    const changed = vi.fn();
+    reg.on("changed", changed);
+    reg.assignTask("w1", "42");
+    expect(changed).toHaveBeenCalledOnce();
+  });
+
+  it("releaseWorker emits changed", () => {
+    reg.register("w1", fakeWs(), "busy");
+    reg.assignTask("w1", "42");
+    const changed = vi.fn();
+    reg.on("changed", changed);
+    reg.releaseWorker("w1");
+    expect(changed).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/foreman.taskqueue.test.ts
+++ b/tests/foreman.taskqueue.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { TaskQueue } from "../src/foreman.js";
 import type { GitHubEvent } from "../src/types.js";
 
@@ -182,5 +182,76 @@ describe("nextPending with predicate", () => {
     q.addTask({ ...baseTask, taskId: "1", issueNumber: 1 });
     q.addTask({ ...baseTask, taskId: "2", issueNumber: 2 });
     expect(q.nextPending()?.taskId).toBe("1");
+  });
+});
+
+describe("TaskQueue changed events", () => {
+  let q: TaskQueue;
+  beforeEach(() => { q = new TaskQueue(); });
+
+  it("addTask emits changed", () => {
+    const changed = vi.fn();
+    q.on("changed", changed);
+    q.addTask(baseTask);
+    expect(changed).toHaveBeenCalledOnce();
+  });
+
+  it("assignTask emits changed", () => {
+    q.addTask(baseTask);
+    const changed = vi.fn();
+    q.on("changed", changed);
+    q.assignTask("42", "w1");
+    expect(changed).toHaveBeenCalledOnce();
+  });
+
+  it("completeTask emits changed", () => {
+    q.addTask(baseTask);
+    q.assignTask("42", "w1");
+    const changed = vi.fn();
+    q.on("changed", changed);
+    q.completeTask("42");
+    expect(changed).toHaveBeenCalledOnce();
+  });
+
+  it("revertTask emits changed", () => {
+    q.addTask(baseTask);
+    q.assignTask("42", "w1");
+    const changed = vi.fn();
+    q.on("changed", changed);
+    q.revertTask("42");
+    expect(changed).toHaveBeenCalledOnce();
+  });
+
+  it("removeTask emits changed when task removed", () => {
+    q.addTask(baseTask);
+    const changed = vi.fn();
+    q.on("changed", changed);
+    q.removeTask("42");
+    expect(changed).toHaveBeenCalledOnce();
+  });
+
+  it("removeTask does not emit changed for assigned task", () => {
+    q.addTask(baseTask);
+    q.assignTask("42", "w1");
+    const changed = vi.fn();
+    q.on("changed", changed);
+    q.removeTask("42"); // no-op for assigned tasks
+    expect(changed).not.toHaveBeenCalled();
+  });
+
+  it("registerPr emits changed", () => {
+    q.addTask(baseTask);
+    const changed = vi.fn();
+    q.on("changed", changed);
+    q.registerPr(10, "42");
+    expect(changed).toHaveBeenCalledOnce();
+  });
+
+  it("markDepsLoaded emits changed", () => {
+    q.addTask({ ...baseTask, depsLoaded: false });
+    const changed = vi.fn();
+    q.on("changed", changed);
+    q.markDepsLoaded([42]);
+    expect(changed).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary

- `TaskQueue` and `WorkerRegistry` extend `EventEmitter` and emit a `changed` event on every state mutation
- `createForemanWss` subscribes once with a debounced `broadcastSnapshot` handler (10ms delay), replacing ~6 manual callsites
- Burst mutations (e.g. assign task + update worker in one operation) are collapsed into a single snapshot broadcast
- Any future mutation path added to these classes automatically propagates to the dashboard — no callsite to forget

## Test plan

- [ ] New unit tests in `foreman.taskqueue.test.ts` verify each mutating method emits `changed`
- [ ] New unit tests in `foreman.registry.test.ts` verify each mutating method emits `changed`
- [ ] Existing PR snapshot test updated to be async (broadcast is now debounced)
- [ ] New integration tests in `foreman.admin-broadcast.test.ts` verify the reactive pipeline end-to-end and debounce collapsing
- [ ] Full test suite passes (1072 tests)

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)