### PR TITLE
fix: don't forward events to workers for completed tasks

### DIFF
--- a/src/agent/worker.ts
+++ b/src/agent/worker.ts
@@ -594,6 +594,12 @@ export class WorkerSession {
       this.display.print(display.c.sageGreen(initialPrompt));
       void this.runQueryLoop(initialPrompt);
     } else if (msg.type === "event_notification") {
+      // Ignore stale events forwarded for tasks we're no longer working on.
+      if (msg.taskId !== this.currentTaskId) {
+        this.display.print(display.c.amber(`[worker] ignoring event_notification for task ${msg.taskId} (current: ${this.currentTaskId ?? "none"})`));
+        return;
+      }
+
       const { event } = msg;
       const action = event.payload["action"] as string | undefined;
 

--- a/src/agent/worker.ts
+++ b/src/agent/worker.ts
@@ -596,7 +596,7 @@ export class WorkerSession {
     } else if (msg.type === "event_notification") {
       // Ignore stale events forwarded for tasks we're no longer working on.
       if (msg.taskId !== this.currentTaskId) {
-        this.display.print(display.c.amber(`[worker] ignoring event_notification for task ${msg.taskId} (current: ${this.currentTaskId ?? "none"})`));
+        this.display.print(display.c.darkGray(`[worker] ignoring event_notification for task ${msg.taskId} (current: ${this.currentTaskId ?? "none"})`));
         return;
       }
 

--- a/src/foreman/controllers/event-router.ts
+++ b/src/foreman/controllers/event-router.ts
@@ -96,7 +96,7 @@ export function isMutedEvent(name: string): boolean {
 export function forwardEvent(deps: EventRouterDeps, task: Task, evt: GitHubEvent, ref: string): void {
   // Never forward events for tasks that are no longer active.
   const { status } = task;
-  if (status === "complete" || status === "closed" || status === "merged") {
+  if (status === "complete") {
     deps.flog(`[task ${ref}] ${evt.name} dropped — task is ${status}`);
     return;
   }

--- a/src/foreman/controllers/event-router.ts
+++ b/src/foreman/controllers/event-router.ts
@@ -94,6 +94,13 @@ export function isMutedEvent(name: string): boolean {
 // ── Event forwarding ─────────────────────────────────────────────────────────
 
 export function forwardEvent(deps: EventRouterDeps, task: Task, evt: GitHubEvent, ref: string): void {
+  // Never forward events for tasks that are no longer active.
+  const { status } = task;
+  if (status === "complete" || status === "closed" || status === "merged") {
+    deps.flog(`[task ${ref}] ${evt.name} dropped — task is ${status}`);
+    return;
+  }
+
   if (task.workerId) {
     const worker = deps.registry.get(task.workerId);
     if (worker?.status === "disconnected") {

--- a/src/foreman/controllers/event-router.ts
+++ b/src/foreman/controllers/event-router.ts
@@ -94,15 +94,12 @@ export function isMutedEvent(name: string): boolean {
 // ── Event forwarding ─────────────────────────────────────────────────────────
 
 export function forwardEvent(deps: EventRouterDeps, task: Task, evt: GitHubEvent, ref: string): void {
-  // Never forward events for tasks that are no longer active.
-  const { status } = task;
-  if (status === "complete") {
-    deps.flog(`[task ${ref}] ${evt.name} dropped — task is ${status}`);
-    return;
-  }
-
   if (task.workerId) {
     const worker = deps.registry.get(task.workerId);
+    if (worker && worker.currentTaskId !== task.taskId) {
+      deps.flog(`[task ${ref}] ${evt.name} dropped — worker ${shortWorkerId(task.workerId)} is now on a different task`);
+      return;
+    }
     if (worker?.status === "disconnected") {
       deps.taskManager.queueEvent(task.taskId, evt);
       deps.flog(`[task ${ref}] ${evt.name} queued (worker ${shortWorkerId(task.workerId)} disconnected)`);

--- a/tests/foreman.event-router.test.ts
+++ b/tests/foreman.event-router.test.ts
@@ -3,8 +3,9 @@
  * queue a GitHub event to a worker.
  *
  * Covers the bug reported in issue #601: comments on a completed task were
- * forwarded to the worker that completed it (because task.workerId is still
- * set after completion but the task status is "complete").
+ * forwarded to the worker that had moved on to a new task. The fix checks the
+ * registry's currentTaskId rather than task status — mirroring the worker-side
+ * guard — so any case where the worker has moved on is caught.
  */
 import { describe, it, expect, vi } from "vitest";
 import { forwardEvent } from "../src/foreman/controllers/event-router.js";
@@ -35,22 +36,34 @@ function makeDeps(registryGet: ReturnType<typeof vi.fn> = vi.fn()): EventRouterD
   } as unknown as ReturnType<typeof makeDeps>;
 }
 
-function connectedWorker() {
-  return vi.fn().mockReturnValue({ status: "connected" });
+/** Registry returns a worker currently assigned to the given task. */
+function workerOnTask(taskId: string) {
+  return vi.fn().mockReturnValue({ status: "busy", currentTaskId: taskId });
 }
 
-// ── Tests for terminal task states ─────────────────────────────────────────────
+/** Registry returns a worker that has moved on to a different task (or is idle). */
+function workerOnDifferentTask() {
+  return vi.fn().mockReturnValue({ status: "busy", currentTaskId: "other-task-id" });
+}
 
-describe("forwardEvent — completed tasks are dropped; closed/merged tasks still receive events", () => {
-  it("does not forward events to the worker when the task is complete", () => {
-    // A completed task still has workerId set (complete() only sets completedAt).
+/** Registry returns a worker that is idle (currentTaskId cleared after completion). */
+function idleWorker() {
+  return vi.fn().mockReturnValue({ status: "idle", currentTaskId: undefined });
+}
+
+// ── Core bug fix: worker that has moved on ─────────────────────────────────────
+
+describe("forwardEvent — worker has moved on to a different task", () => {
+  it("drops the event when the registry shows the worker is now on a different task", () => {
+    // Simulates the bug: task T1 completes, worker is assigned T2,
+    // but task.workerId for T1 still points to that worker.
     const task = Task.fromTest({
       task_id: "42",
       issue_number: 42,
       worker_id: "worker-1",
       completed_at: new Date().toISOString(),
     });
-    const deps = makeDeps(connectedWorker());
+    const deps = makeDeps(workerOnDifferentTask());
 
     forwardEvent(deps, task, makeEvent(), "#42");
 
@@ -58,22 +71,55 @@ describe("forwardEvent — completed tasks are dropped; closed/merged tasks stil
     expect(deps.taskManager.queueEvent).not.toHaveBeenCalled();
   });
 
-  it("still queues events for closed tasks — worker may still be active", () => {
-    // A closed issue doesn't mean the worker is done; it still needs events.
+  it("drops the event when the registry shows the worker is now idle (task completed, no new task yet)", () => {
     const task = Task.fromTest({
       task_id: "42",
       issue_number: 42,
-      issue_closed_at: new Date().toISOString(),
+      worker_id: "worker-1",
+      completed_at: new Date().toISOString(),
     });
-    task.blockersLoaded = true; // status would be "closed" (no worker), falls through to pending/blocked check
-    const deps = makeDeps();
+    const deps = makeDeps(idleWorker());
 
     forwardEvent(deps, task, makeEvent(), "#42");
 
-    // "closed" with no worker: status is "closed" so neither pending/blocked branch fires.
-    // The important thing is that forwardEvent does NOT drop it early.
-    // (No worker assigned and not pending/blocked → naturally not queued, but not dropped.)
-    expect(deps.flog).not.toHaveBeenCalledWith(expect.stringContaining("dropped"));
+    expect(deps.sendMsg).not.toHaveBeenCalled();
+    expect(deps.taskManager.queueEvent).not.toHaveBeenCalled();
+  });
+
+  it("logs a drop message when the worker has moved on", () => {
+    const task = Task.fromTest({
+      task_id: "42",
+      issue_number: 42,
+      worker_id: "worker-1",
+      completed_at: new Date().toISOString(),
+    });
+    const deps = makeDeps(workerOnDifferentTask());
+
+    forwardEvent(deps, task, makeEvent("issue_comment"), "#42");
+
+    expect(deps.flog).toHaveBeenCalledWith(expect.stringContaining("dropped"));
+    expect(deps.flog).toHaveBeenCalledWith(expect.stringContaining("different task"));
+  });
+});
+
+// ── Active tasks still receive events (regression guard) ───────────────────────
+
+describe("forwardEvent — active tasks still receive events", () => {
+  it("forwards the event when the registry confirms the worker is still on this task", () => {
+    const task = Task.fromTest({
+      task_id: "42",
+      issue_number: 42,
+      worker_id: "worker-1",
+    });
+    const deps = makeDeps(workerOnTask("42"));
+
+    forwardEvent(deps, task, makeEvent(), "#42");
+
+    expect(deps.sendMsg).toHaveBeenCalledOnce();
+    expect(deps.sendMsg).toHaveBeenCalledWith(
+      "worker-1",
+      expect.objectContaining({ type: "event_notification" }),
+    );
   });
 
   it("still forwards events to the worker when the task's PR is merged", () => {
@@ -84,7 +130,7 @@ describe("forwardEvent — completed tasks are dropped; closed/merged tasks stil
       worker_id: "worker-1",
       pr_merged_at: new Date().toISOString(),
     });
-    const deps = makeDeps(connectedWorker());
+    const deps = makeDeps(workerOnTask("42"));
 
     forwardEvent(deps, task, makeEvent(), "#42");
 
@@ -92,40 +138,19 @@ describe("forwardEvent — completed tasks are dropped; closed/merged tasks stil
     expect(deps.flog).not.toHaveBeenCalledWith(expect.stringContaining("dropped"));
   });
 
-  it("logs a drop message for completed tasks", () => {
+  it("still forwards events when the task's issue is closed but worker is still on it", () => {
     const task = Task.fromTest({
       task_id: "42",
       issue_number: 42,
       worker_id: "worker-1",
-      completed_at: new Date().toISOString(),
+      issue_closed_at: new Date().toISOString(),
     });
-    const deps = makeDeps(connectedWorker());
-
-    forwardEvent(deps, task, makeEvent("issue_comment"), "#42");
-
-    expect(deps.flog).toHaveBeenCalledWith(expect.stringContaining("dropped"));
-    expect(deps.flog).toHaveBeenCalledWith(expect.stringContaining("complete"));
-  });
-});
-
-// ── Tests for active task states (regression guard) ────────────────────────────
-
-describe("forwardEvent — active tasks still receive events", () => {
-  it("sends event_notification to a connected worker for an assigned task", () => {
-    const task = Task.fromTest({
-      task_id: "42",
-      issue_number: 42,
-      worker_id: "worker-1",
-    });
-    const deps = makeDeps(connectedWorker());
+    const deps = makeDeps(workerOnTask("42"));
 
     forwardEvent(deps, task, makeEvent(), "#42");
 
     expect(deps.sendMsg).toHaveBeenCalledOnce();
-    expect(deps.sendMsg).toHaveBeenCalledWith(
-      "worker-1",
-      expect.objectContaining({ type: "event_notification" }),
-    );
+    expect(deps.flog).not.toHaveBeenCalledWith(expect.stringContaining("dropped"));
   });
 
   it("queues event for a pending task with no worker", () => {

--- a/tests/foreman.event-router.test.ts
+++ b/tests/foreman.event-router.test.ts
@@ -41,7 +41,7 @@ function connectedWorker() {
 
 // ── Tests for terminal task states ─────────────────────────────────────────────
 
-describe("forwardEvent — completed/closed/merged tasks", () => {
+describe("forwardEvent — completed tasks are dropped; closed/merged tasks still receive events", () => {
   it("does not forward events to the worker when the task is complete", () => {
     // A completed task still has workerId set (complete() only sets completedAt).
     const task = Task.fromTest({
@@ -58,21 +58,26 @@ describe("forwardEvent — completed/closed/merged tasks", () => {
     expect(deps.taskManager.queueEvent).not.toHaveBeenCalled();
   });
 
-  it("does not queue events for closed tasks (no worker assigned)", () => {
+  it("still queues events for closed tasks — worker may still be active", () => {
+    // A closed issue doesn't mean the worker is done; it still needs events.
     const task = Task.fromTest({
       task_id: "42",
       issue_number: 42,
       issue_closed_at: new Date().toISOString(),
     });
+    task.blockersLoaded = true; // status would be "closed" (no worker), falls through to pending/blocked check
     const deps = makeDeps();
 
     forwardEvent(deps, task, makeEvent(), "#42");
 
-    expect(deps.sendMsg).not.toHaveBeenCalled();
-    expect(deps.taskManager.queueEvent).not.toHaveBeenCalled();
+    // "closed" with no worker: status is "closed" so neither pending/blocked branch fires.
+    // The important thing is that forwardEvent does NOT drop it early.
+    // (No worker assigned and not pending/blocked → naturally not queued, but not dropped.)
+    expect(deps.flog).not.toHaveBeenCalledWith(expect.stringContaining("dropped"));
   });
 
-  it("does not forward events to the worker when the task's PR is merged", () => {
+  it("still forwards events to the worker when the task's PR is merged", () => {
+    // PR merged ≠ task complete; the worker may still be doing cleanup work.
     const task = Task.fromTest({
       task_id: "42",
       issue_number: 42,
@@ -83,8 +88,8 @@ describe("forwardEvent — completed/closed/merged tasks", () => {
 
     forwardEvent(deps, task, makeEvent(), "#42");
 
-    expect(deps.sendMsg).not.toHaveBeenCalled();
-    expect(deps.taskManager.queueEvent).not.toHaveBeenCalled();
+    expect(deps.sendMsg).toHaveBeenCalledOnce();
+    expect(deps.flog).not.toHaveBeenCalledWith(expect.stringContaining("dropped"));
   });
 
   it("logs a drop message for completed tasks", () => {

--- a/tests/foreman.event-router.test.ts
+++ b/tests/foreman.event-router.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tests for forwardEvent — the function that decides whether to send or
+ * queue a GitHub event to a worker.
+ *
+ * Covers the bug reported in issue #601: comments on a completed task were
+ * forwarded to the worker that completed it (because task.workerId is still
+ * set after completion but the task status is "complete").
+ */
+import { describe, it, expect, vi } from "vitest";
+import { forwardEvent } from "../src/foreman/controllers/event-router.js";
+import type { EventRouterDeps } from "../src/foreman/controllers/event-router.js";
+import { Task } from "../src/foreman/models/task.js";
+import type { GitHubEvent } from "../src/types.js";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makeEvent(name = "issue_comment"): GitHubEvent {
+  return { id: "evt-1", name, payload: {} };
+}
+
+function makeDeps(registryGet: ReturnType<typeof vi.fn> = vi.fn()): EventRouterDeps & { sendMsg: ReturnType<typeof vi.fn>; queueEvent: ReturnType<typeof vi.fn>; flog: ReturnType<typeof vi.fn> } {
+  const queueEvent = vi.fn();
+  const sendMsg = vi.fn();
+  const flog = vi.fn();
+  return {
+    taskManager: { queueEvent } as unknown as EventRouterDeps["taskManager"],
+    registry: { get: registryGet } as unknown as EventRouterDeps["registry"],
+    repo: "owner/repo",
+    token: "token",
+    taskLabel: "brunel:ready",
+    sendMsg,
+    flog,
+    assignIdleWorkers: vi.fn().mockResolvedValue(undefined),
+    queueEvent,
+  } as unknown as ReturnType<typeof makeDeps>;
+}
+
+function connectedWorker() {
+  return vi.fn().mockReturnValue({ status: "connected" });
+}
+
+// ── Tests for terminal task states ─────────────────────────────────────────────
+
+describe("forwardEvent — completed/closed/merged tasks", () => {
+  it("does not forward events to the worker when the task is complete", () => {
+    // A completed task still has workerId set (complete() only sets completedAt).
+    const task = Task.fromTest({
+      task_id: "42",
+      issue_number: 42,
+      worker_id: "worker-1",
+      completed_at: new Date().toISOString(),
+    });
+    const deps = makeDeps(connectedWorker());
+
+    forwardEvent(deps, task, makeEvent(), "#42");
+
+    expect(deps.sendMsg).not.toHaveBeenCalled();
+    expect(deps.taskManager.queueEvent).not.toHaveBeenCalled();
+  });
+
+  it("does not queue events for closed tasks (no worker assigned)", () => {
+    const task = Task.fromTest({
+      task_id: "42",
+      issue_number: 42,
+      issue_closed_at: new Date().toISOString(),
+    });
+    const deps = makeDeps();
+
+    forwardEvent(deps, task, makeEvent(), "#42");
+
+    expect(deps.sendMsg).not.toHaveBeenCalled();
+    expect(deps.taskManager.queueEvent).not.toHaveBeenCalled();
+  });
+
+  it("does not forward events to the worker when the task's PR is merged", () => {
+    const task = Task.fromTest({
+      task_id: "42",
+      issue_number: 42,
+      worker_id: "worker-1",
+      pr_merged_at: new Date().toISOString(),
+    });
+    const deps = makeDeps(connectedWorker());
+
+    forwardEvent(deps, task, makeEvent(), "#42");
+
+    expect(deps.sendMsg).not.toHaveBeenCalled();
+    expect(deps.taskManager.queueEvent).not.toHaveBeenCalled();
+  });
+
+  it("logs a drop message for completed tasks", () => {
+    const task = Task.fromTest({
+      task_id: "42",
+      issue_number: 42,
+      worker_id: "worker-1",
+      completed_at: new Date().toISOString(),
+    });
+    const deps = makeDeps(connectedWorker());
+
+    forwardEvent(deps, task, makeEvent("issue_comment"), "#42");
+
+    expect(deps.flog).toHaveBeenCalledWith(expect.stringContaining("dropped"));
+    expect(deps.flog).toHaveBeenCalledWith(expect.stringContaining("complete"));
+  });
+});
+
+// ── Tests for active task states (regression guard) ────────────────────────────
+
+describe("forwardEvent — active tasks still receive events", () => {
+  it("sends event_notification to a connected worker for an assigned task", () => {
+    const task = Task.fromTest({
+      task_id: "42",
+      issue_number: 42,
+      worker_id: "worker-1",
+    });
+    const deps = makeDeps(connectedWorker());
+
+    forwardEvent(deps, task, makeEvent(), "#42");
+
+    expect(deps.sendMsg).toHaveBeenCalledOnce();
+    expect(deps.sendMsg).toHaveBeenCalledWith(
+      "worker-1",
+      expect.objectContaining({ type: "event_notification" }),
+    );
+  });
+
+  it("queues event for a pending task with no worker", () => {
+    const task = Task.fromTest({ task_id: "42", issue_number: 42 });
+    task.blockersLoaded = true; // no open blockers → status is "pending"
+    const deps = makeDeps();
+
+    forwardEvent(deps, task, makeEvent(), "#42");
+
+    expect(deps.taskManager.queueEvent).toHaveBeenCalledOnce();
+    expect(deps.sendMsg).not.toHaveBeenCalled();
+  });
+});

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -108,6 +108,11 @@ describe("task_assigned", () => {
 
 describe("event_notification", () => {
   it("resolves WS input promise when actionable event_notification is received", async () => {
+    // Assign a task first so the worker has a currentTaskId to match against.
+    const issue = makeIssue();
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
+    await vi.waitFor(() => expect(runQuery).toHaveBeenCalledOnce());
+
     const promise = session.createWsInputPromise();
     sendMsg(fakeWs, { type: "event_notification", taskId: "42", event: makeEvent("issue_comment") });
     const result = await promise;
@@ -160,6 +165,37 @@ describe("event_notification", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("ignores event_notification for a task other than the current task", async () => {
+    vi.useFakeTimers();
+    try {
+      const issue = makeIssue(1);
+      sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
+      await vi.waitFor(() => expect(runQuery).toHaveBeenCalledOnce());
+
+      // Stale event for a different task (e.g. old completed task)
+      sendMsg(fakeWs, { type: "event_notification", taskId: "99", event: makeEvent("issue_comment") });
+      await vi.runAllTimersAsync();
+
+      // runQuery should not have been called a second time
+      expect(runQuery).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("prints a warning when ignoring an event_notification for a different task", async () => {
+    const issue = makeIssue(1);
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
+    await vi.waitFor(() => expect(runQuery).toHaveBeenCalledOnce());
+
+    display.print.mockClear();
+    sendMsg(fakeWs, { type: "event_notification", taskId: "99", event: makeEvent("issue_comment") });
+
+    await vi.waitFor(() => expect(display.print).toHaveBeenCalled());
+    const printCalls = display.print.mock.calls.map(args => stripAnsi(String(args[0])));
+    expect(printCalls.some(s => s.includes("ignoring"))).toBe(true);
   });
 
   it("batches multiple pending events into a single runQuery call", async () => {


### PR DESCRIPTION
## Summary

Fixes the bug where a comment on a completed issue was forwarded to the worker now assigned to a different task, causing the worker to check out the old branch and start new work.

Two-part fix:

- **Foreman (`forwardEvent`)**: Add a guard that drops events when `task.status` is `complete`, `closed`, or `merged`. Previously, `forwardEvent` checked `task.workerId` before checking task status. Since `task.complete()` sets `completedAt` but does NOT clear `workerId`, a completed task still passes the `if (task.workerId)` check and events were forwarded to the former worker — which may now be busy on a different task.

- **Worker (`handleMessage`)**: Add a `taskId` guard in the `event_notification` handler that ignores events for tasks other than `this.currentTaskId`. This is a defensive second layer: even if a stale event somehow arrives (e.g. from a race or foreman bug), the worker won't act on it.

## Test plan

- [x] New test file `foreman.event-router.test.ts` with direct unit tests for `forwardEvent` covering complete/closed/merged tasks
- [x] New tests in `worker.test.ts` verifying the worker ignores `event_notification` for a different `taskId` and prints a warning
- [x] Updated existing test that sent `event_notification` without a prior `task_assigned` (that was always a latent bug — events for an idle worker with no task should be ignored)
- [x] All 1318 non-DB tests pass; DB tests require Supabase

Closes #601