### PR TITLE
Handle API errors in worker gracefully (fix crash on out-of-tokens)

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -480,16 +480,21 @@ export class WorkerSession {
       const ac = new AbortController();
       this.isRunningQuery = true;
       this.refreshStatus();
+      let queryFailed = false;
       try {
         this.currentSessionId = await this.runQuery(initialPrompt, this.currentSessionId, ac) ?? this.currentSessionId;
+      } catch (err) {
+        if (err instanceof Error && /aborted by user/i.test(err.message)) return;
+        this.display.print(display.c.boldRed(`\nERROR: ${fmtError(err)}`));
+        queryFailed = true;
       } finally {
         this.isRunningQuery = false;
         this.refreshStatus();
         void this.refreshBranch();
       }
 
-      // If the user interrupted (^C), skip the event drain and foreman notification.
-      if (ac.signal.aborted) return;
+      // If the user interrupted (^C) or the query failed, skip the event drain.
+      if (ac.signal.aborted || queryFailed) return;
 
       while (this.pendingEvents.length > 0 && this.currentTaskId && this.currentIssue) {
         const eventAc = new AbortController();
@@ -499,6 +504,10 @@ export class WorkerSession {
         this.refreshStatus();
         try {
           this.currentSessionId = await this.runQuery(prompt, this.currentSessionId, eventAc) ?? this.currentSessionId;
+        } catch (err) {
+          if (err instanceof Error && /aborted by user/i.test(err.message)) return;
+          this.display.print(display.c.boldRed(`\nERROR: ${fmtError(err)}`));
+          return;
         } finally {
           this.isRunningQuery = false;
           this.refreshStatus();

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1350,6 +1350,76 @@ describe("afterTask callback on /task-complete", () => {
   });
 });
 
+// ── API error handling ────────────────────────────────────────────────────────
+
+describe("runQuery error handling", () => {
+  it("prints error and remains functional when runQuery throws during task_assigned", async () => {
+    const issue = makeIssue();
+    runQuery.mockRejectedValueOnce(new Error("You're out of extra usage · resets 9am (Etc/Unknown)"));
+
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
+    await vi.waitFor(() => expect(runQuery).toHaveBeenCalledOnce());
+
+    // waitUntilIdle should resolve (not hang) after the error
+    const result = await Promise.race([
+      session.waitUntilIdle().then(() => "idle"),
+      new Promise<"timeout">((r) => setTimeout(() => r("timeout"), 200)),
+    ]);
+    expect(result).toBe("idle");
+
+    // Error message should be printed
+    const printCalls = display.print.mock.calls.map(args => stripAnsi(String(args[0])));
+    expect(printCalls.some(s => s.includes("out of extra usage"))).toBe(true);
+  });
+
+  it("prints error and remains functional when runQuery throws during event processing", async () => {
+    const issue = makeIssue();
+    let resolveFirst!: (v: string | undefined) => void;
+    runQuery.mockReturnValueOnce(new Promise<string | undefined>((r) => { resolveFirst = r; }));
+    runQuery.mockRejectedValueOnce(new Error("Claude Code returned an error result: out of tokens"));
+
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
+    await vi.waitFor(() => expect(runQuery).toHaveBeenCalledOnce());
+
+    // Queue an event while query is running
+    sendMsg(fakeWs, { type: "event_notification", taskId: "42", event: makeEvent("issue_comment") });
+
+    // Finish the first query → event processing starts and throws
+    resolveFirst("session-1");
+    await vi.waitFor(() => expect(runQuery).toHaveBeenCalledTimes(2));
+
+    // waitUntilIdle should resolve (not hang) after the error
+    const result = await Promise.race([
+      session.waitUntilIdle().then(() => "idle"),
+      new Promise<"timeout">((r) => setTimeout(() => r("timeout"), 200)),
+    ]);
+    expect(result).toBe("idle");
+
+    // Error message should be printed
+    const printCalls = display.print.mock.calls.map(args => stripAnsi(String(args[0])));
+    expect(printCalls.some(s => s.includes("out of tokens"))).toBe(true);
+  });
+
+  it("does not print error for abort (^C interrupt) — that is a clean interrupt", async () => {
+    const issue = makeIssue();
+    let rejectQuery!: (e: Error) => void;
+    runQuery.mockReturnValueOnce(new Promise<string | undefined>((_r, reject) => { rejectQuery = reject; }));
+
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
+    await vi.waitFor(() => expect(runQuery).toHaveBeenCalledOnce());
+
+    display.print.mockClear();
+    // runQuery (in repl.ts) swallows AbortError and resolves undefined — but
+    // here we simulate a raw abort thrown by the mock (edge case)
+    rejectQuery(new Error("Operation aborted by user"));
+
+    await vi.waitFor(() => session.waitUntilIdle());
+
+    const printCalls = display.print.mock.calls.map(args => stripAnsi(String(args[0])));
+    expect(printCalls.some(s => s.toLowerCase().includes("error"))).toBe(false);
+  });
+});
+
 describe("sendGoodbye", () => {
   it("sends worker_goodbye with workerId and taskId when ws is open and task is active", async () => {
     const issue = makeIssue();


### PR DESCRIPTION
## Summary

- When `runQuery` throws an API error (e.g. "out of extra usage"), the worker crashed with an unhandled rejection because `runQueryLoop` was called via `void` (fire-and-forget) from the task assignment handler
- Fixed by catching errors from `runQuery` inside `runQueryLoop` and printing them via `display.print` — matching the existing REPL behavior in `main()`
- Abort errors (`/aborted by user/i`) are still treated as clean ^C interrupts and produce no error output
- Added tests covering: error during initial task query, error during event-triggered query, and abort (no error printed)

## Test plan

- [ ] `npm test` passes (1128 tests, DB tests excluded without Supabase)
- [ ] `npx tsc --noEmit` passes

Closes #447