### PR TITLE
fix: include date fields in /api/tasks response

### DIFF
--- a/src/foreman/http-server.ts
+++ b/src/foreman/http-server.ts
@@ -4,7 +4,7 @@ import { Hono } from "hono";
 import { getRequestListener } from "@hono/node-server";
 import type { DbLogger } from "./db.js";
 import type { TaskModel } from "./task-model.js";
-import { rowToTask } from "./task-model.js";
+import { deriveStatus } from "./task-model.js";
 import type { TaskStatus } from "../types.js";
 import { fmtError } from "../utils.js";
 import { summaryEvent, isMutedEvent } from "./event-router.js";
@@ -99,12 +99,24 @@ export function createHttpServer(
   app.get("/api/tasks", async (c) => {
     try {
       const statusFilter = c.req.query("status") as TaskStatus | undefined;
+      const rows = taskModel ? await taskModel.listTasks() : [];
+      const tasks = rows.map((row) => ({
+        taskId: row.taskId,
+        issueNumber: row.issueNumber,
+        repo: row.repo,
+        title: row.title,
+        status: deriveStatus(row),
+        workerId: row.workerId,
+        prNumber: row.prNumber,
+        branch: row.branch,
+        createdAt: row.createdAt,
+        assignedAt: row.assignedAt,
+        completedAt: row.completedAt,
+      }));
       if (statusFilter) {
-        const rows = taskModel ? await taskModel.listTasks() : [];
-        return c.json(rows.map(rowToTask).filter((t) => t.status === statusFilter));
+        return c.json(tasks.filter((t) => t.status === statusFilter));
       }
-      const tasks = taskModel ? await taskModel.listActiveTasks() : [];
-      return c.json(tasks);
+      return c.json(tasks.filter((t) => t.status !== "complete"));
     } catch (err) {
       flog(`ERROR API query failed: ${fmtError(err)}`);
       return c.json({ error: "internal error" }, 500);

--- a/tests/foreman.http.test.ts
+++ b/tests/foreman.http.test.ts
@@ -193,18 +193,19 @@ describe("GET /api/tasks", () => {
     expect(JSON.parse(res.body)).toEqual([]);
   });
 
-  it("returns active tasks from taskModel with derived status, excluding complete", async () => {
+  it("returns active tasks from taskModel with derived status and date fields, excluding complete", async () => {
+    const createdAt = "2026-01-01T00:00:00.000Z";
     const pendingRow = {
       taskId: "1", issueNumber: 1, repo: "test/repo", title: "Pending bug",
       body: "Description", labels: [],
       workerId: null, assignedAt: null, completedAt: null, issueClosedAt: null, prMergedAt: null,
-      prNumber: null, branch: null, createdAt: new Date().toISOString(),
+      prNumber: null, branch: null, createdAt,
     };
     const completeRow = {
       taskId: "2", issueNumber: 2, repo: "test/repo", title: "Done bug",
       body: "Description", labels: [],
-      workerId: null, assignedAt: null, completedAt: new Date().toISOString(), issueClosedAt: null, prMergedAt: null,
-      prNumber: null, branch: null, createdAt: new Date().toISOString(),
+      workerId: null, assignedAt: null, completedAt: "2026-01-02T00:00:00.000Z", issueClosedAt: null, prMergedAt: null,
+      prNumber: null, branch: null, createdAt,
     };
     const store = { listTasks: vi.fn().mockResolvedValue([pendingRow, completeRow]) } as never;
     const tm = new TaskModel(store);
@@ -216,7 +217,14 @@ describe("GET /api/tasks", () => {
       const body = JSON.parse(res.body);
       // complete task is excluded by default
       expect(body).toHaveLength(1);
-      expect(body[0]).toMatchObject({ taskId: "1", status: "pending" });
+      expect(body[0]).toMatchObject({
+        taskId: "1",
+        repo: "test/repo",
+        status: "pending",
+        workerId: null,
+        createdAt,
+        completedAt: null,
+      });
       expect(store.listTasks).toHaveBeenCalled();
     } finally {
       await stopServer(s);


### PR DESCRIPTION
## Summary

- The `/api/tasks` endpoint was calling `rowToTask()` which converts a `TaskRow` to the internal `Task` type, stripping `createdAt`, `completedAt`, `repo`, and `workerId` fields before sending to the frontend
- The frontend expected these fields (typed as `TaskRow`) and showed "Invalid Date" for Created and "—" for Completed because the values were `undefined`
- Fixed by replacing the `rowToTask()` mapping with a direct mapping from `TaskRow` that passes all fields the frontend needs, with `status` derived via `deriveStatus()`
- Also fixed that `repo` (was being returned as `repoUrl`) and `workerId` (was being returned as `assignedWorkerId`) now have the correct field names matching the frontend type

## Test plan

- [x] Updated existing test to assert `createdAt`, `completedAt`, `repo`, and `workerId` are present in the API response
- [x] All tests pass (`npm test`)
- [x] TypeScript passes (`npx tsc --noEmit`)

Closes #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)