### PR TITLE
Delete method-call-only tests, keep behavior edge cases

### DIFF
--- a/frontend/tests/Dashboard.test.tsx
+++ b/frontend/tests/Dashboard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, act } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import Dashboard from "../src/pages/Dashboard.tsx";
@@ -30,15 +30,6 @@ const webhookEntry: LogEntry = {
   summary: "issues/labeled #42",
 };
 
-const messageEntry: LogEntry = {
-  kind: "message",
-  id: 2,
-  timestamp: "2026-01-01T10:01:00.000Z",
-  taskId: "42",
-  workerId: "worker-abc-123",
-  summary: "sent task_assigned",
-};
-
 describe("Dashboard", () => {
   beforeEach(() => {
     capturedHandler = null;
@@ -51,41 +42,6 @@ describe("Dashboard", () => {
   it("shows empty state when no events", () => {
     renderDashboard();
     expect(screen.getByText("No events yet.")).toBeInTheDocument();
-  });
-
-  it("renders events from initial_log WebSocket message", async () => {
-    renderDashboard();
-    act(() => {
-      capturedHandler!({ type: "initial_log", entries: [webhookEntry, messageEntry] });
-    });
-    expect(screen.getByText("issues/labeled #42")).toBeInTheDocument();
-    expect(screen.getByText("sent task_assigned")).toBeInTheDocument();
-  });
-
-  it("shows both webhook and message kinds from initial_log", async () => {
-    renderDashboard();
-    act(() => {
-      capturedHandler!({ type: "initial_log", entries: [webhookEntry, messageEntry] });
-    });
-    expect(screen.getByText("webhook")).toBeInTheDocument();
-    expect(screen.getByText("message")).toBeInTheDocument();
-  });
-
-  it("prepends new log_event messages to events from initial_log", async () => {
-    const newEntry: LogEntry = { kind: "message", id: 3, timestamp: "2026-01-01T10:02:00.000Z", taskId: null, workerId: "worker-abc-123", summary: "received worker_hello" };
-    renderDashboard();
-
-    act(() => {
-      capturedHandler!({ type: "initial_log", entries: [webhookEntry] });
-    });
-    expect(screen.getByText("issues/labeled #42")).toBeInTheDocument();
-
-    act(() => {
-      capturedHandler!({ type: "log_event", entry: newEntry });
-    });
-
-    expect(screen.getByText("received worker_hello")).toBeInTheDocument();
-    expect(screen.getByText("issues/labeled #42")).toBeInTheDocument();
   });
 
   it("does not add events to log on snapshot messages", async () => {

--- a/frontend/tests/TaskDetail.test.tsx
+++ b/frontend/tests/TaskDetail.test.tsx
@@ -64,12 +64,6 @@ describe("TaskDetail", () => {
     await waitFor(() => expect(fetch).toHaveBeenCalledWith("/api/tasks/99/events"));
   });
 
-  it("shows task id in heading", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([]) }));
-    renderTaskDetail("99");
-    await waitFor(() => expect(screen.getByText(/Task #99/)).toBeInTheDocument());
-  });
-
   it("shows empty state when no events", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([]) }));
     renderTaskDetail("99");

--- a/frontend/tests/WorkerDetail.test.tsx
+++ b/frontend/tests/WorkerDetail.test.tsx
@@ -66,12 +66,6 @@ describe("WorkerDetail", () => {
     );
   });
 
-  it("shows truncated worker id in heading", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([]) }));
-    renderWorkerDetail("worker-abc-def-123");
-    await waitFor(() => expect(screen.getByText(/Worker worker-a/)).toBeInTheDocument());
-  });
-
   it("shows empty state when no messages", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([]) }));
     renderWorkerDetail("worker-abc-def-123");

--- a/tests/foreman.admin-broadcast.test.ts
+++ b/tests/foreman.admin-broadcast.test.ts
@@ -1,9 +1,16 @@
 /**
- * Tests that verify the foreman broadcasts BOTH webhook events AND foreman
- * messages to the admin dashboard via adminWss.broadcastLogEvent().
+ * Tests for snapshot-broadcasting behavior: reactive dispatch, debounce, and
+ * prNumber propagation when a PR is opened.
  *
- * Covers the bug in issue #249: only webhooks were broadcast; messages were
- * silently dropped from the real-time admin event log.
+ * The per-event-type log-entry format tests were removed in issue #383 — they
+ * are covered by foreman.logging.test.ts (pure-function) and by the Playwright
+ * admin-dashboard tests (end-to-end). What remains are edge cases that neither
+ * of those suites exercises:
+ *   - snapshot debounce: burst mutations collapse to one broadcast
+ *   - reactive wiring: snapshot fires automatically on state change, not via
+ *     manual callsites
+ *   - prNumber propagation: opening a PR updates the task's prNumber in the
+ *     snapshot
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import http from "http";
@@ -12,17 +19,15 @@ import type { AddressInfo } from "net";
 import { TaskQueue, WorkerRegistry, createForemanWss } from "../src/foreman.js";
 import { loadDefaultConfig } from "../src/config.js";
 const defaultCfg = await loadDefaultConfig();
-import type { AdminWss, AdminSnapshot, LogEntry } from "../src/admin-ws.js";
+import type { AdminWss, AdminSnapshot } from "../src/admin-ws.js";
 import { waitUntil } from "./helpers.js";
 
 // ── Mock AdminWss ─────────────────────────────────────────────────────────────
 
-function makeMockAdminWss(): AdminWss & { logEntries: LogEntry[] } {
-  const logEntries: LogEntry[] = [];
+function makeMockAdminWss(): AdminWss {
   return {
-    logEntries,
     broadcastSnapshot() {},
-    broadcastLogEvent(entry) { logEntries.push({ ...entry }); },
+    broadcastLogEvent() {},
   };
 }
 
@@ -36,22 +41,8 @@ function connectWorker(port: number): Promise<WebSocket> {
   });
 }
 
-function nextMsg(ws: WebSocket): Promise<unknown> {
-  return new Promise((resolve) => {
-    ws.once("message", (data) => resolve(JSON.parse(data.toString())));
-  });
-}
-
 function send(ws: WebSocket, msg: object) {
   ws.send(JSON.stringify(msg));
-}
-
-function closeClient(ws: WebSocket): Promise<void> {
-  return new Promise((resolve) => {
-    if (ws.readyState === WebSocket.CLOSED) { resolve(); return; }
-    ws.once("close", resolve);
-    ws.close();
-  });
 }
 
 // ── Test harness ──────────────────────────────────────────────────────────────
@@ -60,7 +51,7 @@ let queue: TaskQueue;
 let registry: WorkerRegistry;
 let httpServer: http.Server;
 let wss: WebSocketServer;
-let adminWss: ReturnType<typeof makeMockAdminWss>;
+let adminWss: AdminWss;
 let routeEvent: (id: string, name: string, payload: unknown) => void;
 let port: number;
 const openClients: WebSocket[] = [];
@@ -115,195 +106,6 @@ afterEach(() => {
 });
 
 // ── Scenarios ─────────────────────────────────────────────────────────────────
-
-describe("foreman admin broadcast — webhook events", () => {
-  it("broadcasts a webhook event as kind='webhook'", () => {
-    routeEvent("evt-1", "issues", {
-      action: "labeled",
-      label: { name: defaultCfg.taskLabel },
-      issue: { number: 42, title: "Fix the bug", body: "", labels: [] },
-      repository: { html_url: "https://github.com/owner/repo" },
-    });
-
-    expect(adminWss.logEntries).toHaveLength(1);
-    expect(adminWss.logEntries[0].kind).toBe("webhook");
-  });
-
-  it("broadcasts webhook event with a non-zero unique id", () => {
-    routeEvent("evt-1", "issues", { action: "labeled", label: { name: defaultCfg.taskLabel }, issue: { number: 1, title: "T", body: "", labels: [] }, repository: { html_url: "https://github.com/owner/repo" } });
-    routeEvent("evt-2", "issues", { action: "labeled", label: { name: defaultCfg.taskLabel }, issue: { number: 2, title: "T", body: "", labels: [] }, repository: { html_url: "https://github.com/owner/repo" } });
-
-    expect(adminWss.logEntries).toHaveLength(2);
-    const [e1, e2] = adminWss.logEntries;
-    expect(e1.id).toBeGreaterThan(0);
-    expect(e2.id).toBeGreaterThan(0);
-    expect(e1.id).not.toBe(e2.id);
-  });
-
-  it("broadcasts webhook event with summary and taskId", () => {
-    queue.addTask({ taskId: "42", issueNumber: 42, title: "Fix", body: "", labels: [], repoUrl: "https://github.com/owner/repo" });
-
-    routeEvent("evt-1", "issue_comment", {
-      action: "created",
-      issue: { number: 42 },
-      comment: { body: "LGTM" },
-      repository: { html_url: "https://github.com/owner/repo" },
-    });
-
-    expect(adminWss.logEntries[0].taskId).toBe("42");
-    expect(adminWss.logEntries[0].summary).toMatch(/issue_comment/);
-  });
-
-  it("broadcasts check_run event with name and conclusion", () => {
-    routeEvent("evt-1", "check_run", {
-      action: "completed",
-      check_run: { name: "CI / build", conclusion: "success", pull_requests: [] },
-      repository: { html_url: "https://github.com/owner/repo" },
-    });
-
-    expect(adminWss.logEntries[0].summary).toContain("CI / build");
-    expect(adminWss.logEntries[0].summary).toContain("success");
-  });
-
-  it("broadcasts issue_comment event with truncated comment text", () => {
-    queue.addTask({ taskId: "42", issueNumber: 42, title: "Fix", body: "", labels: [], repoUrl: "https://github.com/owner/repo" });
-
-    routeEvent("evt-1", "issue_comment", {
-      action: "created",
-      issue: { number: 42 },
-      comment: { body: "Looks good to me!" },
-      repository: { html_url: "https://github.com/owner/repo" },
-    });
-
-    expect(adminWss.logEntries[0].summary).toContain("Looks good to me!");
-  });
-
-  it("broadcasts push event with branch", () => {
-    routeEvent("evt-1", "push", {
-      ref: "refs/heads/main",
-      commits: [{}],
-      repository: { html_url: "https://github.com/owner/repo" },
-    });
-
-    expect(adminWss.logEntries[0].summary).toContain("refs/heads/main");
-  });
-
-  it("broadcasts delete event with ref_type and ref", () => {
-    routeEvent("evt-1", "delete", {
-      ref_type: "branch",
-      ref: "feature/old",
-      repository: { html_url: "https://github.com/owner/repo" },
-    });
-
-    expect(adminWss.logEntries[0].summary).toContain("branch");
-    expect(adminWss.logEntries[0].summary).toContain("feature/old");
-  });
-
-  it("broadcasts issues/labeled event with label name", () => {
-    routeEvent("evt-1", "issues", {
-      action: "labeled",
-      label: { name: "wontfix" },
-      issue: { number: 5, title: "Minor thing", body: "", labels: [] },
-      repository: { html_url: "https://github.com/owner/repo" },
-    });
-
-    expect(adminWss.logEntries[0].summary).toContain("wontfix");
-  });
-});
-
-describe("foreman admin broadcast — sent messages", () => {
-  it("broadcasts task_assigned sent to worker as kind='message'", async () => {
-    queue.addTask({ taskId: "1", issueNumber: 1, title: "Fix", body: "", labels: [], repoUrl: "https://github.com/owner/repo" });
-
-    const ws = await connect();
-    const reply = nextMsg(ws);
-    send(ws, { type: "worker_hello", workerId: "worker-abc", status: "idle" });
-    await reply; // task_assigned
-
-    const msgEntries = adminWss.logEntries.filter((e) => e.kind === "message");
-    const assigned = msgEntries.find((e) => e.summary.includes("task_assigned"));
-    expect(assigned).toBeDefined();
-    expect(assigned!.taskId).toBe("1");
-  });
-});
-
-describe("foreman admin broadcast — received messages", () => {
-  it("broadcasts received worker_hello as kind='message'", async () => {
-    const ws = await connect();
-    send(ws, { type: "worker_hello", workerId: "worker-abc", status: "idle" });
-    await waitUntil(() => !!registry.get("worker-abc"));
-
-    const received = adminWss.logEntries.filter(
-      (e) => e.kind === "message" && e.summary.includes("received") && e.summary.includes("worker_hello"),
-    );
-    expect(received.length).toBeGreaterThan(0);
-  });
-
-  it("broadcasts worker_hello with 'idle' status in summary", async () => {
-    const ws = await connect();
-    send(ws, { type: "worker_hello", workerId: "worker-abc", status: "idle" });
-    await waitUntil(() => !!registry.get("worker-abc"));
-
-    const hello = adminWss.logEntries.find(
-      (e) => e.kind === "message" && e.summary.includes("worker_hello"),
-    );
-    expect(hello?.summary).toContain("idle");
-  });
-
-  it("broadcasts received task_complete as kind='message'", async () => {
-    queue.addTask({ taskId: "1", issueNumber: 1, title: "Fix", body: "", labels: [], repoUrl: "https://github.com/owner/repo" });
-
-    const ws = await connect();
-    send(ws, { type: "worker_hello", workerId: "worker-abc", status: "idle" });
-    await nextMsg(ws); // task_assigned
-
-    adminWss.logEntries.length = 0; // reset
-    send(ws, { type: "task_complete", workerId: "worker-abc", taskId: "1" });
-    await waitUntil(() => registry.get("worker-abc")?.status === "idle");
-
-    const received = adminWss.logEntries.filter(
-      (e) => e.kind === "message" && e.summary.includes("task_complete"),
-    );
-    expect(received.length).toBeGreaterThan(0);
-  });
-
-  it("broadcasts disconnect event as kind='message' with workerId and close code in summary", async () => {
-    const ws = await connect();
-    send(ws, { type: "worker_hello", workerId: "worker-abc", status: "idle" });
-    await waitUntil(() => !!registry.get("worker-abc"));
-
-    adminWss.logEntries.length = 0;
-    await closeClient(ws);
-    await waitUntil(() => !registry.get("worker-abc"));
-
-    const disconnected = adminWss.logEntries.find(
-      (e) => e.kind === "message" && e.summary.includes("disconnected"),
-    );
-    expect(disconnected).toBeDefined();
-    expect(disconnected!.workerId).toBe("worker-abc");
-    expect(disconnected!.summary).toMatch(/code \d+/);
-  });
-});
-
-describe("foreman admin broadcast — unique IDs across all event types", () => {
-  it("assigns unique IDs to webhook and message broadcasts", async () => {
-    const ws = await connect();
-    send(ws, { type: "worker_hello", workerId: "worker-abc", status: "idle" });
-    await waitUntil(() => !!registry.get("worker-abc"));
-
-    routeEvent("evt-1", "issues", {
-      action: "labeled",
-      label: { name: defaultCfg.taskLabel },
-      issue: { number: 99, title: "T", body: "", labels: [] },
-      repository: { html_url: "https://github.com/owner/repo" },
-    });
-
-    const ids = adminWss.logEntries.map((e) => e.id);
-    const uniqueIds = new Set(ids);
-    expect(uniqueIds.size).toBe(ids.length);
-    expect(ids.every((id) => id > 0)).toBe(true);
-  });
-});
 
 describe("foreman admin broadcast — snapshot on PR registration", () => {
   it("broadcasts updated snapshot with prNumber when a PR is opened for a task", async () => {


### PR DESCRIPTION
## Summary

- Reduces `tests/foreman.admin-broadcast.test.ts` from 13 tests to 3: removes all per-event-format and per-message mock-call tests; keeps snapshot behavior tests (prNumber propagation, reactive dispatch, debounce) not covered by Playwright
- Prunes `frontend/tests/Dashboard.test.tsx`: removes 3 basic-rendering tests now covered by Playwright's log-stream and live-assignment specs
- Prunes `frontend/tests/TaskDetail.test.tsx` and `WorkerDetail.test.tsx`: removes 1 heading test each, both covered exactly by Playwright

The three logging test files named in the issue (`foreman.webhook-logging.test.ts`, `foreman.worker-logging.test.ts`, `foreman.event-forwarding-logging.test.ts`) did not exist in the codebase — no action required for those.

## Test plan

- [ ] `npm test` passes in CI (requires Supabase, which CI starts automatically)
- [ ] No meaningful behavior is left uncovered: pipeline tests verify DB state, Playwright tests verify browser rendering, remaining unit tests cover edge cases

Closes #383