### PR TITLE
feat: fun construction-themed action verbs instead of always "Working…"

### DIFF
--- a/src/display.ts
+++ b/src/display.ts
@@ -746,3 +746,32 @@ export function printMessage(msg: unknown) {
 export function printForemanMessage(msg: ForemanMessage) {
   print(resolve(FOREMAN_MESSAGE_FMT, msg.type, msg));
 }
+
+// ── Working verb ───────────────────────────────────────────────────────────────
+
+export const WORKING_VERBS = [
+  "Building",
+  "Constructing",
+  "Surveying",
+  "Drafting",
+  "Engineering",
+  "Excavating",
+  "Framing",
+  "Grading",
+  "Laying foundations",
+  "Paving",
+  "Scaffolding",
+  "Welding",
+  "Wiring",
+  "Plumbing",
+  "Blueprinting",
+  "Pouring concrete",
+  "Raising beams",
+  "Riveting",
+  "Hoisting",
+  "Bolting",
+];
+
+export function pickWorkingVerb(): string {
+  return WORKING_VERBS[Math.floor(Math.random() * WORKING_VERBS.length)];
+}

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -99,10 +99,11 @@ export async function runQuery(
   // message_delta.usage.output_tokens is cumulative per message, so we sum
   // completed messages and track the current one separately.
   const stats = { turns: 0, inputTokens: 0, completedOutputTokens: 0, currentOutputTokens: 0 };
+  const workingVerb = display.pickWorkingVerb();
   const getStatusText = () => {
     const secs = Math.floor((Date.now() - startTime) / 1000);
     const outTokens = stats.completedOutputTokens + stats.currentOutputTokens;
-    return display.c.darkGray(`Working… ${display.fmtStats(secs, stats.turns || undefined, outTokens || undefined, stats.inputTokens || undefined)}`);
+    return display.c.darkGray(`${workingVerb}… ${display.fmtStats(secs, stats.turns || undefined, outTokens || undefined, stats.inputTokens || undefined)}`);
   };
   display.startStatus(getStatusText);
 

--- a/tests/repl.working-verb.test.ts
+++ b/tests/repl.working-verb.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { WORKING_VERBS, pickWorkingVerb } from "../src/display.js";
+
+describe("WORKING_VERBS", () => {
+  it("is a non-empty array", () => {
+    expect(Array.isArray(WORKING_VERBS)).toBe(true);
+    expect(WORKING_VERBS.length).toBeGreaterThan(0);
+  });
+
+  it("contains only non-empty strings", () => {
+    for (const verb of WORKING_VERBS) {
+      expect(typeof verb).toBe("string");
+      expect(verb.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("includes expected construction/engineering verbs", () => {
+    // At minimum these theme-appropriate verbs should be present
+    const lower = WORKING_VERBS.map((v) => v.toLowerCase());
+    expect(lower).toContain("building");
+    expect(lower).toContain("constructing");
+  });
+});
+
+describe("pickWorkingVerb", () => {
+  it("returns a string from WORKING_VERBS", () => {
+    const verb = pickWorkingVerb();
+    expect(WORKING_VERBS).toContain(verb);
+  });
+
+  it("returns different verbs over many calls (not always the same)", () => {
+    // With enough calls, we should see more than one unique verb (probabilistic)
+    const seen = new Set<string>();
+    for (let i = 0; i < 200; i++) {
+      seen.add(pickWorkingVerb());
+    }
+    expect(seen.size).toBeGreaterThan(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `WORKING_VERBS` array to `display.ts` with 20 construction/civil-engineering-themed present-participle verbs (e.g. "Building", "Surveying", "Excavating", "Riveting", etc.)
- Adds `pickWorkingVerb()` that returns a random entry from the array
- Updates `repl.ts` to pick a verb once per query session and use it in the status line (e.g. "Blueprinting… 5s, 2 turns")

## Test plan

- [ ] `tests/repl.working-verb.test.ts` verifies `WORKING_VERBS` is a non-empty array of strings, includes expected verbs, and `pickWorkingVerb()` returns values from the array and produces variation over many calls
- [ ] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] Lint passes (`npm run lint`)

Closes #421