### PR TITLE
Fix blank task titles on dashboard after foreman restart

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -258,6 +258,8 @@ export interface TaskStore {
   deleteTask(taskId: string): Promise<void>;
   /** Update PR number and branch for a task. Pass null to clear. */
   updateTaskPr(taskId: string, prNumber: number | null, branch: string | null): Promise<void>;
+  /** Fetch a single task by ID, or null if not found. */
+  getTask(taskId: string): Promise<TaskRow | null>;
   /** List tasks, optionally filtered by status. */
   listTasks(opts?: ListTasksOpts): Promise<TaskRow[]>;
 }
@@ -356,6 +358,15 @@ export function createTaskStore(supabase: SupabaseClient): TaskStore {
       if (error) throw error;
     },
 
+    async getTask(taskId) {
+      const { data, error } = await supabase.from("tasks")
+        .select("task_id, issue_number, repo, title, body, labels, status, worker_id, pr_number, branch, created_at, assigned_at, completed_at")
+        .eq("task_id", taskId)
+        .maybeSingle();
+      if (error) throw error;
+      return data ? rowToTaskRow(data as Record<string, unknown>) : null;
+    },
+
     async listTasks(opts) {
       const limit = opts?.limit ?? 200;
       let q = supabase.from("tasks").select(
@@ -379,6 +390,7 @@ export function createNullTaskStore(): TaskStore {
     async markBlocked() {},
     async deleteTask() {},
     async updateTaskPr() {},
+    async getTask() { return null; },
     async listTasks() { return []; },
   };
 }

--- a/src/foreman.ts
+++ b/src/foreman.ts
@@ -458,6 +458,22 @@ export class TaskModel {
     }
   }
 
+  /** Restore a task into the in-memory queue from the DB record.
+   *  Used when a worker reconnects claiming a task that's not in memory (e.g. issue
+   *  was closed mid-task, marking the DB row complete, which startup skips).
+   *  Falls back to empty placeholder if the DB row is missing. */
+  async restoreFromDb(taskId: string, issueNumber: number): Promise<void> {
+    const row = await this.store.getTask(taskId);
+    this.queue.addTask({
+      taskId,
+      issueNumber: row?.issueNumber ?? issueNumber,
+      title: row?.title ?? "",
+      body: row?.body ?? "",
+      labels: row?.labels ?? [],
+      repoUrl: row ? `https://github.com/${row.repo}` : "",
+    });
+  }
+
   /** Assigns a task to a worker. Awaits the DB write; reverts memory and returns
    *  false if the write fails so the caller can release the worker. */
   async assign(taskId: string, workerId: string): Promise<boolean> {
@@ -1124,14 +1140,13 @@ export function createForemanWss(
         const existing = taskQueue.get(msg.taskId);
 
         if (!existing) {
-          // Task not in queue — label may have been removed while worker was disconnected.
-          // Re-add a minimal in-memory entry so GitHub events can still be forwarded.
-          // The DB record still exists (written by the reclaim timer via taskStore.markPending);
-          // no new DB write is needed here.
+          // Task not in queue — issue may have been closed (marking the task complete in DB,
+          // which startup skips) or the label may have been removed while worker was disconnected.
+          // Restore from DB so title/body/labels are preserved on the dashboard.
           const issueNumber = parseInt(msg.taskId, 10);
           if (!isNaN(issueNumber)) {
-            log(workerId, `hello busy task=#${msg.taskId} — task unlabeled, re-adding for event forwarding`);
-            taskQueue.addTask({ taskId: msg.taskId, issueNumber, title: "", body: "", labels: [], repoUrl: "" });
+            log(workerId, `hello busy task=#${msg.taskId} — task not in queue, restoring from DB for event forwarding`);
+            await taskModel.restoreFromDb(msg.taskId, issueNumber);
           } else {
             log(workerId, `hello busy task=#${msg.taskId} — unknown task, respecting busy status`);
           }


### PR DESCRIPTION
## Summary

- When a worker reconnects claiming a task that's not in the in-memory queue (e.g. issue was closed mid-task, marking the DB row complete, which startup skips), the `worker_hello` handler was re-adding the task with hardcoded empty `title`/`body`/`labels`. This caused blank titles on the admin dashboard.
- Added `TaskStore.getTask()` to fetch a single task row by ID, and `TaskModel.restoreFromDb()` to encapsulate the "fetch from DB, add to queue" operation.
- The handler now calls `taskModel.restoreFromDb()` instead of directly constructing an empty placeholder.

## Repro scenario

1. Task assigned to worker → PR merged → issue closed → `closeIssue()` marks task **complete** in DB
2. Foreman restarts → startup skips complete tasks
3. Worker reconnects with `worker_hello { status: "busy" }` → task not in queue → previously created empty placeholder, now fetches from DB

## Test plan

- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run lint` — clean
- [x] `npm test -- tests/foreman.websocket.test.ts` — all 56 tests pass (existing test at line 449 covers the reconnect-to-unlabeled-task path)
- [x] `npm run smoke` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)