### PR TITLE
feat: ^D deletes character under cursor (forward delete)

### DIFF
--- a/src/input.ts
+++ b/src/input.ts
@@ -595,6 +595,13 @@ export function ask(
       fullRedraw(prevRow, computeMatches());
     }
 
+    function deleteForward() {
+      if (cursor === buffer.length) return;
+      const prevRow = screenPosOf(cursor).row;
+      buffer = buffer.slice(0, cursor) + buffer.slice(cursor + 1);
+      fullRedraw(prevRow, computeMatches());
+    }
+
     function moveTo(pos: number) {
       pos = Math.max(0, Math.min(buffer.length, pos));
       if (pos === cursor) return;
@@ -716,7 +723,7 @@ export function ask(
         }
         else if (ch === "\x7f" || ch === "\x08")      { deleteBack(); }
         else if (ch === "\x03") { if (buffer) { replaceBuffer(""); } else { process.stdout.write("^C"); exit(); } }
-        else if (ch === "\x04") { if (!buffer) exit(); }
+        else if (ch === "\x04") { if (!buffer) exit(); else deleteForward(); }
         else if (ch === "\x01")                       { moveTo(0); }             // ^A
         else if (ch === "\x05")                       { moveTo(buffer.length); } // ^E
         else if (ch === "\x0b")                       { killToEnd(); }           // ^K

--- a/tests/repl.input.test.ts
+++ b/tests/repl.input.test.ts
@@ -242,6 +242,43 @@ describe("ask() - kill / delete", () => {
       expect(result).toBe("foo"); // ask() trims; "foo " → "foo"
     });
   });
+
+  it("^D in middle of buffer deletes character under cursor, cursor stays", async () => {
+    await withFakeStdin(async (stdin) => {
+      const p = ask("> ", () => []);
+      stdin.push("abcd");
+      stdin.push("\x01"); // ^A → go to start
+      stdin.push("\x1b[C"); // right → cursor after 'a', before 'b'
+      stdin.push("\x04"); // ^D → deletes 'b'
+      stdin.push("\r");
+      const result = await p;
+      expect(result).toBe("acd");
+    });
+  });
+
+  it("^D at start of buffer deletes first character", async () => {
+    await withFakeStdin(async (stdin) => {
+      const p = ask("> ", () => []);
+      stdin.push("hello");
+      stdin.push("\x01"); // ^A → go to start (cursor=0)
+      stdin.push("\x04"); // ^D → deletes 'h'
+      stdin.push("\r");
+      const result = await p;
+      expect(result).toBe("ello");
+    });
+  });
+
+  it("^D at end of buffer is a no-op", async () => {
+    await withFakeStdin(async (stdin) => {
+      const p = ask("> ", () => []);
+      stdin.push("hello");
+      // cursor is already at end after typing
+      stdin.push("\x04"); // ^D at end → no-op
+      stdin.push("\r");
+      const result = await p;
+      expect(result).toBe("hello");
+    });
+  });
 });
 
 describe("ask() - character insertion", () => {
@@ -270,11 +307,11 @@ describe("ask() - character insertion", () => {
 });
 
 describe("ask() - exit conditions", () => {
-  it("^D on non-empty buffer → no-op (does not exit)", async () => {
+  it("^D with cursor at end of buffer → no-op (does not exit)", async () => {
     await withFakeStdin(async (stdin) => {
       const p = ask("> ", () => []);
       stdin.push("hello");
-      stdin.push("\x04"); // ^D on non-empty → no-op
+      stdin.push("\x04"); // ^D at end → no-op (nothing to delete forward)
       stdin.push("\r");
       const result = await p;
       expect(result).toBe("hello");


### PR DESCRIPTION
## Summary

- Adds a `deleteForward()` function that removes the character at the cursor position without moving the cursor
- `^D` on a non-empty buffer now calls `deleteForward()` instead of being a no-op
- `^D` on an empty buffer still exits (EOF) — existing behavior preserved
- `^D` at end of buffer is a no-op (nothing to delete forward)

## Test plan

- [x] New test: `^D in middle of buffer deletes character under cursor, cursor stays`
- [x] New test: `^D at start of buffer deletes first character`
- [x] New test: `^D at end of buffer is a no-op`
- [x] Updated existing test description to accurately reflect end-of-buffer behavior
- [x] All 67 input tests pass
- [x] Type check clean (`tsc --noEmit`)
- [x] Lint clean

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)