### PR TITLE
fix: add worker-side heartbeat to detect stale connections

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -174,6 +174,8 @@ export type WorkspaceCtx = {
 export type WorkerSessionOptions = {
   afterTask?: () => Promise<void>;
   workspaceCtx?: WorkspaceCtx;
+  /** Interval in ms between WebSocket pings. Defaults to 20_000. */
+  pingIntervalMs?: number;
 };
 
 // Sentinels used to signal WebSocket events through ask()'s abort param
@@ -432,6 +434,22 @@ export class WorkerSession {
     ws.on("open", () => {
       this.connectionState = "hello_sent";
       this.statusModel.update({ connectionStatus: "handshaking" });
+
+      // Heartbeat: send periodic pings to detect stale connections. If no pong
+      // is received before the next ping fires, the connection is dead — terminate
+      // it so the close handler can trigger a reconnect.
+      let isAlive = true;
+      const intervalMs = this.options.pingIntervalMs ?? 20_000;
+      const pingTimer = setInterval(() => {
+        if (!isAlive) {
+          ws.terminate();
+          return;
+        }
+        isAlive = false;
+        ws.ping();
+      }, intervalMs);
+      ws.on("pong", () => { isAlive = true; });
+      ws.once("close", () => clearInterval(pingTimer));
     });
 
     ws.on("message", (data: Buffer | string) => {

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -9,6 +9,11 @@ import { stripAnsi } from "./helpers.js";
 class FakeWs extends EventEmitter {
   readyState = 1; // OPEN
   send = vi.fn();
+  ping = vi.fn();
+  terminate = vi.fn(() => {
+    this.readyState = 3; // CLOSED
+    this.emit("close", 1006, Buffer.from(""));
+  });
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
@@ -1639,5 +1644,101 @@ describe("interrupt()", () => {
     await session.waitUntilIdle();
 
     expect(session.interrupt()).toBe(false);
+  });
+});
+
+// ── Heartbeat ─────────────────────────────────────────────────────────────────
+
+describe("heartbeat", () => {
+  const PING_INTERVAL = 100;
+  let pingWs: FakeWs;
+  let pingWsFactory: ReturnType<typeof vi.fn>;
+  let pingSession: WorkerSession;
+
+  beforeEach(() => {
+    pingWs = new FakeWs();
+    pingWsFactory = vi.fn().mockReturnValue(pingWs);
+    pingSession = new WorkerSession(WORKER_ID, pingWsFactory, runQuery, display, { pingIntervalMs: PING_INTERVAL });
+    pingSession.start();
+  });
+
+  it("sends a ping after the interval when the connection is open", () => {
+    vi.useFakeTimers();
+    try {
+      pingWs.emit("open");
+      vi.advanceTimersByTime(PING_INTERVAL);
+      expect(pingWs.ping).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("terminates connection when no pong is received before the next ping", () => {
+    vi.useFakeTimers();
+    try {
+      pingWs.emit("open");
+      vi.advanceTimersByTime(PING_INTERVAL); // first ping sent, isAlive set to false
+      expect(pingWs.ping).toHaveBeenCalledOnce();
+      vi.advanceTimersByTime(PING_INTERVAL); // second interval: no pong → terminate
+      expect(pingWs.terminate).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not terminate when a pong is received between pings", () => {
+    vi.useFakeTimers();
+    try {
+      pingWs.emit("open");
+      vi.advanceTimersByTime(PING_INTERVAL); // first ping sent
+      pingWs.emit("pong");                   // pong received → isAlive = true
+      vi.advanceTimersByTime(PING_INTERVAL); // second ping sent (not terminate)
+      expect(pingWs.terminate).not.toHaveBeenCalled();
+      expect(pingWs.ping).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reconnects after heartbeat-induced termination", () => {
+    vi.useFakeTimers();
+    try {
+      const newWs = new FakeWs();
+      pingWsFactory.mockReturnValueOnce(newWs);
+
+      pingWs.emit("open");
+      vi.advanceTimersByTime(PING_INTERVAL * 2); // two intervals → terminate → close → reconnect scheduled
+      vi.advanceTimersByTime(5001); // advance past the reconnect delay
+      expect(pingWsFactory).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("shows Disconnected in status bar after heartbeat timeout", () => {
+    vi.useFakeTimers();
+    try {
+      pingWs.emit("open");
+      sendMsg(pingWs, { type: "hello_ack", workerId: WORKER_ID, status: "idle" });
+      expect(stripAnsi(pingSession.getStatusText())).toContain("Connected");
+
+      vi.advanceTimersByTime(PING_INTERVAL * 2); // two intervals → terminate → close
+      expect(stripAnsi(pingSession.getStatusText())).toContain("Disconnected");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not ping after the connection is closed", () => {
+    vi.useFakeTimers();
+    try {
+      pingWs.emit("open");
+      pingWs.emit("close", 1006, Buffer.from("")); // close before first ping
+      pingWs.ping.mockClear();
+      vi.advanceTimersByTime(PING_INTERVAL * 3);
+      expect(pingWs.ping).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Workers showed "Connected" after network drops because silent TCP disconnections don't reliably fire WebSocket `close`/`error` events
- Added a client-side ping/pong heartbeat: the worker sends a `ping` to the foreman every 20 seconds; if no `pong` comes back before the next ping, the socket is terminated, triggering the existing `close` handler and reconnect logic
- The foreman already pings workers (every 25s) but nothing on the worker side was checking liveness

## Test plan

- [x] `sends a ping after the interval when the connection is open`
- [x] `terminates connection when no pong is received before the next ping`
- [x] `does not terminate when a pong is received between pings`
- [x] `reconnects after heartbeat-induced termination`
- [x] `shows Disconnected in status bar after heartbeat timeout`
- [x] `does not ping after the connection is closed`
- [x] All 1225 non-DB tests pass

Closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)