### PR TITLE
fix: remove pending tasks from task list when their issue is closed

### DIFF
--- a/src/foreman.ts
+++ b/src/foreman.ts
@@ -825,6 +825,7 @@ export function createForemanWss(
       }
 
       if (action === "closed") {
+        labeledIssues.delete(issueNumber);
         openIssues.delete(issueNumber);
 
         // Close this issue as a blocker for any tasks that depend on it.

--- a/tests/foreman.reconcile.test.ts
+++ b/tests/foreman.reconcile.test.ts
@@ -205,9 +205,10 @@ describe("issues/closed — task lifecycle", () => {
     expect(queue.get("42")?.status).toBe("complete");
   });
 
-  it("does not affect a pending task when its issue is closed", () => {
-    // A pending task's issue being closed should not mark it complete —
-    // reconcile() will remove it if the label is also gone.
+  it("removes a pending task from the task list when its issue is closed", () => {
+    // Bug #385: closing a pending issue should remove it from the task list.
+    // Previously, issues/closed did not remove the issue from labeledIssues,
+    // so reconcile() never removed the pending task.
     labeledIssues.set(42, { issue: makeIssue(42), depsLoaded: true });
     queue.addTask({ taskId: "42", issueNumber: 42, title: "T", body: "b", labels: [], repoUrl: "" });
 
@@ -216,7 +217,21 @@ describe("issues/closed — task lifecycle", () => {
       issue: { number: 42, title: "T", body: "", labels: [] },
     });
 
-    expect(queue.get("42")?.status).toBe("pending");
+    expect(queue.get("42")).toBeUndefined();
+  });
+
+  it("does not mark a pending task complete (just removes it) when its issue is closed", () => {
+    // Closing should trigger removal via reconcile, not a status change to complete.
+    labeledIssues.set(42, { issue: makeIssue(42), depsLoaded: true });
+    queue.addTask({ taskId: "42", issueNumber: 42, title: "T", body: "b", labels: [], repoUrl: "" });
+
+    routeEvent("evt-1", "issues", {
+      action: "closed",
+      issue: { number: 42, title: "T", body: "", labels: [] },
+    });
+
+    // Task should be gone entirely, not stuck at "pending" and not bumped to "complete"
+    expect(queue.get("42")).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

- When a GitHub issue is closed, the foreman was removing it from `openIssues` but **not** from `labeledIssues`
- `reconcile()` step 3 removes pending/blocked tasks whose issue is absent from `labeledIssues` — so pending tasks for closed issues lingered in the dashboard forever
- Fix: add `labeledIssues.delete(issueNumber)` in the `issues/closed` webhook handler so the subsequent `reconcile()` call removes the pending task

## Test plan

- [ ] New test: `"removes a pending task from the task list when its issue is closed"` — fails before fix, passes after
- [ ] New test: `"does not mark a pending task complete (just removes it) when its issue is closed"` — confirms the task is gone entirely, not stuck at pending or bumped to complete
- [ ] Existing tests for assigned/complete tasks when closed still pass (those tasks remain in queue as expected)
- [ ] Full test suite: 1192 tests pass

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)