### PR TITLE
fix: update TaskList status live via WebSocket snapshots

### DIFF
--- a/frontend/src/pages/TaskList.tsx
+++ b/frontend/src/pages/TaskList.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Link, useSearchParams } from "react-router-dom";
-import type { TaskRow } from "../types.ts";
+import { useAdminWs } from "../hooks/useAdminWs.ts";
+import type { AdminMessage, TaskRow } from "../types.ts";
 
 export default function TaskList() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -16,6 +17,18 @@ export default function TaskList() {
       .then((data) => { setTasks(data); setLoading(false); })
       .catch((err) => { console.error(err); setLoading(false); });
   }, [statusFilter]);
+
+  const handleMessage = useCallback((msg: AdminMessage) => {
+    if (msg.type === "snapshot") {
+      const statusMap = new Map(msg.tasks.map((t) => [t.taskId, t.status]));
+      setTasks((prev) => prev.map((row) => {
+        const newStatus = statusMap.get(row.taskId);
+        return newStatus && newStatus !== row.status ? { ...row, status: newStatus } : row;
+      }));
+    }
+  }, []);
+
+  useAdminWs(handleMessage);
 
   function setFilter(s: "all" | "pending" | "assigned" | "complete") {
     if (s === "all") setSearchParams({});

--- a/frontend/tests/TaskList.test.tsx
+++ b/frontend/tests/TaskList.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen, waitFor, act } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import TaskList from "../src/pages/TaskList.tsx";
+import type { AdminMessage, TaskRow } from "../src/types.ts";
+
+let capturedHandler: ((msg: AdminMessage) => void) | null = null;
+
+vi.mock("../src/hooks/useAdminWs.ts", () => ({
+  useAdminWs: (handler: (msg: AdminMessage) => void) => {
+    capturedHandler = handler;
+  },
+}));
+
+const assignedTask: TaskRow = {
+  taskId: "42",
+  issueNumber: 42,
+  repo: "owner/repo",
+  title: "Fix the bug",
+  status: "assigned",
+  workerId: "worker-abc-123",
+  prNumber: null,
+  branch: null,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  assignedAt: "2026-01-01T01:00:00.000Z",
+  completedAt: null,
+};
+
+function renderTaskList() {
+  return render(
+    <MemoryRouter>
+      <TaskList />
+    </MemoryRouter>
+  );
+}
+
+describe("TaskList", () => {
+  beforeEach(() => {
+    capturedHandler = null;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches tasks from /api/tasks on mount", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([]) }));
+    renderTaskList();
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith("/api/tasks"));
+  });
+
+  it("shows tasks loaded from the API", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([assignedTask]) }));
+    renderTaskList();
+    await waitFor(() => expect(screen.getByText("Fix the bug")).toBeInTheDocument());
+    // The status cell shows "assigned" (the filter buttons also say "assigned", so use getAllByText)
+    expect(screen.getAllByText("assigned").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("updates task status to complete when snapshot arrives via WebSocket", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([assignedTask]) }));
+    renderTaskList();
+    await waitFor(() => expect(screen.getByText("Fix the bug")).toBeInTheDocument());
+
+    act(() => {
+      capturedHandler!({
+        type: "snapshot",
+        tasks: [{ taskId: "42", issueNumber: 42, title: "Fix the bug", status: "complete" }],
+        workers: [],
+      });
+    });
+
+    // Status cell should now show "complete"; the filter button "assigned" may still exist
+    // but the task row status cell should NOT show "assigned"
+    const rows = screen.getAllByRole("row");
+    // rows[0] = header, rows[1] = task row
+    expect(rows[1].textContent).toContain("complete");
+    expect(rows[1].textContent).not.toContain("assigned");
+  });
+
+  it("does not change status when snapshot has no matching task", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([assignedTask]) }));
+    renderTaskList();
+    await waitFor(() => expect(screen.getByText("Fix the bug")).toBeInTheDocument());
+
+    act(() => {
+      capturedHandler!({
+        type: "snapshot",
+        tasks: [{ taskId: "99", issueNumber: 99, title: "Other task", status: "complete" }],
+        workers: [],
+      });
+    });
+
+    const rows = screen.getAllByRole("row");
+    expect(rows[1].textContent).toContain("assigned");
+  });
+});


### PR DESCRIPTION
## Summary

- `TaskList` was fetching task data from `/api/tasks` once on mount and never updating, so completed tasks stayed shown as "assigned" unless the user manually changed the filter or refreshed
- Fix: subscribe `TaskList` to the admin WebSocket and update task statuses in-place whenever a snapshot arrives
- Added tests in `frontend/tests/TaskList.test.tsx` covering live status updates from snapshots

## Root cause

`TaskList.tsx` only re-fetched when the `statusFilter` URL param changed. Once tasks were loaded as "assigned", they stayed "assigned" in the UI even after the worker completed the task and the DB was updated.

The [Dashboard](https://github.com/jasoncrawford/brunel/blob/main/frontend/src/pages/Dashboard.tsx) already uses `useAdminWs` for live updates — this brings `TaskList` in line with the same pattern.

## Test plan

- [ ] `cd frontend && npm test` — new `TaskList.test.tsx` tests pass, no regressions
- [ ] `npm test` (root) — all 1060 backend tests pass

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)