### PR TITLE
docs: remove pipeline.test.ts flakiness workaround

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,6 @@ npm test
 
 `tests/globalSetup.ts` runs once before the test suite. It reads the service-role key from `supabase status` (or from `SUPABASE_SERVICE_ROLE_KEY` if already set) and injects it into `process.env` so all Vitest worker threads inherit it. If Supabase is unavailable it sets `SUPABASE_UNAVAILABLE=true`; `createTestSupabase()` then throws with a helpful message so only DB tests fail. CI starts Supabase automatically via `supabase/setup-cli@v1` + `supabase start`.
 
-`pipeline.test.ts` is occasionally flaky in CI — timing-sensitive `pollUntil` calls can time out on slow runners. If it fails with `pollUntil timed out after 10000ms`, push an empty commit to retrigger CI: `git commit --allow-empty -m "ci: retrigger CI (pipeline.test.ts flaky timeout)"`. See issue #501.
 
 ## Database
 


### PR DESCRIPTION
## Summary

- Removes the `pipeline.test.ts` flakiness note from CLAUDE.md — the root cause (upsertTask/markAssigned race condition) was fixed in PR #504

🤖 Generated with [Claude Code](https://claude.com/claude-code)