### PR TITLE
Fix: advise agents not to sleep/poll for test results

### DIFF
--- a/src/templates.ts
+++ b/src/templates.ts
@@ -167,7 +167,7 @@ export function resolveEventTemplate(table: EventTemplateFmtTable, key: string, 
 }
 
 const BRANCH_REVIEW_PROMPT =
-  "Check whether all tests have passed. If not, take no action now; wait for the remaining ones. " +
+  "Check whether all tests have passed. If not, take no action now — you will be notified when each check completes, so do not sleep or poll waiting for results. " +
   "If all tests passed, check if the branch is up to date, and if not, rebase it. " +
   "Then check if the PR can be merged. If anything is blocking merge, resolve it, but do not merge yourself.";
 

--- a/tests/templates.test.ts
+++ b/tests/templates.test.ts
@@ -615,6 +615,17 @@ describe("EVENT_FMT — new entries", () => {
     expect(result).toContain("do not merge yourself");
   });
 
+  it("branch-review prompt advises not to sleep or poll", () => {
+    const evt: GitHubEvent = {
+      id: "e1",
+      name: "_check_suites",
+      payload: { status: "succeeded", failed: [], succeeded: ["CI"] },
+    };
+    const result = EVENT_FMT._check_suites(evt.payload, evt);
+    expect(result).toMatch(/do not sleep|don't sleep/i);
+    expect(result).toMatch(/notif/i);
+  });
+
   it("_code_review renders PR number, review state, body, and inline comments", () => {
     const evt: GitHubEvent = {
       id: "e1",


### PR DESCRIPTION
## Summary
- Updates `BRANCH_REVIEW_PROMPT` in `src/templates.ts` to explicitly tell agents they will be notified when checks complete, so they should not sleep or poll
- The old wording ("wait for the remaining ones") was being interpreted by agents as "sleep for a couple minutes and check back," wasting time and missing notifications

## Test plan
- [x] Added test asserting the prompt contains "do not sleep" and "notif" language
- [x] All 65 template tests pass
- [x] Lint and type check clean

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)