### PR TITLE
fix: correct column widths when table cells contain inline markdown

### DIFF
--- a/src/display.ts
+++ b/src/display.ts
@@ -333,6 +333,53 @@ function wrapText(text: string, width: number): string[] {
   return lines.length > 0 ? lines : [""];
 }
 
+// Strips ANSI escape sequences to measure the visible length of a string.
+function visLen(str: string): number {
+  return str.replace(/\x1b\[[0-9;]*m/g, "").length;
+}
+
+// Pads a (possibly ANSI-formatted) string to `width` visible characters.
+function ansiPadEnd(str: string, width: number): string {
+  return str + " ".repeat(Math.max(0, width - visLen(str)));
+}
+
+// Like wrapText but measures word lengths by visible characters, so ANSI
+// escape sequences in pre-formatted strings don't distort line breaks.
+function wrapTextAnsi(text: string, width: number): string[] {
+  if (width <= 0 || visLen(text) <= width) return [text];
+  const words = text.split(" ");
+  const lines: string[] = [];
+  let current = "";
+  let currentLen = 0;
+  for (const word of words) {
+    const wl = visLen(word);
+    if (currentLen === 0) {
+      if (wl > width) {
+        // Can't safely split ANSI strings mid-character; push as-is.
+        lines.push(word);
+      } else {
+        current = word;
+        currentLen = wl;
+      }
+    } else if (currentLen + 1 + wl <= width) {
+      current += " " + word;
+      currentLen += 1 + wl;
+    } else {
+      lines.push(current);
+      if (wl > width) {
+        lines.push(word);
+        current = "";
+        currentLen = 0;
+      } else {
+        current = word;
+        currentLen = wl;
+      }
+    }
+  }
+  if (current) lines.push(current);
+  return lines.length > 0 ? lines : [""];
+}
+
 function distributeWidths(naturalWidths: number[], available: number): number[] {
   const N = naturalWidths.length;
   if (N === 0) return [];
@@ -363,29 +410,35 @@ export function renderTable(tableLines: string[], maxWidth?: number): string {
     line.split("|").slice(1, -1).map(cell => cell.trim())
   );
   const isSep = (row: string[]) => row.every(cell => /^[-: ]+$/.test(cell));
-  const dataRows = rows.filter(r => !isSep(r));
+
+  // Pre-apply inline formatting so column widths are measured in visible
+  // characters, not raw markdown source (e.g. **bold** is 4 visible chars,
+  // not 8 raw chars).
+  const fmtRows = rows.map(row => isSep(row) ? row : row.map(mdInline));
+
+  const dataRows = fmtRows.filter(r => !isSep(r));
   const colCount = Math.max(...dataRows.map(r => r.length));
   const naturalWidths = Array.from({ length: colCount }, (_, i) =>
-    Math.max(...dataRows.map(r => (r[i] ?? "").length))
+    Math.max(...dataRows.map(r => visLen(r[i] ?? "")))
   );
   // overhead: "│ " (2) + " │ " * (N-1) (3*(N-1)) + " │" (2) = 1 + 3*N
   const overhead = 1 + 3 * colCount;
   const available = Math.max(termWidth - overhead, colCount);
   const widths = distributeWidths(naturalWidths, available);
   const renderRow = (row: string[]): string => {
-    const wrapped = widths.map((w, i) => wrapText(row[i] ?? "", w));
+    const wrapped = widths.map((w, i) => wrapTextAnsi(row[i] ?? "", w));
     const numLines = Math.max(...wrapped.map(ls => ls.length));
     const termRows: string[] = [];
     for (let ln = 0; ln < numLines; ln++) {
       termRows.push(
-        "│ " + widths.map((w, i) => mdInline((wrapped[i][ln] ?? "").padEnd(w))).join(" │ ") + " │"
+        "│ " + widths.map((w, i) => ansiPadEnd(wrapped[i][ln] ?? "", w)).join(" │ ") + " │"
       );
     }
     return termRows.join("\n");
   };
   const divider = "├─" + widths.map(w => "─".repeat(w)).join("─┼─") + "─┤";
   const out: string[] = [];
-  for (const row of rows) {
+  for (const row of fmtRows) {
     if (isSep(row)) { out.push(divider); continue; }
     out.push(renderRow(row));
   }

--- a/tests/repl.markdown.test.ts
+++ b/tests/repl.markdown.test.ts
@@ -294,6 +294,77 @@ describe("renderTable - text wrapping", () => {
   });
 });
 
+describe("renderTable - inline formatting column widths", () => {
+  it("all rows have equal visible column widths when mixing bold and plain cells", () => {
+    // **Alice** is 9 raw chars but 5 visible; Bob is 3 visible
+    // Both columns should render with the same width (max visible = 5)
+    const lines = [
+      "| Name | Status |",
+      "| --- | --- |",
+      "| **Alice** | active |",
+      "| Bob | inactive |",
+    ];
+    const result = renderTable(lines, 80);
+    const rowLines = stripAnsi(result).split("\n").filter(l => l.startsWith("│"));
+    const lengths = rowLines.map(l => l.length);
+    expect(lengths.every(l => l === lengths[0])).toBe(true);
+  });
+
+  it("bold cell renders with ANSI bold codes in output", () => {
+    const lines = [
+      "| Name |",
+      "| --- |",
+      "| **Alice** |",
+    ];
+    const result = renderTable(lines, 80);
+    expect(result).toContain("\x1b[1m");
+    expect(stripAnsi(result)).toContain("Alice");
+  });
+
+  it("inline code in table cell renders with bold+underline", () => {
+    const lines = [
+      "| Command |",
+      "| --- |",
+      "| `git status` |",
+    ];
+    const result = renderTable(lines, 80);
+    expect(result).toContain("\x1b[1m");
+    expect(result).toContain("\x1b[4m");
+    expect(stripAnsi(result)).toContain("git status");
+  });
+
+  it("column width reflects visible length not raw markdown length", () => {
+    // A table with only one formatted cell; column width should equal
+    // the visible length of **bold** (4), not the raw length (9)
+    // Header "Col" is 3 chars, so column width = max(3, 4) = 4
+    const lines = [
+      "| Col |",
+      "| --- |",
+      "| **bold** |",
+    ];
+    const result = stripAnsi(renderTable(lines, 80));
+    expect(result).toContain("bold");
+    // Divider for width=4: "├─" + "────" + "─┤" = "├──────┤"
+    expect(result).toContain("├──────┤");
+    // Data row for "bold" padded to 4: "│ bold │" (no extra spaces)
+    expect(result).toContain("│ bold │");
+  });
+
+  it("plain text rows still align with formatted rows", () => {
+    const lines = [
+      "| Name | Status |",
+      "| --- | --- |",
+      "| **Alice** | active |",
+      "| Bob | inactive |",
+    ];
+    const result = stripAnsi(renderTable(lines, 80));
+    const rowLines = result.split("\n").filter(l => l.startsWith("│"));
+    // Each row must end with │ at the same position
+    const lastPipe = rowLines.map(l => l.lastIndexOf("│"));
+    expect(lastPipe.every(p => p === lastPipe[0])).toBe(true);
+  });
+});
+
 describe("renderMarkdown - mixed content", () => {
   it("heading + paragraph + list all rendered", () => {
     const input = "# Title\n\nSome text.\n\n- item1\n- item2";


### PR DESCRIPTION
## Summary

- Column widths in `renderTable` were measured from raw markdown source length, so `**bold**` (8 raw chars) allocated 8 chars of width, but only 5 visible chars ("bold" + ANSI codes) were rendered — causing the `│` separators to appear misaligned across rows.
- Pre-applies `mdInline` to each cell before width measurement, then uses `visLen` (ANSI-stripped length) for `naturalWidths` computation.
- Adds `ansiPadEnd` and `wrapTextAnsi` helpers that measure visible character widths correctly when padding/wrapping pre-formatted (ANSI-containing) strings.

## Test plan

- [ ] New tests in `renderTable - inline formatting column widths`: verifies bold/plain cells in same column produce equal-length rows, bold ANSI codes are present, divider width matches visible content
- [ ] All existing `renderTable` wrapping tests still pass (plain text is unaffected since `visLen(plainText) === plainText.length`)
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run lint` passes

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)