### PR TITLE
feat: include permissions, output mode, and logfile in worker startup banner

### DIFF
--- a/src/repl.ts
+++ b/src/repl.ts
@@ -403,6 +403,9 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
       githubToken: config.githubToken,
       githubRepo: config.githubRepo,
       repoUrl: config.repoUrl,
+      permissionMode: config.permissionMode,
+      verbose: config.verbose,
+      logFile: LOG_FILE,
     });
   } else {
     void main(permConfig, workspaceCfg);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -7,6 +7,7 @@ import * as display from "./display.js";
 import { buildInitialPrompt, buildEventPrompt } from "./templates.js";
 import { ask, listWorkerCommands, dispatchInput, pick } from "./input.js";
 import type { ForemanMessage, GitHubEvent, TaskIssue, WorkerMessage } from "./types.js";
+import type { PermissionMode } from "@anthropic-ai/claude-agent-sdk";
 import { Workspace, confirmIfUnsafe } from "./workspace.js";
 import { fmtError } from "./utils.js";
 
@@ -440,6 +441,9 @@ export async function workerMain(
     githubToken: string;
     githubRepo: string;
     repoUrl?: string;
+    permissionMode: PermissionMode;
+    verbose: boolean;
+    logFile: string;
   },
 ): Promise<void> {
   const FOREMAN_URL = config.foremanUrl;
@@ -520,6 +524,7 @@ export async function workerMain(
   display.print(display.c.sageGreen(display.hr("═")));
   display.print(display.c.skyBlue(display.s.bold("  Brunel Worker")));
   display.print(display.c.lavender(`  Worker ID: ${workerId} | Foreman: ${FOREMAN_URL}`));
+  display.print(display.c.lavender(`  Permissions: ${config.permissionMode} | Output: ${config.verbose ? "verbose" : "quiet"} | Log: ${config.logFile}`));
   display.print(display.c.sageGreen(display.hr("═")));
 
   session.start();

--- a/tests/worker.main.test.ts
+++ b/tests/worker.main.test.ts
@@ -42,6 +42,8 @@ vi.mock("../src/input.js", async (importOriginal) => {
 import { workerMain } from "../src/worker.js";
 import { Workspace, confirmIfUnsafe } from "../src/workspace.js";
 import * as inputModule from "../src/input.js";
+import * as displayModule from "../src/display.js";
+import { stripAnsi } from "./helpers.js";
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -50,6 +52,9 @@ const WORKER_CONFIG = {
   workspaceDir: "/fake/workers",
   githubToken: "test-token",
   githubRepo: "owner/repo",
+  permissionMode: "bypassPermissions" as const,
+  verbose: true,
+  logFile: "worker.log",
 };
 
 async function runWorkerMain(): Promise<{ exitCalled: boolean; exitCode: number | undefined }> {
@@ -73,6 +78,32 @@ async function runWorkerMain(): Promise<{ exitCalled: boolean; exitCode: number 
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("workerMain startup banner", () => {
+  let chdirSpy: ReturnType<typeof vi.spyOn>;
+  let printSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    chdirSpy = vi.spyOn(process, "chdir").mockImplementation(() => {});
+    printSpy = vi.spyOn(displayModule, "print").mockImplementation(() => {});
+    vi.mocked(inputModule.ask).mockResolvedValue("__eof__");
+    vi.mocked(confirmIfUnsafe).mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    chdirSpy.mockRestore();
+    printSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it("includes permissions, output mode, and logfile in the startup banner", async () => {
+    await runWorkerMain();
+    const printed = printSpy.mock.calls.map(([s]: [unknown]) => stripAnsi(String(s))).join("\n");
+    expect(printed).toContain("Permissions: bypassPermissions");
+    expect(printed).toContain("Output: verbose");
+    expect(printed).toContain("Log: worker.log");
+  });
+});
 
 describe("workerMain exit behavior", () => {
   let chdirSpy: ReturnType<typeof vi.spyOn>;


### PR DESCRIPTION
## Summary

- Adds `permissionMode`, `verbose`, and `logFile` to `workerMain`'s config type
- Prints a banner line in worker mode matching the REPL's format: `Permissions: <mode> | Output: verbose/quiet | Log: <file>`
- Passes those values from `repl.ts` when starting in `--worker-mode`
- Adds a test in `worker.main.test.ts` that verifies the banner line is printed

## Test plan

- [ ] New test `workerMain startup banner > includes permissions, output mode, and logfile in the startup banner` covers the new behavior
- [ ] TypeScript type-check passes (`npx tsc --noEmit`)
- [ ] ESLint passes (`npm run lint`)
- [ ] CI passes

Closes #236