### PR TITLE
ci: cache Supabase/Playwright, parallelize test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,29 @@ jobs:
         with:
           version: latest
 
+      - name: Get Supabase CLI version for cache key
+        id: supabase-version
+        run: echo "version=$(supabase --version)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Supabase Docker images
+        id: supabase-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/supabase-images.tar
+          key: supabase-docker-${{ runner.os }}-${{ steps.supabase-version.outputs.version }}
+
+      - name: Load cached Supabase images
+        if: steps.supabase-cache.outputs.cache-hit == 'true'
+        run: docker load -i /tmp/supabase-images.tar
+
       - name: Start local Supabase
         run: supabase start
+
+      - name: Save Supabase Docker images
+        if: steps.supabase-cache.outputs.cache-hit != 'true'
+        run: |
+          docker save $(docker images --format '{{.Repository}}:{{.Tag}}' | grep -v '<none>') \
+            -o /tmp/supabase-images.tar
 
       - name: Export Supabase credentials for tests
         run: |
@@ -57,8 +78,27 @@ jobs:
 
       - run: npm run lint
 
+  browser-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: npm ci
+
       - name: Build frontend for browser tests
         run: npm run build
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('package-lock.json') }}
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium


### PR DESCRIPTION
## Summary

- Splits CI into two parallel jobs: `test` (vitest + Supabase) and `browser-test` (Playwright)
- Caches Supabase Docker image tarball keyed on CLI version — saves ~60-90s on warm runs
- Caches Playwright browser binaries keyed on `package-lock.json` — saves ~30s on warm runs

On warm caches, wall-clock time should drop from ~3.5 min to ~1.5 min (dominated by whichever job is slower).

First run after merging will be a cold-cache miss for both, so expect the usual ~3.5 min. After that, caches stay warm until the Supabase CLI version or `package-lock.json` changes.

## Test plan

- [ ] Verify both jobs appear and run in parallel on the PR checks page
- [ ] Merge, then open a follow-up PR and confirm cache hits appear in the workflow logs for both Supabase and Playwright steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)