### PR TITLE
feat: humanized Puritan-name worker IDs

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,45 @@
+export const PURITAN_NAMES = [
+  "caleb",
+  "charity",
+  "clement",
+  "constance",
+  "ebenezer",
+  "elihu",
+  "endeavour",
+  "experience",
+  "ezekiel",
+  "faith",
+  "grace",
+  "hezekiah",
+  "hope",
+  "humility",
+  "increase",
+  "jedediah",
+  "jeremiah",
+  "justice",
+  "mercy",
+  "nehemiah",
+  "obadiah",
+  "patience",
+  "preserved",
+  "prudence",
+  "resolved",
+  "silence",
+  "submit",
+  "temperance",
+  "thankful",
+  "verity",
+  "waitstill",
+  "zephaniah",
+];
+
+/** Generate a human-readable worker ID by prepending a random Puritan name to a UUID.
+ * E.g. "patience-a9bdda00-1234-5678-abcd-ef0123456789" */
+export function generateWorkerId(): string {
+  const name = PURITAN_NAMES[Math.floor(Math.random() * PURITAN_NAMES.length)];
+  return `${name}-${crypto.randomUUID()}`;
+}
+
 /** Serialize an unknown thrown value to a human-readable string.
  * Handles native Error, Supabase PostgrestError (plain object with `message`), strings, and fallback JSON. */
 export function fmtError(err: unknown): string {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,5 +1,4 @@
 import "dotenv/config";
-import crypto from "crypto";
 import os from "node:os";
 import path from "node:path";
 import { WebSocket } from "ws";
@@ -9,7 +8,7 @@ import { ask, listWorkerCommands, dispatchInput, pick } from "./input.js";
 import type { ForemanMessage, GitHubEvent, TaskIssue, WorkerMessage } from "./types.js";
 import type { PermissionMode } from "@anthropic-ai/claude-agent-sdk";
 import { Workspace, confirmIfUnsafe } from "./workspace.js";
-import { fmtError } from "./utils.js";
+import { fmtError, generateWorkerId } from "./utils.js";
 
 // ── Event classification ───────────────────────────────────────────────────────
 
@@ -447,7 +446,7 @@ export async function workerMain(
   },
 ): Promise<void> {
   const FOREMAN_URL = config.foremanUrl;
-  const workerId = crypto.randomUUID();
+  const workerId = generateWorkerId();
 
   const originalCwd = process.cwd();
   const workspaceDir = config.workspaceDir ?? path.join(os.homedir(), ".brunel", "workers");

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { generateWorkerId, PURITAN_NAMES } from "../src/utils.js";
+
+describe("generateWorkerId", () => {
+  it("returns a string with a Puritan name prefix followed by a UUID", () => {
+    const id = generateWorkerId();
+    // Format: <name>-<uuid>
+    const parts = id.split("-");
+    // UUID has 5 parts; name adds 1 more at the front
+    expect(parts.length).toBe(6);
+    expect(PURITAN_NAMES).toContain(parts[0]);
+  });
+
+  it("contains a valid UUID after the name prefix", () => {
+    const id = generateWorkerId();
+    const uuidPart = id.slice(id.indexOf("-") + 1);
+    expect(uuidPart).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("uses lowercase names", () => {
+    for (let i = 0; i < 20; i++) {
+      const id = generateWorkerId();
+      const name = id.split("-")[0];
+      expect(name).toBe(name.toLowerCase());
+    }
+  });
+
+  it("generates unique IDs", () => {
+    const ids = new Set(Array.from({ length: 100 }, () => generateWorkerId()));
+    expect(ids.size).toBe(100);
+  });
+
+  it("PURITAN_NAMES contains at least 20 names", () => {
+    expect(PURITAN_NAMES.length).toBeGreaterThanOrEqual(20);
+  });
+});


### PR DESCRIPTION
## Summary

- Worker IDs now take the form `patience-a9bdda00-1234-...` instead of a bare UUID
- Adds `PURITAN_NAMES` list (32 names) and `generateWorkerId()` to `src/utils.ts`
- Removes the now-unused `crypto` import from `src/worker.ts`
- Adds `tests/utils.test.ts` covering format, UUID validity, lowercase, uniqueness, and list size

## Test plan

- [ ] `npm run lint` passes
- [ ] `npx tsc --noEmit` passes
- [ ] `npm test` passes (requires Supabase; runs in CI)
- [ ] Smoke-test: start a worker and confirm the printed Worker ID looks like `patience-a9bdda00-...`

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)