### PR TITLE
feat: print relative filenames in tool call display

### DIFF
--- a/src/display.ts
+++ b/src/display.ts
@@ -198,6 +198,14 @@ export function fmtStats(secs: number, turns?: number, outputTokens?: number, in
   return parts.join(", ");
 }
 
+export function toRelativePath(filePath: string): string {
+  const cwd = process.cwd();
+  if (filePath === cwd) return ".";
+  const prefix = cwd + "/";
+  if (filePath.startsWith(prefix)) return filePath.slice(prefix.length);
+  return filePath;
+}
+
 export function fmtArgs(input: Record<string, unknown>, maxVal = 50): string {
   return Object.entries(input ?? {})
     .map(([k, v]) => `${k}=${trunc(String(v), maxVal)}`)
@@ -515,11 +523,11 @@ export const USER_BLOCK_FMT: FmtTable = {
 
 export const TOOL_CALL_FMT: FmtTable = {
   Bash:       (b) => fmtToolCall(b, `$ ${b.input?.command ?? ""}`),
-  Read:       (b) => fmtToolCall(b, `• Read(${b.input?.file_path ?? "?"})`),
-  Write:      (b) => fmtToolCall(b, `• Write(${b.input?.file_path ?? "?"})`),
-  Edit:       (b) => fmtToolCall(b, `• Edit(${b.input?.file_path ?? "?"})`),
+  Read:       (b) => fmtToolCall(b, `• Read(${toRelativePath(b.input?.file_path ?? "?")})`),
+  Write:      (b) => fmtToolCall(b, `• Write(${toRelativePath(b.input?.file_path ?? "?")})`),
+  Edit:       (b) => fmtToolCall(b, `• Edit(${toRelativePath(b.input?.file_path ?? "?")})`),
   Glob:       (b) => fmtToolCall(b, `• Glob(${b.input?.pattern ?? "?"})`),
-  Grep:       (b) => fmtToolCall(b, `• grep ${trunc(b.input?.pattern ?? "?", 30)} ${b.input?.path ?? "."}`),
+  Grep:       (b) => fmtToolCall(b, `• grep ${trunc(b.input?.pattern ?? "?", 30)} ${b.input?.path != null ? toRelativePath(b.input.path as string) : "."}`),
   Skill:      (b) => fmtToolCall(b, `• Skill(${b.input?.skill ?? "?"})`),
   Agent:      (b) => fmtToolCall(b, `• ${b.input?.subagent_type ?? "Agent"}(${trunc(b.input?.prompt ?? "", 80)})`),
   ToolSearch: (b) => fmtToolCall(b, `• ToolSearch(${b.input?.query ?? "?"})`),

--- a/tests/display.relative-paths.test.ts
+++ b/tests/display.relative-paths.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for toRelativePath() — strips cwd prefix from file paths before display.
+ */
+import path from "path";
+import { describe, it, expect } from "vitest";
+import { stripAnsi } from "./helpers.js";
+import { toRelativePath, resolve, TOOL_CALL_FMT, type FmtTable } from "../src/display.js";
+
+function r(table: FmtTable, key: string, data: any): string | null {
+  const result = resolve(table, key, data);
+  return result === null ? null : stripAnsi(result);
+}
+
+describe("toRelativePath()", () => {
+  it("strips cwd prefix from path under cwd", () => {
+    const abs = path.join(process.cwd(), "src/foreman.ts");
+    expect(toRelativePath(abs)).toBe("src/foreman.ts");
+  });
+
+  it("strips cwd prefix from deeply nested path under cwd", () => {
+    const abs = path.join(process.cwd(), "tests/fixtures/messages.ts");
+    expect(toRelativePath(abs)).toBe("tests/fixtures/messages.ts");
+  });
+
+  it("returns original path when not under cwd", () => {
+    expect(toRelativePath("/tmp/some/other/file.ts")).toBe("/tmp/some/other/file.ts");
+  });
+
+  it("returns '.' when path equals cwd exactly", () => {
+    expect(toRelativePath(process.cwd())).toBe(".");
+  });
+
+  it("does not confuse cwd prefix with a differently-named parent directory", () => {
+    // e.g. cwd=/home/foo, path=/home/foobar/file.ts should NOT become "bar/file.ts"
+    const cwd = process.cwd();
+    const sibling = cwd + "extra/file.ts"; // no separator, so not a child
+    expect(toRelativePath(sibling)).toBe(sibling);
+  });
+
+  it("returns path unchanged when already relative", () => {
+    expect(toRelativePath("src/foreman.ts")).toBe("src/foreman.ts");
+  });
+});
+
+describe("TOOL_CALL_FMT — relative paths for Read/Write/Edit", () => {
+  it("Read: relativizes absolute path under cwd", () => {
+    const abs = path.join(process.cwd(), "src/foreman.ts");
+    const result = r(TOOL_CALL_FMT, "Read", { input: { file_path: abs } });
+    expect(result).toContain("• Read(src/foreman.ts)");
+    expect(result).not.toContain(process.cwd());
+  });
+
+  it("Read: keeps path outside cwd as-is", () => {
+    const result = r(TOOL_CALL_FMT, "Read", { input: { file_path: "/foo/bar.ts" } });
+    expect(result).toContain("• Read(/foo/bar.ts)");
+  });
+
+  it("Write: relativizes absolute path under cwd", () => {
+    const abs = path.join(process.cwd(), "src/output.ts");
+    const result = r(TOOL_CALL_FMT, "Write", { input: { file_path: abs } });
+    expect(result).toContain("• Write(src/output.ts)");
+    expect(result).not.toContain(process.cwd());
+  });
+
+  it("Write: keeps path outside cwd as-is", () => {
+    const result = r(TOOL_CALL_FMT, "Write", { input: { file_path: "/foo/out.ts" } });
+    expect(result).toContain("• Write(/foo/out.ts)");
+  });
+
+  it("Edit: relativizes absolute path under cwd", () => {
+    const abs = path.join(process.cwd(), "src/edit.ts");
+    const result = r(TOOL_CALL_FMT, "Edit", { input: { file_path: abs } });
+    expect(result).toContain("• Edit(src/edit.ts)");
+    expect(result).not.toContain(process.cwd());
+  });
+
+  it("Edit: keeps path outside cwd as-is", () => {
+    const result = r(TOOL_CALL_FMT, "Edit", { input: { file_path: "/foo/edit.ts" } });
+    expect(result).toContain("• Edit(/foo/edit.ts)");
+  });
+});
+
+describe("TOOL_CALL_FMT — relative paths for Grep", () => {
+  it("Grep: relativizes absolute path under cwd", () => {
+    const abs = path.join(process.cwd(), "src");
+    const result = r(TOOL_CALL_FMT, "Grep", { input: { pattern: "foo", path: abs } });
+    expect(result).toContain("• grep foo src");
+    expect(result).not.toContain(process.cwd());
+  });
+
+  it("Grep: keeps path outside cwd as-is", () => {
+    const result = r(TOOL_CALL_FMT, "Grep", { input: { pattern: "foo", path: "/src" } });
+    expect(result).toContain("• grep foo /src");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `toRelativePath()` helper in `src/display.ts` that strips the `process.cwd()` prefix from absolute file paths
- Applies it to `Read`, `Write`, `Edit` (via `file_path`) and `Grep` (via `path`) entries in `TOOL_CALL_FMT`
- Paths outside the working directory are shown unchanged
- New test file `tests/display.relative-paths.test.ts` covers the helper and the four affected formatters

## Test plan

- [ ] `toRelativePath()` unit tests: path under cwd → relative, path outside cwd → unchanged, path equal to cwd → `.`, adjacent-name (no separator) edge case, already-relative path
- [ ] `TOOL_CALL_FMT` tests: Read/Write/Edit/Grep each relativize cwd-prefixed paths and leave outside-cwd paths as-is
- [ ] Existing `repl.formats.test.ts` tests for Read/Write/Edit still pass (they use `/foo/bar.ts` which is outside cwd)
- [ ] Type check (`npx tsc --noEmit`) passes
- [ ] Lint (`npm run lint`) passes

Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)