### PR TITLE
fix: redraw prompt from correct position on status update during multiline input

### DIFF
--- a/src/display.ts
+++ b/src/display.ts
@@ -709,6 +709,17 @@ export function getInputPrintCallback(): (() => void) | null {
   return _inputPrintCallback;
 }
 
+// Callback invoked when the status bar changes while ask() is active.
+// Unlike _inputPrintCallback (which assumes the cursor is at a fresh new line
+// after display.print()), this callback is called while the cursor is at the
+// current buffer position.  ask() registers a handler that navigates back to
+// the prompt line (using the known cursor row) and calls fullRedraw(), so the
+// status bars are redrawn without misplacing them inside the buffer area.
+let _inputStatusCallback: (() => void) | null = null;
+export function setInputStatusCallback(fn: (() => void) | null) {
+  _inputStatusCallback = fn;
+}
+
 // Callback invoked by print() BEFORE console.log to clear the prompt area.
 // When the prompt string has a leading \n (blank-line prefix), the clear must
 // also erase that blank line; otherwise it is orphaned above the printed
@@ -724,7 +735,7 @@ function _lineCount(): number {
   return n === 2 ? 3 : n; // blank separator between the two bars when both are active
 }
 function _clearStatus() {
-  if (_inputPrintCallback) return; // ask() owns the screen; drawFresh handles redraws
+  if (_inputPrintCallback || _inputStatusCallback) return; // ask() owns the screen; drawFresh handles redraws
   const n = _lineCount();
   if (n === 0) return;
   // Cursor rests on the blank separator row above the status lines.
@@ -738,8 +749,14 @@ function _clearStatus() {
 }
 
 function _drawStatus() {
+  if (_inputStatusCallback) {
+    // ask() is active and cursor is in the buffer area — use the status-aware
+    // redraw that navigates back to the prompt line before redrawing.
+    _inputStatusCallback();
+    return;
+  }
   if (_inputPrintCallback) {
-    // ask() is active — let drawFresh handle the full redraw including status bars.
+    // ask() is active after display.print() — cursor is at a fresh new line.
     _inputPrintCallback();
     return;
   }

--- a/src/input.ts
+++ b/src/input.ts
@@ -575,6 +575,17 @@ export function ask(
       }
     }
 
+    // Called when the status bar changes while ask() is waiting for input.
+    // Unlike drawFresh (which assumes cursor is at a fresh new line after
+    // display.print()), this is called while the cursor is at the current
+    // buffer position.  Navigate back to the prompt line using the known
+    // cursor row, then call fullRedraw so status bars land in the right place.
+    function redrawFromCurrent() {
+      if (done) return;
+      const curRow = screenPosOf(cursor).row;
+      fullRedraw(curRow, computeMatches());
+    }
+
     // Register the fresh-redraw hook so display.print() can notify us.
     // Only register when there is a visible prompt to redraw — an empty prompt
     // string means the caller doesn't want any prompt shown (e.g. worker
@@ -582,6 +593,7 @@ export function ask(
     if (promptLine) {
       display.setInputClearCallback(clearForPrint);
       display.setInputPrintCallback(drawFresh);
+      display.setInputStatusCallback(redrawFromCurrent);
     }
 
     if (abort) {
@@ -611,6 +623,7 @@ export function ask(
     function cleanup() {
       display.setInputPrintCallback(null);
       display.setInputClearCallback(null);
+      display.setInputStatusCallback(null);
       process.stdin.removeListener("data", onData);
     }
 

--- a/tests/repl.multiline.test.ts
+++ b/tests/repl.multiline.test.ts
@@ -250,6 +250,89 @@ describe("ask() - up/down arrow navigation", () => {
   });
 });
 
+// ── Status update callback (issue #486: paste + status bar) ──────────────────
+//
+// When the persistent status bar changes while ask() has a multiline buffer
+// displayed (e.g. from a large paste), the old code called drawFresh() via
+// _inputPrintCallback.  drawFresh() assumes the cursor is at a fresh new line
+// (after display.print()); when called with the cursor in the buffer area it
+// writes the prompt at the wrong row, leaving status-bar text interleaved with
+// the buffer content.
+//
+// The fix: ask() registers _inputStatusCallback = redrawFromCurrent(), which
+// calls fullRedraw(cursorRow, ...).  fullRedraw() navigates back to the prompt
+// line before redrawing, so the status bars always land below the buffer.
+
+describe("ask() - status update during multiline input (issue #486)", () => {
+  it("status update while cursor is on row 1 navigates up to prompt before redrawing", async () => {
+    // cols=10, prompt="> " (2 chars), buffer=9 chars → cursor on row 1.
+    // When updatePersistentStatus fires, the first write should be \x1b[1A
+    // (cursor-up to row 0) so the prompt is redrawn from the top, not from
+    // row 1 where the buffer cursor sits.
+    setColumns(10);
+    const writeSpy = vi.mocked(process.stdout.write);
+
+    display.startPersistentStatus(() => "status");
+
+    await withFakeStdin(async (stdin) => {
+      const p = ask("> ", () => []);
+      stdin.push("123456789"); // cursor on row 1 (9 chars + 2-char prompt wraps)
+      writeSpy.mockClear();
+
+      // Simulate a status update (e.g. branch refresh, WS reconnect) while
+      // the cursor is sitting on row 1 of the multiline buffer.
+      display.updatePersistentStatus();
+
+      // The redraw must start by going up 1 row (\x1b[1A) to reach the prompt
+      // line (row 0), then write the prompt "> ".  Without the fix, drawFresh()
+      // would write the prompt at the current cursor row (row 1), so "\x1b[1A"
+      // would appear only AFTER the prompt text — indicating wrong behaviour.
+      const output = collectOutput(writeSpy);
+      const cursorUp   = output.indexOf("\x1b[1A");
+      const promptPos  = output.indexOf("> ");
+      expect(cursorUp).toBeGreaterThan(-1);   // cursor-up must appear
+      expect(promptPos).toBeGreaterThan(-1);  // prompt must appear
+      // cursor-up must come BEFORE the prompt (navigate back, then draw)
+      expect(cursorUp).toBeLessThan(promptPos);
+
+      stdin.push("\r");
+      expect(await p).toBe("123456789");
+    });
+
+    display.stopPersistentStatus();
+  });
+
+  it("status update while cursor is on row 0 does not emit spurious cursor-up", async () => {
+    // cols=10, prompt="> " (2 chars), buffer=5 chars — all fits on row 0.
+    // No cursor-up should be needed: the prompt is already at the top.
+    setColumns(10);
+    const writeSpy = vi.mocked(process.stdout.write);
+
+    display.startPersistentStatus(() => "status");
+
+    await withFakeStdin(async (stdin) => {
+      const p = ask("> ", () => []);
+      stdin.push("hello"); // 5 chars, stays on row 0
+      writeSpy.mockClear();
+
+      display.updatePersistentStatus();
+
+      const output = collectOutput(writeSpy);
+      // A \x1b[0A is a no-op (guard in fullRedraw), so we just verify the
+      // prompt appears and the output doesn't start with a cursor-up.
+      expect(output).toContain("> ");
+      // First non-trivial write must be \r (go to col 0), not \x1b[NA.
+      const firstWrite = String(writeSpy.mock.calls[0]?.[0] ?? "");
+      expect(firstWrite).not.toMatch(/^\x1b\[\d+A/); // no leading cursor-up
+
+      stdin.push("\r");
+      expect(await p).toBe("hello");
+    });
+
+    display.stopPersistentStatus();
+  });
+});
+
 // ── Print callback (worker mode cursor fix) ────────────────────────────────────
 
 describe("display.print() callback for ask() redraw", () => {


### PR DESCRIPTION
## Summary

- When pasting long text into the worker prompt, `updatePersistentStatus()` could fire while the cursor was positioned inside the multiline buffer area
- `_drawStatus()` was calling `_inputPrintCallback` = `drawFresh()`, which assumes the cursor is at a fresh new line (post-`display.print()`); from the buffer area it wrote the prompt at the wrong row, leaving status-bar text interleaved with the pasted content
- Fix: adds a separate `_inputStatusCallback` that `ask()` populates with `redrawFromCurrent()`, which calls `fullRedraw(screenPosOf(cursor).row, ...)` to navigate back to the prompt line first

## Test plan

- [ ] New tests in `tests/repl.multiline.test.ts` verify that a status update while cursor is on row 1 emits `\x1b[1A` (cursor-up) before the prompt text
- [ ] New test verifies that a status update while cursor is on row 0 does not emit a spurious leading cursor-up
- [ ] Full test suite passes (DB tests excluded — require Supabase)
- [ ] TypeScript type-check clean, lint clean

Closes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)