### PR TITLE
feat: format system/api_retry messages in amber warning color

### DIFF
--- a/src/display.ts
+++ b/src/display.ts
@@ -589,6 +589,7 @@ export const SYSTEM_FMT: FmtTable = {
   task_notification: (m) => c.lavender(`  ◀︎ ${m.status}: ${m.summary}`),
   compact_boundary:  (m) => c.darkGray(`↩ Context compacted (${fmtCompactionDetail(m.compact_metadata)})`),
   status:            (m) => m.status === "compacting" ? c.darkGray("Compacting context...") : null,
+  api_retry:         (m) => c.amber(`API failure, retrying in ${(m.retry_delay_ms / 1000).toFixed(1).replace(/\.0$/, "")}s (attempt ${m.attempt}/${m.max_retries})`),
   hook_started:      { verbose: (m) => c.darkGray(`hook: ${m.hook_name} (${m.hook_event})`) },
   hook_response:     { verbose: (m) => c.darkGray(`hook: ${m.hook_name} — ${m.outcome}${fmtHookExitCode(m.exit_code)}`) },
   _default:          { verbose: (m) => c.darkGray(`system/${m.subtype}`) },

--- a/tests/repl.formats.test.ts
+++ b/tests/repl.formats.test.ts
@@ -610,6 +610,29 @@ describe("SYSTEM_FMT", () => {
       .toBe("hook: my-hook — success");
   });
 
+  it("api_retry → shown in non-verbose mode (not verbose-only)", () => {
+    setVerbose(false);
+    const msg = { subtype: "api_retry", attempt: 1, max_retries: 10, retry_delay_ms: 500 };
+    expect(resolve(SYSTEM_FMT, "api_retry", msg)).not.toBeNull();
+  });
+
+  it("api_retry → amber warning color", () => {
+    const msg = { subtype: "api_retry", attempt: 1, max_retries: 10, retry_delay_ms: 500 };
+    const raw = resolve(SYSTEM_FMT, "api_retry", msg)!;
+    // amber: \x1b[38;5;214m
+    expect(raw).toContain("\x1b[38;5;214m");
+  });
+
+  it("api_retry → 'API failure, retrying in Xs (attempt N/M)'", () => {
+    const msg = { subtype: "api_retry", attempt: 1, max_retries: 10, retry_delay_ms: 545.686 };
+    expect(r(SYSTEM_FMT, "api_retry", msg)).toBe("API failure, retrying in 0.5s (attempt 1/10)");
+  });
+
+  it("api_retry → rounds delay to 1 decimal place", () => {
+    const msg = { subtype: "api_retry", attempt: 3, max_retries: 5, retry_delay_ms: 2000 };
+    expect(r(SYSTEM_FMT, "api_retry", msg)).toBe("API failure, retrying in 2s (attempt 3/5)");
+  });
+
   it("_default, VERBOSE=false → null", () => {
     setVerbose(false);
     expect(resolve(SYSTEM_FMT, "unknown_subtype", { subtype: "unknown_subtype" })).toBeNull();


### PR DESCRIPTION
## Summary

- Adds a formatter for `system/api_retry` messages in `SYSTEM_FMT`
- Always shown (not verbose-only) since retries are important operational info
- Displayed in amber warning color
- Format: `API failure, retrying in 0.5s (attempt 1/10)`

## Test plan

- [ ] `api_retry` shown in non-verbose mode (not null)
- [ ] `api_retry` uses amber color (`\x1b[38;5;214m`)
- [ ] Delay formatted correctly: 545.686ms → `0.5s`, 2000ms → `2s`
- [ ] Attempt/max shown correctly

Closes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)