### PR TITLE
build: pin supabase/setup-cli to node24-compatible commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: 20
 
-      - uses: supabase/setup-cli@v1
+      - uses: supabase/setup-cli@03559d0a6c2f0163187cadab1412d6dce3a6a481 # node24-compatible (post-v1.6.0)
         with:
           version: latest
 

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: supabase/setup-cli@v1
+      - uses: supabase/setup-cli@03559d0a6c2f0163187cadab1412d6dce3a6a481 # node24-compatible (post-v1.6.0)
         with:
           version: latest
 


### PR DESCRIPTION
## Summary

- The `supabase/setup-cli@v1` branch still targets Node.js 20, which GitHub Actions is deprecating (forced migration June 2, 2026)
- No new tagged release or updated `v1` branch has been published yet; the node24 fix landed on `main` as commit `03559d0a6c2f0163187cadab1412d6dce3a6a481` (PR [#400](https://github.com/supabase/setup-cli/pull/400))
- Pins both `ci.yml` and `migrate.yml` to that commit SHA, which is also a security best practice (prevents supply-chain attacks via a mutable tag)

## Test plan

- [ ] CI passes on this PR (the pinned commit uses `node24`)
- [ ] No functional change — only the action ref changes; all Supabase CLI behaviour is identical

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)