### PR TITLE
fix: two task cancellation bugs

### DIFF
--- a/src/foreman.ts
+++ b/src/foreman.ts
@@ -1100,9 +1100,15 @@ export function createForemanWss(
 
     ws.on("close", (code, reason) => {
       if (workerId) {
+        // Guard against stale close events from a previous connection. If the worker
+        // has already reconnected with a new WebSocket, the old socket's close event
+        // fires after the registry was updated to the new socket — ignore it.
+        const currentState = registry.get(workerId);
+        if (currentState && currentState.ws !== ws) return;
+
         const reasonStr = reason?.length ? `: ${reason}` : "";
         log(workerId, `disconnected (code ${code}${reasonStr})`);
-        const taskId = registry.get(workerId)?.currentTaskId ?? null;
+        const taskId = currentState?.currentTaskId ?? null;
         const disconnPayload = { code, reason: reason?.toString() ?? null };
         dbLogger?.logForemanMessage({
           direction: "received",

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -465,6 +465,7 @@ export class WorkerSession {
     if (msg.type === "hello_ack") {
       if (msg.status === "cancelled") {
         // Task was reassigned while worker was disconnected — stop and reset.
+        this.currentAc?.abort(); // abort any running query immediately
         this.connectionState = "registered";
         this.bufferedMessages = [];
         this.currentTaskId = undefined;

--- a/tests/foreman.websocket.test.ts
+++ b/tests/foreman.websocket.test.ts
@@ -1353,6 +1353,43 @@ describe("reclaim timer (fake timers)", () => {
     await new Promise<void>((r) => wsA2.once("close", r));
     await new Promise<void>((r) => testWss.close(() => srv.close(r)));
   });
+
+  it("stale close from old connection does not corrupt registry when worker has already reconnected", async () => {
+    // Bug: if ws1's close event fires AFTER ws2 has already reconnected and registered,
+    // the foreman was incorrectly marking ws2's registry entry as "disconnected" and
+    // starting a reclaim timer. This would eventually cancel a legitimately working worker.
+
+    // Connect wsA and get a task
+    const wsA = await connect();
+    queue.addTask(makeTask(1));
+    const qA = makeQueue(wsA);
+    send(wsA, { type: "worker_hello", workerId: "worker-a", status: "idle" });
+    await qA.next(); // hello_ack
+    await qA.next(); // task_assigned
+    await waitUntil(() => registry.get("worker-a")?.status === "busy");
+
+    // Worker reconnects with a NEW connection (wsA2) claiming the task,
+    // BEFORE wsA's close event fires on the server.
+    const wsA2 = await connect();
+    const qA2 = makeQueue(wsA2);
+    send(wsA2, { type: "worker_hello", workerId: "worker-a", taskId: "1", status: "busy" });
+    const busyAck = await qA2.next(); // hello_ack busy
+    expect(busyAck).toMatchObject({ type: "hello_ack", status: "busy" });
+    // wsA2's hello has been processed — registry now points to wsA2's server socket
+
+    // Simulate stale close: wsA closes AFTER wsA2 has registered
+    wsA.close();
+    await new Promise<void>((r) => wsA.once("close", r));
+    // Give server a few event-loop ticks to process the close
+    for (let i = 0; i < 10; i++) await new Promise((r) => setImmediate(r));
+
+    // The stale close must be ignored — registry stays "busy", no reclaim timer
+    expect(registry.get("worker-a")?.status).toBe("busy");
+    expect(registry.get("worker-a")?.currentTaskId).toBe("1");
+
+    wsA2.close();
+    await new Promise<void>((r) => wsA2.once("close", r));
+  });
 });
 
 // ── Graceful shutdown ──────────────────────────────────────────────────────────

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -750,6 +750,43 @@ describe("hello_ack handshake — buffering", () => {
     }
   });
 
+  it("aborts running query when hello_ack cancelled is received", async () => {
+    vi.useFakeTimers();
+    try {
+      let capturedAc: AbortController | undefined;
+      let resolveQuery!: (v: string) => void;
+      const pendingQuery = new Promise<string>((resolve) => { resolveQuery = resolve; });
+
+      runQuery.mockImplementationOnce(async (
+        _prompt: string,
+        _sessionId: string | undefined,
+        ac: AbortController,
+      ) => {
+        capturedAc = ac;
+        return pendingQuery;
+      });
+
+      // Assign task — starts runQuery (which is now pending)
+      const issue = makeIssue();
+      sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
+      await vi.waitFor(() => expect(capturedAc).toBeDefined());
+
+      // Simulate reconnect and receive cancelled ack while query is still running
+      const newWs = reconnectWithNewWs();
+      newWs.emit("open");
+      sendMsg(newWs, { type: "hello_ack", workerId: WORKER_ID, status: "cancelled" });
+
+      // The running query's AbortController must be aborted
+      expect(capturedAc?.signal.aborted).toBe(true);
+
+      // Clean up: resolve the pending promise so the async loop can exit
+      resolveQuery("session-1");
+    } finally {
+      vi.restoreAllMocks();
+      vi.useRealTimers();
+    }
+  });
+
   it("flushes buffered task_complete on hello_ack idle (worker had stale task before reconnect)", async () => {
     vi.useFakeTimers();
     try {


### PR DESCRIPTION
## Summary

Fixes two bugs in task cancellation reported in #474.

**Bug 1 — Foreman incorrectly cancels reconnecting worker (stale close race)**

When a worker briefly disconnects and reconnects, there's a race: the old WebSocket's `close` event can fire on the server *after* the worker's new connection has already been registered. The close handler had no guard against this, so it called `markDisconnected` and started a reclaim timer on the new connection's entry — eventually reverting the task to pending, assigning it to another worker, and false-cancelling the original worker.

Fix: check that the closing `ws` still matches the registry's current socket for `workerId`. If the worker has already reconnected, `currentState.ws !== ws` and the stale close is ignored.

**Bug 2 — Worker continues working after receiving cancellation**

When the worker received a `hello_ack cancelled` message, it cleared task state and reset the workspace, but never aborted the currently running query's `AbortController`. The query kept executing even after cancellation — matching the symptom in the logs where the worker printed "Task cancelled" and "Workspace reset" but then continued reasoning about the codebase.

Fix: call `this.currentAc?.abort()` at the top of the `cancelled` branch before clearing task state.

## Test plan

- [x] New test: `worker.test.ts` — `aborts running query when hello_ack cancelled is received`: captures the AbortController in a pending `runQuery` mock, sends `hello_ack cancelled`, asserts the AC was aborted
- [x] New test: `foreman.websocket.test.ts` — `stale close from old connection does not corrupt registry when worker has already reconnected`: connects wsA2 and waits for its `hello_ack`, then closes wsA, asserts registry stays `"busy"`
- [x] All 1193 non-DB tests pass; type check and lint clean

Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)