### PR TITLE
fix: remove Supabase Docker image caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Free disk space
-        run: |
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /usr/local/.ghcup
-
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -27,29 +20,8 @@ jobs:
         with:
           version: latest
 
-      - name: Get Supabase CLI version for cache key
-        id: supabase-version
-        run: echo "version=$(supabase --version)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Supabase Docker images
-        id: supabase-cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/supabase-images.tar
-          key: supabase-docker-${{ runner.os }}-${{ steps.supabase-version.outputs.version }}
-
-      - name: Load cached Supabase images
-        if: steps.supabase-cache.outputs.cache-hit == 'true'
-        run: docker load -i /tmp/supabase-images.tar
-
       - name: Start local Supabase
         run: supabase start
-
-      - name: Save Supabase Docker images
-        if: steps.supabase-cache.outputs.cache-hit != 'true'
-        run: |
-          docker save $(docker images --format '{{.Repository}}:{{.Tag}}' | grep -v '<none>') \
-            -o /tmp/supabase-images.tar
 
       - name: Export Supabase credentials for tests
         run: |


### PR DESCRIPTION
## Summary

- The Docker image cache was making CI **slower**, not faster
- Observed timings on a cache-hit run: 48s (cache restore) + 2m27s (`docker load`) + 38s (`supabase start`) ≈ **3m53s total**
- `supabase start` pulling fresh images directly from Docker Hub takes ~2-3 minutes — comparable or better
- Root cause: `docker load` on a multi-GB tar is inherently slow, and the save step captured all Docker images (not just Supabase ones), making the archive unnecessarily large
- Also removed the "Free disk space" step that was only needed to make room for the cache tar file

## Test plan

- [ ] CI runs on this PR — verify the `test` job completes within the 15-minute timeout
- [ ] Check that "Start local Supabase" step timing is reasonable (expect ~2-3 minutes)
- [ ] No disk-space failures

Closes #471