### PR TITLE
Add docs update reminders to worker prompts

### DIFF
--- a/src/agent/templates.ts
+++ b/src/agent/templates.ts
@@ -169,7 +169,8 @@ export function resolveEventTemplate(table: EventTemplateFmtTable, key: string, 
 const BRANCH_REVIEW_PROMPT =
   "Check whether all tests have passed. If not, take no action now — you will be notified when each check completes, so do not sleep or poll waiting for results. " +
   "If all tests passed, check if the branch is up to date, and if not, rebase it. " +
-  "Then check if the PR can be merged. If anything is blocking merge, resolve it, but do not merge yourself.";
+  "Then check if the PR can be merged. If anything is blocking merge, resolve it, but do not merge yourself. " +
+  "Before merging, also check whether any project documentation (like CLAUDE.md or README) should be updated to reflect your changes, and include those updates in this PR.";
 
 const CODE_REVIEW_PROMPT = "Please respond in whatever way you think is most appropriate, replying and/or making code changes.";
 
@@ -211,6 +212,9 @@ export const EVENT_FMT: EventTemplateFmtTable = {
   pull_request: (p) => {
     const pr = p.pull_request as Record<string, unknown> | undefined;
     const prNumber = pr?.number;
+    if (p.action === "opened") {
+      return `PR #${prNumber} has been created. While waiting for user feedback and CI checks, consider whether any project documentation should be updated, like CLAUDE.md, and include those updates in this PR.`;
+    }
     if (p.action === "auto_merge_enabled") {
       return `Auto-merge was enabled on PR #${prNumber}. ${BRANCH_REVIEW_PROMPT}`;
     }

--- a/tests/templates.test.ts
+++ b/tests/templates.test.ts
@@ -215,6 +215,15 @@ describe("check_suite success prompt", () => {
     expect(p).toContain("all tests passed");
     expect(p).toContain("wait");
   });
+
+  it("branch-review prompt reminds to check docs", () => {
+    const events: GitHubEvent[] = [
+      { id: "e1", name: "check_suite", payload: { action: "completed", check_suite: { conclusion: "success", name: "CI" } } },
+    ];
+    const p = buildEventPrompt(events);
+    expect(p).toContain("documentation");
+    expect(p).toContain("CLAUDE.md");
+  });
 });
 
 describe("fmtEventList", () => {
@@ -360,6 +369,24 @@ describe("EVENT_FMT table", () => {
     expect(result).toContain("memories");
     expect(result).toMatch(/not|do not|don't/i);
     expect(result).toContain("persist");
+  });
+});
+
+describe("pull_request/opened", () => {
+  it("includes PR number and prompt to check docs", () => {
+    const evt: GitHubEvent = {
+      id: "e1",
+      name: "pull_request",
+      payload: {
+        action: "opened",
+        pull_request: { number: 42 },
+      },
+    };
+    const result = EVENT_FMT.pull_request(evt.payload, evt);
+    expect(result).toContain("PR #42");
+    expect(result).toContain("created");
+    expect(result).toContain("documentation");
+    expect(result).toContain("CLAUDE.md");
   });
 });
 


### PR DESCRIPTION
## Summary

Addresses issue #547 by adding two doc update reminders to encourage workers to include documentation updates as part of their PRs rather than in separate follow-up commits:

1. **Updated BRANCH_REVIEW_PROMPT**: Now reminds workers to check whether any project documentation (like CLAUDE.md or README) should be updated, and include those updates in the PR before merge.

2. **Added pull_request/opened event handler**: Prompts workers to consider updating project documentation while waiting for CI checks and user feedback.

## Test plan

- All template tests pass (67 tests)
- Added new test for `pull_request/opened` event handler
- Added test verifying docs reminder in branch review prompt
- No regressions in other tests

Closes #547