### PR TITLE
feat: set npm min-release-age=7

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7


### PR DESCRIPTION
Adds `.npmrc` with `min-release-age=7` so npm will refuse to install packages published less than 7 days ago. This protects against typosquatting and early-window supply chain attacks.

Closes #437