### PR TITLE
fix: reconcile() syncs title and refreshes DB content for existing tasks

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -244,6 +244,8 @@ export interface TaskStore {
   /** Upsert task: insert with status=pending, or on re-label reset an existing row back to pending
    * and refresh title/body/labels/assigned_at/completed_at/worker_id. */
   upsertTask(taskId: string, issueNumber: number, repo: string, title: string, body: string, labels: string[]): Promise<void>;
+  /** Refresh title/body/labels for an existing task without touching status or assignment. */
+  updateTaskContent(taskId: string, title: string, body: string, labels: string[]): Promise<void>;
   /** Mark task as assigned to a worker. */
   markAssigned(taskId: string, workerId: string): Promise<void>;
   /** Mark task as complete. */
@@ -298,6 +300,13 @@ export function createTaskStore(supabase: SupabaseClient): TaskStore {
         },
         { onConflict: "task_id" },
       );
+      if (error) throw error;
+    },
+
+    async updateTaskContent(taskId, title, body, labels) {
+      const { error } = await supabase.from("tasks")
+        .update({ title, body, labels })
+        .eq("task_id", taskId);
       if (error) throw error;
     },
 
@@ -363,6 +372,7 @@ export function createTaskStore(supabase: SupabaseClient): TaskStore {
 export function createNullTaskStore(): TaskStore {
   return {
     async upsertTask() {},
+    async updateTaskContent() {},
     async markAssigned() {},
     async markComplete() {},
     async markPending() {},

--- a/src/foreman.ts
+++ b/src/foreman.ts
@@ -339,6 +339,12 @@ export class TaskModel {
     await this.store.markPending(taskId);
   }
 
+  refreshContent(taskId: string, title: string, body: string, labels: string[]): void {
+    this.store.updateTaskContent(taskId, title, body, labels).catch((err: unknown) =>
+      this.logError(`ERROR Failed to refresh content for task #${taskId}: ${fmtError(err)}`)
+    );
+  }
+
   register(
     taskId: string,
     issueNumber: number,
@@ -1186,15 +1192,17 @@ export function createForemanWss(
       }
     }
 
-    // Step 2: sync depsLoaded and body/labels from labeledIssues to existing tasks.
-    // body and labels are not stored in the DB, so tasks restored at startup need
-    // them populated from GitHub data once loadIssuesToQueue has run.
+    // Step 2: sync title/body/labels/depsLoaded from labeledIssues to existing tasks.
+    // Tasks restored from the DB at startup need their content refreshed from GitHub
+    // data once loadIssuesToQueue has run.
     for (const [num, { issue, depsLoaded }] of labeledIssues) {
       const t = taskQueue.getTaskForIssue(num);
       if (t) {
         t.depsLoaded = depsLoaded;
+        t.title = issue.title;
         t.body = issue.body;
         t.labels = issue.labels;
+        taskModel.refreshContent(t.taskId, issue.title, issue.body, issue.labels);
       }
     }
 

--- a/tests/foreman.blockers.test.ts
+++ b/tests/foreman.blockers.test.ts
@@ -15,6 +15,7 @@ function makeLabeledIssues(issueNumber: number): Map<number, LabeledIssueState> 
 function makeTaskStore(overrides: Partial<TaskStore> = {}): TaskStore {
   return {
     upsertTask: vi.fn().mockResolvedValue(undefined),
+    updateTaskContent: vi.fn().mockResolvedValue(undefined),
     markAssigned: vi.fn().mockResolvedValue(undefined),
     markComplete: vi.fn().mockResolvedValue(undefined),
     markPending: vi.fn().mockResolvedValue(undefined),

--- a/tests/foreman.reconcile.test.ts
+++ b/tests/foreman.reconcile.test.ts
@@ -55,8 +55,50 @@ describe("reconcile()", () => {
     queue.addTask({ taskId: "42", issueNumber: 42, title: "Existing", body: "b", labels: [], repoUrl: "", depsLoaded: true });
     labeledIssues.set(42, { issue: makeIssue(42), depsLoaded: true });
     reconcile();
-    // Title must not be overwritten by reconcile
-    expect(queue.get("42")?.title).toBe("Existing");
+    // Only one task for issue 42 exists (no duplicate created)
+    expect(queue.getTaskForIssue(42)).toBeDefined();
+    // Title is synced from GitHub
+    expect(queue.get("42")?.title).toBe("Issue 42");
+  });
+
+  it("syncs title from labeledIssues to an existing in-memory task", () => {
+    // Simulates: task restored from DB with empty/stale title, then GitHub data loaded.
+    queue.addTask({ taskId: "42", issueNumber: 42, title: "", body: "b", labels: [], repoUrl: "", depsLoaded: true });
+    labeledIssues.set(42, { issue: { ...makeIssue(42), title: "Real Title" }, depsLoaded: true });
+    reconcile();
+    expect(queue.get("42")?.title).toBe("Real Title");
+  });
+
+  it("calls updateTaskContent for existing tasks (not upsertTask)", async () => {
+    const mockStore = {
+      upsertTask: vi.fn().mockResolvedValue(undefined),
+      markAssigned: vi.fn().mockResolvedValue(undefined),
+      markComplete: vi.fn().mockResolvedValue(undefined),
+      markPending: vi.fn().mockResolvedValue(undefined),
+      markBlocked: vi.fn().mockResolvedValue(undefined),
+      updateTaskContent: vi.fn().mockResolvedValue(undefined),
+      updateTaskPr: vi.fn().mockResolvedValue(undefined),
+      listTasks: vi.fn().mockResolvedValue([]),
+    };
+    const server2 = http.createServer();
+    const { reconcile: rec2 } = createForemanWss(queue, registry, server2, {
+      taskLabel: TASK_LABEL,
+      reclaimTimeoutMs: defaultCfg.workerReclaimTimeoutMs,
+      labeledIssues,
+      taskStore: mockStore as any,
+    });
+
+    // Existing task in queue
+    queue.addTask({ taskId: "42", issueNumber: 42, title: "Old Title", body: "old", labels: [], repoUrl: "", depsLoaded: true });
+    labeledIssues.set(42, { issue: { ...makeIssue(42), title: "New Title", body: "new body", labels: ["brunel:ready", "bug"] }, depsLoaded: true });
+
+    rec2();
+    await new Promise((r) => setImmediate(r));
+
+    // updateTaskContent should be called for the existing task
+    expect(mockStore.updateTaskContent).toHaveBeenCalledWith("42", "New Title", "new body", ["brunel:ready", "bug"]);
+    // upsertTask should NOT be called (it resets status to pending)
+    expect(mockStore.upsertTask).not.toHaveBeenCalled();
   });
 
   it("syncs depsLoaded from labeledIssues to an existing task that has depsLoaded: false", () => {

--- a/tests/foreman.startup.test.ts
+++ b/tests/foreman.startup.test.ts
@@ -20,6 +20,7 @@ function makeTaskStore(rows: Partial<TaskRow>[] = []): TaskStore {
   }));
   return {
     upsertTask: vi.fn().mockResolvedValue(undefined),
+    updateTaskContent: vi.fn().mockResolvedValue(undefined),
     markAssigned: vi.fn().mockResolvedValue(undefined),
     markComplete: vi.fn().mockResolvedValue(undefined),
     markPending: vi.fn().mockResolvedValue(undefined),

--- a/tests/foreman.task-model.test.ts
+++ b/tests/foreman.task-model.test.ts
@@ -7,6 +7,7 @@ import type { TaskStore } from "../src/db.js";
 function makeStore(): TaskStore {
   return {
     upsertTask: vi.fn().mockResolvedValue(undefined),
+    updateTaskContent: vi.fn().mockResolvedValue(undefined),
     markAssigned: vi.fn().mockResolvedValue(undefined),
     markComplete: vi.fn().mockResolvedValue(undefined),
     markPending: vi.fn().mockResolvedValue(undefined),

--- a/tests/foreman.websocket.test.ts
+++ b/tests/foreman.websocket.test.ts
@@ -994,6 +994,7 @@ describe("worker_goodbye — DB persistence", () => {
   it("calls markPending when goodbye carries a taskId", async () => {
     const taskStore: TaskStore = {
       upsertTask: vi.fn().mockResolvedValue(undefined),
+      updateTaskContent: vi.fn().mockResolvedValue(undefined),
       markAssigned: vi.fn().mockResolvedValue(undefined),
       markComplete: vi.fn().mockResolvedValue(undefined),
       markPending: vi.fn().mockResolvedValue(undefined),
@@ -1039,6 +1040,7 @@ describe("worker_goodbye — DB persistence", () => {
   it("does not call markPending when goodbye has no taskId", async () => {
     const taskStore: TaskStore = {
       upsertTask: vi.fn().mockResolvedValue(undefined),
+      updateTaskContent: vi.fn().mockResolvedValue(undefined),
       markAssigned: vi.fn().mockResolvedValue(undefined),
       markComplete: vi.fn().mockResolvedValue(undefined),
       markPending: vi.fn().mockResolvedValue(undefined),
@@ -1085,6 +1087,7 @@ describe("issues/closed — DB persistence", () => {
   it("calls markComplete immediately when an issue is closed while a worker is active", async () => {
     const taskStore: TaskStore = {
       upsertTask: vi.fn().mockResolvedValue(undefined),
+      updateTaskContent: vi.fn().mockResolvedValue(undefined),
       markAssigned: vi.fn().mockResolvedValue(undefined),
       markComplete: vi.fn().mockResolvedValue(undefined),
       markPending: vi.fn().mockResolvedValue(undefined),
@@ -1119,6 +1122,7 @@ describe("worker_hello — DB persistence", () => {
   it("calls markComplete when cancelling a worker whose task is already complete (issue closed)", async () => {
     const taskStore: TaskStore = {
       upsertTask: vi.fn().mockResolvedValue(undefined),
+      updateTaskContent: vi.fn().mockResolvedValue(undefined),
       markAssigned: vi.fn().mockResolvedValue(undefined),
       markComplete: vi.fn().mockResolvedValue(undefined),
       markPending: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Summary

- Adds `updateTaskContent(taskId, title, body, labels)` to `TaskStore` — updates only content fields, not status/assignment
- Adds `TaskModel.refreshContent()` that calls `updateTaskContent` and handles errors
- Fixes `reconcile()` Step 2 to also sync `t.title` from GitHub (alongside body/labels) and call `refreshContent` to persist the update to the DB

Previously, tasks restored from the DB at startup could have stale or empty titles because `reconcile()` only synced `body` and `labels` in memory, never `title`, and never wrote any content back to the DB for existing tasks. Issue #448 showed up in the dashboard with a blank title because of this gap.

## Test plan

- [x] New test: `syncs title from labeledIssues to an existing in-memory task`
- [x] New test: `calls updateTaskContent for existing tasks (not upsertTask)` — uses mock store to verify the DB call happens with correct args, and that `upsertTask` (which resets status) is NOT called
- [x] Updated existing test: `does not create a duplicate task` — corrected assertion now verifies title IS synced from GitHub (old assertion tested the wrong/broken behavior)
- [x] All 1195 non-DB tests pass

Closes #473