### PR TITLE
Prompt workers to update project docs alongside code

### DIFF
--- a/src/templates.ts
+++ b/src/templates.ts
@@ -34,7 +34,8 @@ You are working in ${workspaceContext}. Use your branch-discipline skill, and re
 1. Pull main to get the latest before making any edits.
 2. ${branchInstruction}
 3. As much as possible, use test-driven development.
-4. Create a PR when done, and include the text "Closes #${issue.number}".
+4. Before creating a PR, check whether your changes call for updates to project documentation (CLAUDE.md, README, or other docs). Include any doc updates in the same PR as the code changes.
+5. Create a PR when done, and include the text "Closes #${issue.number}".
 
 Do not work on any other issues: leave task assignment to the foreman. Do not merge any PRs or set them to auto-merge: leave merging to the user after UAT.`;
 }

--- a/tests/templates.test.ts
+++ b/tests/templates.test.ts
@@ -72,6 +72,14 @@ describe("buildInitialPrompt", () => {
     expect(p).not.toContain("isolated worktree");
   });
 
+  it("reminds worker to update project docs alongside code changes", () => {
+    const p = buildInitialPrompt({
+      number: 1, title: "T", body: "body", labels: [], repoUrl: "https://github.com/x/y",
+    }, true);
+    expect(p).toContain("CLAUDE.md");
+    expect(p).toMatch(/project doc/i);
+  });
+
   it("shared checkout — mentions worktree", () => {
     const p = buildInitialPrompt({
       number: 1, title: "T", body: "body", labels: [], repoUrl: "https://github.com/x/y",


### PR DESCRIPTION
## Summary

- Adds step 4 to the initial worker prompt: before creating a PR, check whether changes call for updates to project documentation (CLAUDE.md, README, or other docs) and include them in the same PR
- Existing post-merge prompt remains as a safety net for anything missed

Closes #463

## Test plan

- [x] New test in `tests/templates.test.ts` verifies the initial prompt mentions CLAUDE.md and project docs
- [x] All existing tests pass
- [x] Lint and type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)