### PR TITLE
fix: reduce effective terminal width in verbose mode

### DIFF
--- a/src/display.ts
+++ b/src/display.ts
@@ -5,6 +5,18 @@ import type { ForemanMessage, GitHubEvent } from "./types.js";
 export const W = 70;
 export const hr = (ch = "─") => ch.repeat(W);
 
+/** Visible width of the verbose timestamp prefix "HH:mm:ss " */
+export const VERBOSE_PREFIX_LEN = 9;
+
+/**
+ * Returns the usable terminal width, accounting for the verbose timestamp
+ * prefix when verbose mode is active. Pass a fallback used when
+ * process.stdout.columns is unavailable.
+ */
+export function effectiveWidth(fallback = W): number {
+  return (process.stdout.columns ?? fallback) - (verbose ? VERBOSE_PREFIX_LEN : 0);
+}
+
 // ── Verbose flag ──────────────────────────────────────────────────────────────
 
 export let verbose = false;
@@ -40,7 +52,7 @@ export const s = {
 };
 
 export function clearBreak(): string {
-  const width = process.stdout.columns ?? W;
+  const width = effectiveWidth();
   const label = "=== Context cleared ";
   const fill = "=".repeat(Math.max(0, width - label.length));
   return "\n" + c.sageGreen(s.bold(label + fill));
@@ -220,7 +232,7 @@ export function fmtToolCall(b: ToolUseBlock, fmt: string) {
 
 export function fmtHunk(hunk: Hunk): string {
   const header = c.darkGray(`@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@`);
-  const width = process.stdout.columns ?? 80;
+  const width = effectiveWidth(80);
   const lines = hunk.lines.map(line => {
     if (line.startsWith("+")) return c.bgGreen(line.padEnd(width));
     if (line.startsWith("-")) return c.bgRed(line.padEnd(width));
@@ -413,7 +425,7 @@ function distributeWidths(naturalWidths: number[], available: number): number[] 
 }
 
 export function renderTable(tableLines: string[], maxWidth?: number): string {
-  const termWidth = maxWidth ?? (process.stdout.columns || W);
+  const termWidth = maxWidth ?? effectiveWidth();
   const rows = tableLines.map(line =>
     line.split("|").slice(1, -1).map(cell => cell.trim())
   );

--- a/tests/display.effective-width.test.ts
+++ b/tests/display.effective-width.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { stripAnsi } from "./helpers.js";
+import {
+  setVerbose,
+  effectiveWidth,
+  VERBOSE_PREFIX_LEN,
+  clearBreak,
+  renderTable,
+  fmtHunk,
+  W,
+} from "../src/display.js";
+
+beforeEach(() => setVerbose(false));
+afterEach(() => setVerbose(false));
+
+describe("VERBOSE_PREFIX_LEN", () => {
+  it("is 9 (length of 'HH:mm:ss ')", () => {
+    expect(VERBOSE_PREFIX_LEN).toBe(9);
+  });
+});
+
+describe("effectiveWidth()", () => {
+  it("verbose=false: returns full terminal width", () => {
+    setVerbose(false);
+    const expected = process.stdout.columns ?? W;
+    expect(effectiveWidth()).toBe(expected);
+  });
+
+  it("verbose=true: returns terminal width minus VERBOSE_PREFIX_LEN", () => {
+    setVerbose(true);
+    const expected = (process.stdout.columns ?? W) - VERBOSE_PREFIX_LEN;
+    expect(effectiveWidth()).toBe(expected);
+  });
+
+  it("verbose=false with custom fallback: uses fallback when no columns", () => {
+    setVerbose(false);
+    const cols = process.stdout.columns;
+    if (cols == null) {
+      expect(effectiveWidth(80)).toBe(80);
+    } else {
+      expect(effectiveWidth(80)).toBe(cols);
+    }
+  });
+
+  it("verbose=true with custom fallback: subtracts prefix from fallback when no columns", () => {
+    setVerbose(true);
+    const cols = process.stdout.columns;
+    if (cols == null) {
+      expect(effectiveWidth(80)).toBe(80 - VERBOSE_PREFIX_LEN);
+    } else {
+      expect(effectiveWidth(80)).toBe(cols - VERBOSE_PREFIX_LEN);
+    }
+  });
+});
+
+describe("clearBreak() - verbose mode reduces width", () => {
+  it("verbose=false: divider fills full terminal width", () => {
+    setVerbose(false);
+    const expectedWidth = process.stdout.columns ?? W;
+    const lines = stripAnsi(clearBreak()).split("\n");
+    expect(lines[1]).toHaveLength(expectedWidth);
+  });
+
+  it("verbose=true: divider is narrower by VERBOSE_PREFIX_LEN", () => {
+    setVerbose(true);
+    const expectedWidth = (process.stdout.columns ?? W) - VERBOSE_PREFIX_LEN;
+    const lines = stripAnsi(clearBreak()).split("\n");
+    expect(lines[1]).toHaveLength(expectedWidth);
+  });
+});
+
+describe("renderTable() - verbose mode reduces width", () => {
+  const tableLines = [
+    "| A | B |",
+    "| --- | --- |",
+    "| short | text |",
+  ];
+
+  it("verbose=false: uses full terminal width for layout", () => {
+    setVerbose(false);
+    const fullWidth = process.stdout.columns ?? W;
+    const verboseResult = stripAnsi(renderTable(tableLines));
+    const explicitResult = stripAnsi(renderTable(tableLines, fullWidth));
+    expect(verboseResult).toBe(explicitResult);
+  });
+
+  it("verbose=true: uses reduced width (same as maxWidth minus VERBOSE_PREFIX_LEN)", () => {
+    setVerbose(true);
+    const reducedWidth = (process.stdout.columns ?? W) - VERBOSE_PREFIX_LEN;
+    const verboseResult = stripAnsi(renderTable(tableLines));
+    const explicitResult = stripAnsi(renderTable(tableLines, reducedWidth));
+    expect(verboseResult).toBe(explicitResult);
+  });
+});
+
+describe("fmtHunk() - verbose mode reduces padding width", () => {
+  const hunk = {
+    oldStart: 1, oldLines: 1, newStart: 1, newLines: 1,
+    lines: ["+added line", "-removed line", " context line"],
+  };
+
+  it("verbose=false: diff lines padded to full terminal width", () => {
+    setVerbose(false);
+    const fullWidth = process.stdout.columns ?? 80;
+    const result = fmtHunk(hunk);
+    // Strip ANSI and find the added line — it should be padded to fullWidth
+    const addedLine = stripAnsi(result).split("\n").find(l => l.startsWith("+"));
+    expect(addedLine).toBeDefined();
+    expect(addedLine!.length).toBe(fullWidth);
+  });
+
+  it("verbose=true: diff lines padded to reduced width", () => {
+    setVerbose(true);
+    const reducedWidth = (process.stdout.columns ?? 80) - VERBOSE_PREFIX_LEN;
+    const result = fmtHunk(hunk);
+    const addedLine = stripAnsi(result).split("\n").find(l => l.startsWith("+"));
+    expect(addedLine).toBeDefined();
+    expect(addedLine!.length).toBe(reducedWidth);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `VERBOSE_PREFIX_LEN = 9` constant (visible width of the `"HH:mm:ss "` timestamp prefix)
- Adds `effectiveWidth(fallback?)` helper that returns the terminal width minus `VERBOSE_PREFIX_LEN` when verbose mode is active, and the full width otherwise
- Updates `clearBreak`, `fmtHunk`, and `renderTable` to use `effectiveWidth()` instead of reading `process.stdout.columns` directly

This prevents diff color-fill lines and Markdown tables from overflowing the terminal width when the verbose timestamp prefix is present.

## Test plan

- [ ] `tests/display.effective-width.test.ts` — new tests covering `VERBOSE_PREFIX_LEN`, `effectiveWidth()` in both modes, and the corrected behavior of `clearBreak`, `renderTable`, and `fmtHunk`
- [ ] Existing `display.clear-break.test.ts` still passes (verbose=false is the default; `effectiveWidth()` returns the full width in that case)
- [ ] `npx tsc --noEmit` passes

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)