### PR TITLE
fix: print task cancelled message in quiet mode

### DIFF
--- a/src/agent/display.ts
+++ b/src/agent/display.ts
@@ -652,7 +652,10 @@ export const MESSAGE_FMT: FmtTable = {
 export const FOREMAN_MESSAGE_FMT: FmtTable = {
   task_assigned:      { verbose: (m) => c.darkGray(`Task assigned: #${m.issue.number}, ${m.issue.title}`) },
   event_notification: { verbose: (m) => c.darkGray(`Event received [${fmtTime()}]: ${fmtEvent(m.event as GitHubEvent)}`) },
-  hello_ack:          { verbose: (m) => c.darkGray(`hello_ack: ${m.status}`) },
+  hello_ack: {
+    verbose: (m) => c.darkGray(`hello_ack: ${m.status}`),
+    quiet: (m) => m.status === "cancelled" ? c.amber("Task cancelled (reassigned to another worker).") : null,
+  },
   _default:           (m) => c.darkGray(`Unknown foreman message: ${m.type}`),
 };
 

--- a/src/agent/worker.ts
+++ b/src/agent/worker.ts
@@ -555,7 +555,6 @@ export class WorkerSession {
           prNumber: undefined,
           branch: "",
         });
-        this.display.print(display.c.amber("Task cancelled (reassigned to another worker)."));
         const ctx = this.options.workspaceCtx;
         if (ctx) {
           void ctx.workspace.reset().then(() => {

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from "events";
 import { WorkerSession, classifyEvent, debounceMs } from "../src/agent/worker.js";
 import type { ForemanMessage, GitHubEvent, TaskIssue } from "../src/types.js";
 import { stripAnsi } from "./helpers.js";
+import * as displayModule from "../src/agent/display.js";
 
 // ── Fake WebSocket ─────────────────────────────────────────────────────────────
 
@@ -51,9 +52,17 @@ beforeEach(() => {
   fakeWs = new FakeWs();
   wsFactory = vi.fn().mockReturnValue(fakeWs);
   runQuery = vi.fn().mockResolvedValue("session-1");
+  const mockPrint = vi.fn();
+  const mockPrintForemanMessage = vi.fn((msg: ForemanMessage) => {
+    // Use real printForemanMessage logic that calls the mocked print function
+    const formatted = displayModule.resolve(displayModule.FOREMAN_MESSAGE_FMT, msg.type, msg);
+    if (formatted) {
+      mockPrint(formatted);
+    }
+  });
   display = {
-    print: vi.fn(),
-    printForemanMessage: vi.fn(),
+    print: mockPrint,
+    printForemanMessage: mockPrintForemanMessage,
     startPersistentStatus: vi.fn(),
     stopPersistentStatus: vi.fn(),
     updatePersistentStatus: vi.fn(),


### PR DESCRIPTION
## Summary
- Add a `quiet` formatter for the `hello_ack` message in FOREMAN_MESSAGE_FMT that prints the task cancellation message when status is 'cancelled'
- Ensures the message is printed in both quiet and verbose modes, not just verbose
- Remove duplicate message print from worker.ts cancellation handler
- Update test setup to properly mock the printForemanMessage function while still tracking calls

## Test plan
- [x] Run full worker test suite - all 128 tests pass
- [x] Verify cancellation message is printed when hello_ack with status='cancelled' is received
- [x] Verify message includes explanation that task was "reassigned to another worker"
- [x] Confirm workspace reset still happens asynchronously as before

Closes #544

🤖 Generated with [Claude Code](https://claude.com/claude-code)