### PR TITLE
fix: route startup blocked-status reconciliation through TaskModel

### DIFF
--- a/src/foreman.ts
+++ b/src/foreman.ts
@@ -575,6 +575,7 @@ export function createHttpServer(
 
 export interface ForemanWss {
   wss: WebSocketServer;
+  taskModel: TaskModel;
   routeEvent(id: string, name: string, payload: unknown): void;
   reconcile(): void;
   /** Close all connected worker clients with code 1001 and wait for their close events to fire. */
@@ -1205,7 +1206,7 @@ export function createForemanWss(
     });
   }
 
-  return { wss, routeEvent, reconcile, shutdown };
+  return { wss, taskModel, routeEvent, reconcile, shutdown };
 }
 
 // Only start listening when run directly (not when imported by tests)
@@ -1321,15 +1322,11 @@ if (isMain) {
     for (const t of taskQueue.getPendingAndBlockedTasks()) {
       const shouldBeBlocked = isBlocked(t.issueNumber, graph, openIssues);
       if (t.status === "blocked" && !shouldBeBlocked) {
-        taskQueue.setUnblocked(t.taskId);
-        taskStore.markPending(t.taskId).catch((err) =>
+        foremanWss.taskModel.unblock(t.taskId).catch((err) =>
           flog(`ERROR Failed to mark task #${t.taskId} pending on startup: ${fmtError(err)}`)
         );
       } else if (t.status === "pending" && shouldBeBlocked) {
-        taskQueue.setBlocked(t.taskId);
-        taskStore.markBlocked(t.taskId).catch((err) =>
-          flog(`ERROR Failed to mark task #${t.taskId} blocked on startup: ${fmtError(err)}`)
-        );
+        foremanWss.taskModel.block(t.taskId);
       }
     }
 

--- a/tests/foreman.startup.test.ts
+++ b/tests/foreman.startup.test.ts
@@ -464,14 +464,19 @@ describe("startup — blocked status reconciliation after graph rebuild", () => 
     const graph = new Map([[42, new Set([5])]]);
     const openIssues = new Set<number>(); // issue 5 is closed — not in openIssues
 
-    // Simulate the startup reconciliation loop
+    // Use taskModel from foremanWss (mirrors what main() does after the fix)
+    const { wss: fwss, taskModel } = createForemanWss(taskQueue, registry, httpServer, {
+      taskLabel: "brunel:ready",
+      taskStore,
+      reclaimTimeoutMs: 1000,
+    });
+    wss = fwss;
+
     for (const t of taskQueue.getPendingAndBlockedTasks()) {
       if (t.status === "blocked" && !isBlocked(t.issueNumber, graph, openIssues)) {
-        taskQueue.setUnblocked(t.taskId);
-        taskStore.markPending(t.taskId).catch(() => {});
+        taskModel.unblock(t.taskId).catch(() => {});
       } else if (t.status === "pending" && isBlocked(t.issueNumber, graph, openIssues)) {
-        taskQueue.setBlocked(t.taskId);
-        taskStore.markBlocked(t.taskId).catch(() => {});
+        taskModel.block(t.taskId);
       }
     }
 
@@ -489,13 +494,19 @@ describe("startup — blocked status reconciliation after graph rebuild", () => 
     const graph = new Map([[42, new Set([5])]]);
     const openIssues = new Set([5]);
 
+    // Use taskModel from foremanWss (mirrors what main() does after the fix)
+    const { wss: fwss, taskModel } = createForemanWss(taskQueue, registry, httpServer, {
+      taskLabel: "brunel:ready",
+      taskStore,
+      reclaimTimeoutMs: 1000,
+    });
+    wss = fwss;
+
     for (const t of taskQueue.getPendingAndBlockedTasks()) {
       if (t.status === "blocked" && !isBlocked(t.issueNumber, graph, openIssues)) {
-        taskQueue.setUnblocked(t.taskId);
-        taskStore.markPending(t.taskId).catch(() => {});
+        taskModel.unblock(t.taskId).catch(() => {});
       } else if (t.status === "pending" && isBlocked(t.issueNumber, graph, openIssues)) {
-        taskQueue.setBlocked(t.taskId);
-        taskStore.markBlocked(t.taskId).catch(() => {});
+        taskModel.block(t.taskId);
       }
     }
 


### PR DESCRIPTION
## Summary

- Adds `taskModel: TaskModel` to the `ForemanWss` interface and return value of `createForemanWss`
- Updates the startup blocked-status reconciliation loop in `main()` to call `foremanWss.taskModel.unblock` / `foremanWss.taskModel.block` instead of calling `taskQueue` and `taskStore` directly (which bypassed `TaskModel`)
- Updates the corresponding tests to use `foremanWss.taskModel` so they exercise the actual production code path

## Test plan

- [ ] All existing tests pass (`npm test`)
- [ ] `npx tsc --noEmit` passes (no type errors)
- [ ] The two "startup — blocked status reconciliation" tests now go through `TaskModel` and would fail without the interface change

Closes #480