### PR TITLE
feat: add verbose-only formatter for hello_ack message

### DIFF
--- a/src/display.ts
+++ b/src/display.ts
@@ -535,6 +535,7 @@ export const MESSAGE_FMT: FmtTable = {
 export const FOREMAN_MESSAGE_FMT: FmtTable = {
   task_assigned:      { verbose: (m) => c.darkGray(`Task assigned: #${m.issue.number}, ${m.issue.title}`) },
   event_notification: { verbose: (m) => c.darkGray(`Event received [${fmtTime()}]: ${fmtEvent(m.event as GitHubEvent)}`) },
+  hello_ack:          { verbose: (m) => c.darkGray(`hello_ack: ${m.status}`) },
   _default:           (m) => c.darkGray(`Unknown foreman message: ${m.type}`),
 };
 

--- a/tests/repl.foreman-message.test.ts
+++ b/tests/repl.foreman-message.test.ts
@@ -137,6 +137,35 @@ describe("printForemanMessage", () => {
 
 });
 
+describe("printForemanMessage - hello_ack", () => {
+  it("hello_ack, VERBOSE=false → silent", () => {
+    const msg: ForemanMessage = { type: "hello_ack", workerId: "w-1", status: "idle" };
+    const output = captureOutput(() => printForemanMessage(msg));
+    expect(stripAnsi(output).trim()).toBe("");
+  });
+
+  it("hello_ack, VERBOSE=true → prints ack status", () => {
+    setVerbose(true);
+    const msg: ForemanMessage = { type: "hello_ack", workerId: "w-1", status: "idle" };
+    const output = captureOutput(() => printForemanMessage(msg));
+    expect(stripAnsi(output)).toContain("idle");
+  });
+
+  it("hello_ack, VERBOSE=true → includes status for busy", () => {
+    setVerbose(true);
+    const msg: ForemanMessage = { type: "hello_ack", workerId: "w-1", status: "busy" };
+    const output = captureOutput(() => printForemanMessage(msg));
+    expect(stripAnsi(output)).toContain("busy");
+  });
+
+  it("hello_ack, VERBOSE=true → includes status for cancelled", () => {
+    setVerbose(true);
+    const msg: ForemanMessage = { type: "hello_ack", workerId: "w-1", status: "cancelled" };
+    const output = captureOutput(() => printForemanMessage(msg));
+    expect(stripAnsi(output)).toContain("cancelled");
+  });
+});
+
 describe("printForemanMessage - _default", () => {
   it("unknown type prints <type>", () => {
     const output = captureOutput(() => printForemanMessage({ type: "unknown_future_type" } as any));


### PR DESCRIPTION
## Summary
- Adds a `hello_ack` entry to `FOREMAN_MESSAGE_FMT` in `src/display.ts`
- Formatter is verbose-only (silent in default mode)
- Prints the ack status (`idle`, `busy`, or `cancelled`)
- Replaces the generic "Unknown foreman message: hello_ack" fallback

## Test plan
- [ ] `hello_ack` with verbose=false → silent (no output)
- [ ] `hello_ack` with verbose=true → prints the status value (`idle`, `busy`, `cancelled`)
- [ ] Type check passes (`npx tsc --noEmit`)

Closes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)