### PR TITLE
docs: update CLAUDE.md to remove brunel:done label reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # brunel
 
-A GitHub-driven autonomous agent. Labels a GitHub issue `brunel:ready` → the foreman picks it up, assigns it to a worker → the worker runs a Claude Agent SDK loop and labels it `brunel:done` when finished.
+A GitHub-driven autonomous agent. Labels a GitHub issue `brunel:ready` → the foreman picks it up, assigns it to a worker → the worker runs a Claude Agent SDK loop and reports completion when finished.
 
 ## Architecture
 


### PR DESCRIPTION
Removes the stale reference to `brunel:done` in the top-level description of CLAUDE.md, following the removal of the done label feature in #395.

## Test plan
- [ ] No code changes — docs only