### PR TITLE
refactor: consolidate getPendingAndBlockedTasks() into listActiveTasks()

### DIFF
--- a/src/foreman/event-router.ts
+++ b/src/foreman/event-router.ts
@@ -163,7 +163,7 @@ export async function reconcile(deps: EventRouterDeps): Promise<void> {
 
   // Step 3: remove pending/blocked tasks whose issue no longer has the label
   const cancelPromises: Promise<void>[] = [];
-  for (const t of await deps.taskModel.getPendingAndBlockedTasks()) {
+  for (const t of await deps.taskModel.listActiveTasks()) {
     if (!labeledIssues.has(t.issueNumber)) {
       cancelPromises.push(
         deps.taskModel.cancel(t.taskId)

--- a/src/foreman/task-model.ts
+++ b/src/foreman/task-model.ts
@@ -135,13 +135,7 @@ export class TaskModel extends EventEmitter {
     return null;
   }
 
-  async getPendingAndBlockedTasks(): Promise<Task[]> {
-    const rows = await this.store.listTasks();
-    // Filter out complete tasks (those with completedAt set)
-    return rows.filter(r => !r.completedAt).map(rowToTask);
-  }
-
-  /** All active (non-complete) tasks — used by the dashboard task list API. */
+  /** All active (non-complete) tasks — used by the dashboard task list API and dependency resolution. */
   async listActiveTasks(): Promise<Task[]> {
     const rows = await this.store.listTasks();
     return rows.filter((row) => !row.completedAt).map(rowToTask);

--- a/tests/foreman.taskqueue.test.ts
+++ b/tests/foreman.taskqueue.test.ts
@@ -151,14 +151,14 @@ describe("TaskModel — derived blocked status", () => {
     expect(task2).toBeNull();
   });
 
-  it("getPendingAndBlockedTasks returns pending and assigned but not complete", async () => {
+  it("listActiveTasks returns pending and assigned but not complete", async () => {
     await registerBase(m, { taskId: "1", issueNumber: 1 }); // pending
     await registerBase(m, { taskId: "2", issueNumber: 2 }); // will be assigned
     await m.assign("2", "w1");
     await registerBase(m, { taskId: "3", issueNumber: 3 }); // will be complete
     await m.assign("3", "w2");
     await m.complete("3");
-    const result = await m.getPendingAndBlockedTasks();
+    const result = await m.listActiveTasks();
     expect(result.map((t) => t.taskId)).toEqual(expect.arrayContaining(["1", "2"]));
     expect(result.map((t) => t.taskId)).not.toContain("3");
   });


### PR DESCRIPTION
## Summary
- Removed the duplicate `getPendingAndBlockedTasks()` method from `TaskModel` — it was identical to `listActiveTasks()` and misleadingly named (it returned *all* non-complete tasks, not just pending/blocked ones)
- Updated the one call site in `event-router.ts` to use `listActiveTasks()`
- Renamed the corresponding test

Closes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)