### PR TITLE
refactor: replace WorkerRegistry with Worker active-record

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Two independent processes: **foreman** (server) and **worker** (agent). They com
 
 MVC structure. Models own state; controllers handle external inputs.
 
-- **Models** (`models/`) — `Task` is the active-record for all DB reads/writes. `TaskManager` owns ephemeral in-memory state only (event queues, branch mappings, blocker state). `WorkerRegistry` tracks connected workers.
+- **Models** (`models/`) — `Task` is the active-record for all DB reads/writes. `TaskManager` owns ephemeral in-memory state only (event queues, branch mappings, blocker state). `Worker` is the active-record for connected workers (module-level registry, static finders, `Worker._reset()` for test isolation).
 - **Controllers** (`controllers/`) — `http-server.ts` handles webhooks + REST + SPA. `wss.ts` handles the WebSocket lifecycle with workers. `event-router.ts` routes GitHub events to the right worker or queue.
 - **Infrastructure** — `db-client.ts` wires the shared Supabase client. `admin-ws.ts` broadcasts to the admin dashboard. `github.ts` wraps GitHub API calls.
 
@@ -80,4 +80,5 @@ Most tests run without Supabase. DB tests (`db.*.test.ts`, `pipeline.test.ts`) r
 - Use `display.print()` (not `console.log`) for output in agent/worker code — it routes through the status-bar-aware renderer so messages don't corrupt the TUI.
 - Prefer event-based designs for real-time UIs: a model holds state and emits on change; the UI subscribes once rather than scattering manual refresh calls.
 - In unit tests, use `setupInMemoryTasks()` from `tests/helpers/task.ts` instead of `initDb()` — it mocks the `Task` layer with an in-memory map.
+- In foreman tests that call `createForemanWss`, call `Worker._reset()` in `beforeEach` to clear the module-level worker registry between tests. `createForemanWss` takes no `registry` parameter — `Worker` is imported directly by `wss.ts` and `event-router.ts`.
 - In browser tests, the server is shared across all tests — use unique issue numbers per test rather than resetting server state.

--- a/src/foreman/controllers/event-router.ts
+++ b/src/foreman/controllers/event-router.ts
@@ -2,7 +2,7 @@ import type { GitHubEvent, ForemanMessage, TaskIssue } from "../../types.js";
 import { fetchIssueStates } from "../github.js";
 import type { TaskManager } from "../models/task-manager.js";
 import { Task } from "../models/task.js";
-import type { WorkerRegistry } from "../models/worker-registry.js";
+import { Worker } from "../models/worker-registry.js";
 import { shortWorkerId } from "../../../shared/utils.js";
 import { fmtError } from "../../utils.js";
 
@@ -10,7 +10,6 @@ import { fmtError } from "../../utils.js";
 
 export interface EventRouterDeps {
   taskManager: TaskManager;
-  registry: WorkerRegistry;
   repo: string;
   token: string;
   githubApiUrl?: string;
@@ -95,7 +94,7 @@ export function isMutedEvent(name: string): boolean {
 
 export function forwardEvent(deps: EventRouterDeps, task: Task, evt: GitHubEvent, ref: string): void {
   if (task.workerId) {
-    const worker = deps.registry.get(task.workerId);
+    const worker = Worker.get(task.workerId);
     if (worker && worker.currentTaskId !== task.taskId) {
       deps.flog(`[task ${ref}] ${evt.name} dropped — worker ${shortWorkerId(task.workerId)} is now on a different task`);
       return;

--- a/src/foreman/controllers/wss.ts
+++ b/src/foreman/controllers/wss.ts
@@ -9,7 +9,7 @@ import { shortWorkerId } from "../../../shared/utils.js";
 import type { BrunelConfig } from "../../config.js";
 import type { TaskManager } from "../models/task-manager.js";
 import { Task } from "../models/task.js";
-import type { WorkerRegistry } from "../models/worker-registry.js";
+import { Worker } from "../models/worker-registry.js";
 import { doRouteEvent, isMutedEvent, summaryEvent, forwardEvent } from "./event-router.js";
 import type { EventRouterDeps } from "./event-router.js";
 
@@ -35,7 +35,6 @@ export interface ForemanWss {
 
 export function createForemanWss(
   taskManager: TaskManager,
-  registry: WorkerRegistry,
   server: http.Server,
   config: Pick<BrunelConfig, "taskLabel" | "githubRepo" | "githubToken" | "githubApiUrl" | "workerSecret" | "pingIntervalMs">,
   deps?: {
@@ -73,7 +72,7 @@ export function createForemanWss(
 
   function sendMsg(workerId: string, msg: ForemanMessage, logTaskId?: string): void {
     const taskId = logTaskId ?? (("taskId" in msg ? msg.taskId : null) ?? null);
-    registry.send(workerId, msg);
+    Worker.get(workerId)?.send(msg);
     const msgPayload = msg as unknown as Record<string, unknown>;
     dbLogger?.logForemanMessage({ direction: "sent", workerId, taskId, msgType: msg.type, payload: msgPayload });
     broadcastMessageEvent({ direction: "sent", workerId, taskId, msgType: msg.type, payload: msgPayload });
@@ -87,13 +86,13 @@ export function createForemanWss(
     if (!adminWss) return;
     adminWss.broadcastSnapshot({
       tasks: await taskManager.getTaskSnapshots(),
-      workers: registry.getWorkerSnapshots(),
+      workers: Worker.all().map((w) => w.toSnapshot()),
     });
   }
 
   const debouncedBroadcast = debounce(broadcastSnapshot, 10);
   taskManager.on("changed", debouncedBroadcast);
-  registry.on("changed", debouncedBroadcast);
+  Worker.events.on("changed", debouncedBroadcast);
 
   // Mutex that ensures at most one assignIdleWorkers() runs at a time.
   // Without this, two concurrent webhook events can each call assignIdleWorkers()
@@ -105,7 +104,7 @@ export function createForemanWss(
       // Sequential (not concurrent) to prevent double-assignment: each tryAssignWork
       // must complete its DB write before the next one calls nextPending(), otherwise
       // two workers can both see the same pending task. (Issue #563)
-      for (const w of registry.getIdleWorkers()) {
+      for (const w of Worker.getIdle()) {
         await tryAssignWork(w.workerId).catch(err => flog(`ERROR tryAssignWork: ${fmtError(err)}`));
       }
     });
@@ -117,12 +116,13 @@ export function createForemanWss(
       (t) => t.blockersLoaded && t.status === "pending",
     );
     if (task) {
-      registry.assignTask(workerId, task.taskId);
+      const worker = Worker.get(workerId);
+      worker?.assign(task.taskId);
       try {
         await task.assign(workerId);
       } catch (err) {
         flog(`ERROR Failed to persist assignment for task #${task.taskId}: ${fmtError(err)}`);
-        registry.releaseWorker(workerId);
+        worker?.release();
         log(workerId, "→ idle (DB write failed)");
         return;
       }
@@ -152,7 +152,6 @@ export function createForemanWss(
   // Build the event router deps object
   const routerDeps: EventRouterDeps = {
     taskManager,
-    registry,
     repo,
     token,
     githubApiUrl,
@@ -222,12 +221,13 @@ export function createForemanWss(
       }
 
       function cancelWorker(taskId?: string) {
-        registry.register(workerId, ws, "idle");
+        Worker.register(workerId, ws);
         sendMsg(workerId, { type: "hello_ack", workerId, status: "cancelled" }, taskId);
       }
 
       async function reclaimWorker(task: Task) {
-        registry.register(workerId, ws, "busy", task.taskId);
+        const w = Worker.register(workerId, ws);
+        w.assign(task.taskId);
         // Only call assign if task is not already complete (to preserve task status)
         if (task.status !== "complete") {
           await task.assign(workerId);
@@ -278,7 +278,7 @@ export function createForemanWss(
         } else {
           log(workerId, "hello idle");
         }
-        registry.register(workerId, ws, "idle");
+        Worker.register(workerId, ws);
         sendMsg(workerId, { type: "hello_ack", workerId, status: "idle" });
       }
     }
@@ -295,7 +295,7 @@ export function createForemanWss(
           flog(`ERROR Failed to mark task #${msg.taskId} complete: ${fmtError(err)}`)
         );
       }
-      registry.releaseWorker(workerId);
+      Worker.get(workerId)?.release();
     }
 
     async function handleWorkerGoodbye(msg: Extract<WorkerMessage, { type: "worker_goodbye" }>) {
@@ -309,7 +309,7 @@ export function createForemanWss(
           );
         }
       }
-      registry.remove(workerId);
+      Worker.get(workerId)?.remove();
     }
 
     ws.on("message", (data) => {
@@ -339,12 +339,12 @@ export function createForemanWss(
 
     ws.on("close", (code, reason) => {
       if (workerId) {
-        const currentState = registry.get(workerId);
-        if (currentState && currentState.ws !== ws) return;
+        const currentWorker = Worker.get(workerId);
+        if (currentWorker && !currentWorker.isCurrentSocket(ws)) return;
 
         const reasonStr = reason?.length ? `: ${reason}` : "";
         log(workerId, `disconnected (code ${code}${reasonStr})`);
-        const taskId = currentState?.currentTaskId ?? null;
+        const taskId = currentWorker?.currentTaskId ?? null;
         const disconnPayload = { code, reason: reason?.toString() ?? null };
         dbLogger?.logForemanMessage({
           direction: "received",
@@ -355,9 +355,9 @@ export function createForemanWss(
         });
         broadcastMessageEvent({ direction: "received", workerId, taskId, msgType: "worker_disconnected", payload: disconnPayload });
         if (taskId) {
-          registry.markDisconnected(workerId);
+          currentWorker?.markDisconnected();
         } else {
-          registry.remove(workerId);
+          currentWorker?.remove();
         }
       }
     });

--- a/src/foreman/index.ts
+++ b/src/foreman/index.ts
@@ -9,7 +9,7 @@ import { createDbLogger } from "./db.js";
 import type { DbLogger } from "./db.js";
 import { TaskManager } from "./models/task-manager.js";
 import { initDb } from "./db-client.js";
-import { WorkerRegistry } from "./models/worker-registry.js";
+import { Worker } from "./models/worker-registry.js";
 import { createHttpServer } from "./controllers/http-server.js";
 import { createForemanWss } from "./controllers/wss.js";
 import type { ForemanWss } from "./controllers/wss.js";
@@ -32,7 +32,6 @@ const isMain = process.argv[1] === fileURLToPath(import.meta.url);
 if (isMain) {
   const config = await loadConfig(process.argv);
 
-  const registry = new WorkerRegistry();
   const webhooks = config.webhookSecret
     ? new Webhooks({ secret: config.webhookSecret })
     : null;
@@ -53,10 +52,10 @@ if (isMain) {
   // Admin WebSocket broadcaster
   const adminWss = createAdminWss(server, async () => ({
     tasks: await taskManager.getTaskSnapshots(),
-    workers: registry.getWorkerSnapshots(),
+    workers: Worker.all().map((w) => w.toSnapshot()),
   }));
 
-  foremanWss = createForemanWss(taskManager, registry, server, config, {
+  foremanWss = createForemanWss(taskManager, server, config, {
     dbLogger,
     adminWss,
   });

--- a/src/foreman/models/worker-registry.ts
+++ b/src/foreman/models/worker-registry.ts
@@ -3,86 +3,99 @@ import type { ForemanMessage } from "../../types.js";
 import type { WebSocket as WsSocket } from "ws";
 import type { WorkerSnapshot } from "../admin-ws.js";
 
-export interface WorkerState {
-  workerId: string;
-  ws: WsSocket;
-  status: "idle" | "busy" | "disconnected";
+const registry = new Map<string, Worker>();
+
+export class Worker {
+  static readonly events: EventEmitter = new EventEmitter();
+
+  private constructor(
+    readonly workerId: string,
+    private ws: WsSocket,
+  ) {}
+
+  status: "idle" | "busy" | "disconnected" = "idle";
   currentTaskId?: string;
   disconnectedAt?: Date;
-}
 
-export class WorkerRegistry extends EventEmitter {
-  private workers = new Map<string, WorkerState>();
+  // Static registry operations
 
-  register(workerId: string, ws: WsSocket, status: "idle" | "busy", taskId?: string): void {
-    this.workers.set(workerId, { workerId, ws, status, currentTaskId: taskId });
-    this.emit("changed");
+  static register(workerId: string, ws: WsSocket): Worker {
+    const worker = new Worker(workerId, ws);
+    registry.set(workerId, worker);
+    Worker.events.emit("changed");
+    return worker;
   }
 
-  get(workerId: string): WorkerState | undefined {
-    return this.workers.get(workerId);
+  static get(workerId: string): Worker | undefined {
+    return registry.get(workerId);
   }
 
-  remove(workerId: string) {
-    this.workers.delete(workerId);
-    this.emit("changed");
+  static getIdle(): Worker[] {
+    return [...registry.values()].filter((w) => w.status === "idle");
   }
 
-  markDisconnected(workerId: string) {
-    const w = this.workers.get(workerId);
-    if (!w) return;
-    w.status = "disconnected";
-    w.disconnectedAt = new Date();
-    this.emit("changed");
-  }
-
-  getIdleWorker(): WorkerState | null {
-    for (const w of this.workers.values()) {
-      if (w.status === "idle") return w;
-    }
-    return null;
-  }
-
-  getIdleWorkers(): WorkerState[] {
-    return [...this.workers.values()].filter((w) => w.status === "idle");
-  }
-
-  getWorkerForTask(taskId: string): WorkerState | null {
-    for (const w of this.workers.values()) {
+  static getByTask(taskId: string): Worker | undefined {
+    for (const w of registry.values()) {
       if (w.currentTaskId === taskId) return w;
     }
-    return null;
+    return undefined;
   }
 
-  assignTask(workerId: string, taskId: string) {
-    const w = this.workers.get(workerId);
-    if (!w) return;
-    w.status = "busy";
-    w.currentTaskId = taskId;
-    this.emit("changed");
+  static all(): Worker[] {
+    return [...registry.values()];
   }
 
-  releaseWorker(workerId: string) {
-    const w = this.workers.get(workerId);
-    if (!w) return;
-    w.status = "idle";
-    w.currentTaskId = undefined;
-    this.emit("changed");
+  /** Clear registry — use in tests for isolation. */
+  static _reset(): void {
+    registry.clear();
   }
 
+  // Instance operations
 
-  send(workerId: string, msg: ForemanMessage) {
-    const w = this.workers.get(workerId);
-    if (w?.ws.readyState === 1 /* OPEN */) {
-      w.ws.send(JSON.stringify(msg));
+  assign(taskId: string): void {
+    this.status = "busy";
+    this.currentTaskId = taskId;
+    Worker.events.emit("changed");
+  }
+
+  release(): void {
+    this.status = "idle";
+    this.currentTaskId = undefined;
+    Worker.events.emit("changed");
+  }
+
+  markDisconnected(): void {
+    this.status = "disconnected";
+    this.disconnectedAt = new Date();
+    Worker.events.emit("changed");
+  }
+
+  remove(): void {
+    registry.delete(this.workerId);
+    Worker.events.emit("changed");
+  }
+
+  isCurrentSocket(ws: WsSocket): boolean {
+    return this.ws === ws;
+  }
+
+  send(msg: ForemanMessage): boolean {
+    if (this.ws.readyState === 1 /* OPEN */) {
+      this.ws.send(JSON.stringify(msg));
+      return true;
     }
+    return false;
   }
 
-  getWorkerSnapshots(): WorkerSnapshot[] {
-    return [...this.workers.values()].map((w) => ({
-      workerId: w.workerId,
-      status: w.status,
-      currentTaskId: w.currentTaskId,
-    }));
+  toSnapshot(): WorkerSnapshot {
+    return {
+      workerId: this.workerId,
+      status: this.status,
+      currentTaskId: this.currentTaskId,
+    };
   }
 }
+
+// Disable max-listeners warning — tests call createForemanWss many times,
+// each adding a listener to this static emitter.
+Worker.events.setMaxListeners(0);

--- a/tests/browser/server.ts
+++ b/tests/browser/server.ts
@@ -36,7 +36,7 @@ const _realFetch = globalThis.fetch;
 import http from "http";
 import type { AddressInfo } from "net";
 import { WebSocket } from "ws";
-import { WorkerRegistry } from "../../src/foreman/models/worker-registry.js";
+import { Worker } from "../../src/foreman/models/worker-registry.js";
 import { createForemanWss } from "../../src/foreman/controllers/wss.js";
 import { createHttpServer } from "../../src/foreman/controllers/http-server.js";
 import { TaskManager } from "../../src/foreman/models/task-manager.js";
@@ -45,7 +45,6 @@ import { initDb } from "../../src/foreman/db-client.js";
 import { createMemoryTaskDb } from "../helpers/memory-db.js";
 import { createAdminWss } from "../../src/foreman/admin-ws.js";
 import { loadDefaultConfig } from "../../src/config.js";
-import type { DependencyGraph } from "../../src/foreman/dependencies.js";
 
 const PORT = parseInt(process.env.PORT ?? "14567", 10);
 
@@ -53,8 +52,6 @@ const cfg = await loadDefaultConfig();
 
 // ── Foreman state ─────────────────────────────────────────────────────────────
 
-const registry = new WorkerRegistry();
-const graph: DependencyGraph = new Map();
 const taskModel = new TaskManager();
 initDb(createMemoryTaskDb());
 Task.events.on("changed", () => taskModel.emit("changed"));
@@ -144,13 +141,13 @@ async function handleTestRoute(
 // ── Admin WebSocket ───────────────────────────────────────────────────────────
 
 const adminWss = createAdminWss(server, async () => ({
-  tasks: await taskModel.getTaskSnapshots(graph),
-  workers: registry.getWorkerSnapshots(),
+  tasks: await taskModel.getTaskSnapshots(),
+  workers: Worker.all().map((w) => w.toSnapshot()),
 }));
 
 // ── Foreman WebSocket ─────────────────────────────────────────────────────────
 
-foremanWss = createForemanWss(taskModel, registry, server, cfg, { graph, adminWss });
+foremanWss = createForemanWss(taskModel, server, cfg, { adminWss });
 
 // ── Start ─────────────────────────────────────────────────────────────────────
 

--- a/tests/foreman.admin-broadcast.test.ts
+++ b/tests/foreman.admin-broadcast.test.ts
@@ -16,7 +16,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import http from "http";
 import { WebSocket, WebSocketServer } from "ws";
 import type { AddressInfo } from "net";
-import { WorkerRegistry } from "../src/foreman/models/worker-registry.js";
+import { Worker } from "../src/foreman/models/worker-registry.js";
 import { createForemanWss } from "../src/foreman/controllers/wss.js";
 import { TaskManager } from "../src/foreman/models/task-manager.js";
 import { Task } from "../src/foreman/models/task.js";
@@ -67,7 +67,7 @@ function send(ws: WebSocket, msg: object) {
 // ── Test harness ──────────────────────────────────────────────────────────────
 
 let taskManager: TaskManager;
-let registry: WorkerRegistry;
+
 let httpServer: http.Server;
 let wss: WebSocketServer;
 let adminWss: AdminWss;
@@ -80,16 +80,17 @@ function connect(): Promise<WebSocket> {
 }
 
 beforeEach(() => {
+  Worker._reset();
   vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
   process.env.GITHUB_REPO = "owner/repo";
   process.env.GITHUB_TOKEN = "token";
 
   taskManager = new TaskManager();
   setupInMemoryTasks(taskManager);
-  registry = new WorkerRegistry();
+
   adminWss = makeMockAdminWss();
   httpServer = http.createServer();
-  ({ wss, routeEvent } = createForemanWss(taskManager, registry, httpServer, defaultCfg, { adminWss }));
+  ({ wss, routeEvent } = createForemanWss(taskManager, httpServer, defaultCfg, { adminWss }));
 
   return new Promise<void>((resolve) => {
     httpServer.listen(0, () => {

--- a/tests/foreman.blockers.test.ts
+++ b/tests/foreman.blockers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { WorkerRegistry } from "../src/foreman/models/worker-registry.js";
+import { Worker } from "../src/foreman/models/worker-registry.js";
 import { createForemanWss } from "../src/foreman/controllers/wss.js";
 import { TaskManager } from "../src/foreman/models/task-manager.js";
 import { Task } from "../src/foreman/models/task.js";
@@ -15,6 +15,7 @@ describe("foreman — blocker transitions via routeEvent", () => {
   let taskManager: TaskManager;
 
   beforeEach(() => {
+    Worker._reset();
     taskManager = new TaskManager();
     setupInMemoryTasks(taskManager);
   });
@@ -24,7 +25,6 @@ describe("foreman — blocker transitions via routeEvent", () => {
   });
 
   it("task derives blocked status when blocker is open", async () => {
-    const registry = new WorkerRegistry();
     const server = http.createServer();
 
     await Task.upsert("10", 10, "owner/repo", "T", "b", []);
@@ -33,7 +33,7 @@ describe("foreman — blocker transitions via routeEvent", () => {
     taskManager.markBlockersLoaded(10);
     taskManager.setIssueOpenState(5, true); // blocker is open
 
-    const { wss } = createForemanWss(taskManager, registry, server, { ...defaultCfg, taskLabel: "brunel:ready", workerReclaimTimeoutMs: 300_000 });
+    const { wss } = createForemanWss(taskManager, server, { ...defaultCfg, taskLabel: "brunel:ready", workerReclaimTimeoutMs: 300_000 });
     wss.close();
 
     const snapshots = await taskManager.getTaskSnapshots();
@@ -41,7 +41,6 @@ describe("foreman — blocker transitions via routeEvent", () => {
   });
 
   it("task derives pending status when blocker is closed", async () => {
-    const registry = new WorkerRegistry();
     const server = http.createServer();
 
     await Task.upsert("10", 10, "owner/repo", "T", "b", []);
@@ -50,7 +49,7 @@ describe("foreman — blocker transitions via routeEvent", () => {
     taskManager.markBlockersLoaded(10);
     taskManager.setIssueOpenState(5, true);
 
-    const { wss, routeEvent } = createForemanWss(taskManager, registry, server, { ...defaultCfg, taskLabel: "brunel:ready" });
+    const { wss, routeEvent } = createForemanWss(taskManager, server, { ...defaultCfg, taskLabel: "brunel:ready" });
     wss.close();
 
     // Initially blocked
@@ -69,7 +68,6 @@ describe("foreman — blocker transitions via routeEvent", () => {
   });
 
   it("task remains blocked when other blockers are still open", async () => {
-    const registry = new WorkerRegistry();
     const server = http.createServer();
 
     await Task.upsert("10", 10, "owner/repo", "T", "b", []);
@@ -80,7 +78,7 @@ describe("foreman — blocker transitions via routeEvent", () => {
     taskManager.setIssueOpenState(5, true);
     taskManager.setIssueOpenState(6, true);
 
-    const { wss, routeEvent } = createForemanWss(taskManager, registry, server, { ...defaultCfg, taskLabel: "brunel:ready" });
+    const { wss, routeEvent } = createForemanWss(taskManager, server, { ...defaultCfg, taskLabel: "brunel:ready" });
     wss.close();
 
     // Initially blocked

--- a/tests/foreman.event-router.test.ts
+++ b/tests/foreman.event-router.test.ts
@@ -7,49 +7,39 @@
  * registry's currentTaskId rather than task status — mirroring the worker-side
  * guard — so any case where the worker has moved on is caught.
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { forwardEvent } from "../src/foreman/controllers/event-router.js";
 import type { EventRouterDeps } from "../src/foreman/controllers/event-router.js";
 import { Task } from "../src/foreman/models/task.js";
+import { Worker } from "../src/foreman/models/worker-registry.js";
 import type { GitHubEvent } from "../src/types.js";
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
+
+function fakeWs() {
+  return { send: vi.fn(), close: vi.fn(), readyState: 1 } as any;
+}
 
 function makeEvent(name = "issue_comment"): GitHubEvent {
   return { id: "evt-1", name, payload: {} };
 }
 
-function makeDeps(registryGet: ReturnType<typeof vi.fn> = vi.fn()): EventRouterDeps & { sendMsg: ReturnType<typeof vi.fn>; queueEvent: ReturnType<typeof vi.fn>; flog: ReturnType<typeof vi.fn> } {
+function makeDeps(): EventRouterDeps & { sendMsg: ReturnType<typeof vi.fn>; flog: ReturnType<typeof vi.fn> } {
   const queueEvent = vi.fn();
   const sendMsg = vi.fn();
   const flog = vi.fn();
   return {
     taskManager: { queueEvent } as unknown as EventRouterDeps["taskManager"],
-    registry: { get: registryGet } as unknown as EventRouterDeps["registry"],
     repo: "owner/repo",
     token: "token",
     taskLabel: "brunel:ready",
     sendMsg,
     flog,
     assignIdleWorkers: vi.fn().mockResolvedValue(undefined),
-    queueEvent,
   } as unknown as ReturnType<typeof makeDeps>;
 }
 
-/** Registry returns a worker currently assigned to the given task. */
-function workerOnTask(taskId: string) {
-  return vi.fn().mockReturnValue({ status: "busy", currentTaskId: taskId });
-}
-
-/** Registry returns a worker that has moved on to a different task (or is idle). */
-function workerOnDifferentTask() {
-  return vi.fn().mockReturnValue({ status: "busy", currentTaskId: "other-task-id" });
-}
-
-/** Registry returns a worker that is idle (currentTaskId cleared after completion). */
-function idleWorker() {
-  return vi.fn().mockReturnValue({ status: "idle", currentTaskId: undefined });
-}
+beforeEach(() => { Worker._reset(); });
 
 // ── Core bug fix: worker that has moved on ─────────────────────────────────────
 
@@ -63,7 +53,9 @@ describe("forwardEvent — worker has moved on to a different task", () => {
       worker_id: "worker-1",
       completed_at: new Date().toISOString(),
     });
-    const deps = makeDeps(workerOnDifferentTask());
+    const w = Worker.register("worker-1", fakeWs());
+    w.assign("other-task-id"); // worker has moved on to a different task
+    const deps = makeDeps();
 
     forwardEvent(deps, task, makeEvent(), "#42");
 
@@ -78,7 +70,8 @@ describe("forwardEvent — worker has moved on to a different task", () => {
       worker_id: "worker-1",
       completed_at: new Date().toISOString(),
     });
-    const deps = makeDeps(idleWorker());
+    Worker.register("worker-1", fakeWs()); // idle with no currentTaskId
+    const deps = makeDeps();
 
     forwardEvent(deps, task, makeEvent(), "#42");
 
@@ -93,7 +86,9 @@ describe("forwardEvent — worker has moved on to a different task", () => {
       worker_id: "worker-1",
       completed_at: new Date().toISOString(),
     });
-    const deps = makeDeps(workerOnDifferentTask());
+    const w = Worker.register("worker-1", fakeWs());
+    w.assign("other-task-id");
+    const deps = makeDeps();
 
     forwardEvent(deps, task, makeEvent("issue_comment"), "#42");
 
@@ -111,7 +106,9 @@ describe("forwardEvent — active tasks still receive events", () => {
       issue_number: 42,
       worker_id: "worker-1",
     });
-    const deps = makeDeps(workerOnTask("42"));
+    const w = Worker.register("worker-1", fakeWs());
+    w.assign("42");
+    const deps = makeDeps();
 
     forwardEvent(deps, task, makeEvent(), "#42");
 
@@ -130,7 +127,9 @@ describe("forwardEvent — active tasks still receive events", () => {
       worker_id: "worker-1",
       pr_merged_at: new Date().toISOString(),
     });
-    const deps = makeDeps(workerOnTask("42"));
+    const w = Worker.register("worker-1", fakeWs());
+    w.assign("42");
+    const deps = makeDeps();
 
     forwardEvent(deps, task, makeEvent(), "#42");
 
@@ -145,7 +144,9 @@ describe("forwardEvent — active tasks still receive events", () => {
       worker_id: "worker-1",
       issue_closed_at: new Date().toISOString(),
     });
-    const deps = makeDeps(workerOnTask("42"));
+    const w = Worker.register("worker-1", fakeWs());
+    w.assign("42");
+    const deps = makeDeps();
 
     forwardEvent(deps, task, makeEvent(), "#42");
 

--- a/tests/foreman.reconcile.test.ts
+++ b/tests/foreman.reconcile.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import http from "http";
-import { WorkerRegistry } from "../src/foreman/models/worker-registry.js";
+import { Worker } from "../src/foreman/models/worker-registry.js";
 import { createForemanWss } from "../src/foreman/controllers/wss.js";
 import { TaskManager } from "../src/foreman/models/task-manager.js";
 import { Task } from "../src/foreman/models/task.js";
@@ -15,17 +15,16 @@ function makeIssue(n: number): TaskIssue {
   return { number: n, title: `Issue ${n}`, body: "body", labels: [TASK_LABEL], repoUrl: "https://github.com/o/r" };
 }
 
-let registry: WorkerRegistry;
 let taskManager: TaskManager;
 let reconcile: () => Promise<void>;
 let routeEvent: (id: string, name: string, payload: unknown) => Promise<void>;
 
 beforeEach(() => {
+  Worker._reset();
   taskManager = new TaskManager();
   setupInMemoryTasks(taskManager);
-  registry = new WorkerRegistry();
   const server = http.createServer();
-  ({ reconcile, routeEvent } = createForemanWss(taskManager, registry, server, { ...defaultCfg, taskLabel: TASK_LABEL }));
+  ({ reconcile, routeEvent } = createForemanWss(taskManager, server, { ...defaultCfg, taskLabel: TASK_LABEL }));
 });
 
 afterEach(() => {
@@ -39,7 +38,7 @@ describe("reconcile()", () => {
 
   it("does not assign a pending task when its blockersLoaded is false", async () => {
     const fakeWs = { send: vi.fn(), close: vi.fn(), readyState: 1 } as any;
-    registry.register("w1", fakeWs, "idle");
+    Worker.register("w1", fakeWs);
 
     await Task.upsert("42", 42, "test/repo", "T", "b", []);
     taskManager.trackIssue(42); // blockersLoaded defaults to false — NOT calling markBlockersLoaded
@@ -52,7 +51,7 @@ describe("reconcile()", () => {
 
   it("assigns a pending task to an idle worker when blockersLoaded is true", async () => {
     const fakeWs = { send: vi.fn(), close: vi.fn(), readyState: 1 } as any;
-    registry.register("w1", fakeWs, "idle");
+    Worker.register("w1", fakeWs);
 
     await Task.upsert("42", 42, "test/repo", "T", "b", []);
     taskManager.trackIssue(42);
@@ -63,7 +62,7 @@ describe("reconcile()", () => {
 
     expect(fakeWs.send).toHaveBeenCalledWith(expect.stringContaining('"task_assigned"'));
     expect((await Task.get("42"))?.status).toBe("assigned");
-    expect(registry.get("w1")?.status).toBe("busy");
+    expect(Worker.get("w1")?.status).toBe("busy");
   });
 
   it("does NOT remove an assigned task (reconcile never deletes)", async () => {

--- a/tests/foreman.registry.test.ts
+++ b/tests/foreman.registry.test.ts
@@ -1,151 +1,198 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { WorkerRegistry } from "../src/foreman/models/worker-registry.js";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Worker } from "../src/foreman/models/worker-registry.js";
 import type { ForemanMessage } from "../src/types.js";
 
 function fakeWs() {
   return { send: vi.fn(), close: vi.fn(), readyState: 1 } as any;
 }
 
-describe("WorkerRegistry", () => {
-  let reg: WorkerRegistry;
-  beforeEach(() => { reg = new WorkerRegistry(); });
+beforeEach(() => { Worker._reset(); });
 
+describe("Worker", () => {
   it("registers a worker and retrieves it", () => {
-    reg.register("w1", fakeWs(), "idle");
-    expect(reg.get("w1")).toMatchObject({ workerId: "w1", status: "idle" });
+    Worker.register("w1", fakeWs());
+    expect(Worker.get("w1")).toMatchObject({ workerId: "w1", status: "idle" });
   });
 
-  it("getIdleWorker returns an idle worker", () => {
-    reg.register("w1", fakeWs(), "idle");
-    expect(reg.getIdleWorker()?.workerId).toBe("w1");
+  it("getIdle returns an idle worker", () => {
+    Worker.register("w1", fakeWs());
+    expect(Worker.getIdle().map(w => w.workerId)).toContain("w1");
   });
 
-  it("getIdleWorker returns null when all busy", () => {
-    reg.register("w1", fakeWs(), "busy");
-    expect(reg.getIdleWorker()).toBeNull();
+  it("getIdle returns empty array when all busy", () => {
+    const w = Worker.register("w1", fakeWs());
+    w.assign("42");
+    expect(Worker.getIdle()).toHaveLength(0);
   });
 
-  it("assignTask marks worker busy with taskId", () => {
-    reg.register("w1", fakeWs(), "idle");
-    reg.assignTask("w1", "42");
-    const w = reg.get("w1")!;
+  it("assign marks worker busy with taskId", () => {
+    const w = Worker.register("w1", fakeWs());
+    w.assign("42");
     expect(w.status).toBe("busy");
     expect(w.currentTaskId).toBe("42");
   });
 
-  it("releaseWorker marks worker idle and clears taskId", () => {
-    reg.register("w1", fakeWs(), "busy");
-    reg.assignTask("w1", "42");
-    reg.releaseWorker("w1");
-    const w = reg.get("w1")!;
+  it("release marks worker idle and clears taskId", () => {
+    const w = Worker.register("w1", fakeWs());
+    w.assign("42");
+    w.release();
     expect(w.status).toBe("idle");
     expect(w.currentTaskId).toBeUndefined();
   });
 
-  it("remove deletes the worker", () => {
-    reg.register("w1", fakeWs(), "idle");
-    reg.remove("w1");
-    expect(reg.get("w1")).toBeUndefined();
+  it("remove deletes the worker from the registry", () => {
+    const w = Worker.register("w1", fakeWs());
+    w.remove();
+    expect(Worker.get("w1")).toBeUndefined();
   });
 
-  it("getWorkerForTask returns worker assigned to that task", () => {
-    reg.register("w1", fakeWs(), "idle");
-    reg.assignTask("w1", "42");
-    expect(reg.getWorkerForTask("42")?.workerId).toBe("w1");
+  it("getByTask returns worker assigned to that task", () => {
+    const w = Worker.register("w1", fakeWs());
+    w.assign("42");
+    expect(Worker.getByTask("42")?.workerId).toBe("w1");
+  });
+
+  it("all returns all registered workers", () => {
+    Worker.register("w1", fakeWs());
+    Worker.register("w2", fakeWs());
+    expect(Worker.all().map(w => w.workerId)).toEqual(expect.arrayContaining(["w1", "w2"]));
+    expect(Worker.all()).toHaveLength(2);
   });
 
   it("send serializes message and calls ws.send", () => {
     const ws = fakeWs();
-    reg.register("w1", ws, "idle");
+    const w = Worker.register("w1", ws);
     const msg: ForemanMessage = { type: "task_assigned", taskId: "1", issue: { number: 1, title: "T", body: "", labels: [], repoUrl: "https://github.com/o/r" } };
-    reg.send("w1", msg);
+    w.send(msg);
     expect(ws.send).toHaveBeenCalledWith(JSON.stringify(msg));
+  });
+
+  it("send returns true when OPEN", () => {
+    const ws = fakeWs();
+    const w = Worker.register("w1", ws);
+    const result = w.send({ type: "task_assigned", taskId: "1", issue: { number: 1, title: "T", body: "", labels: [], repoUrl: "https://github.com/o/r" } });
+    expect(result).toBe(true);
+  });
+
+  it("toSnapshot returns WorkerSnapshot", () => {
+    const w = Worker.register("w1", fakeWs());
+    w.assign("42");
+    expect(w.toSnapshot()).toEqual({ workerId: "w1", status: "busy", currentTaskId: "42" });
   });
 
   describe("markDisconnected", () => {
     it("sets status to disconnected and records disconnectedAt", () => {
-      reg.register("w1", fakeWs(), "busy");
-      reg.assignTask("w1", "42");
-      reg.markDisconnected("w1");
-      const w = reg.get("w1")!;
+      const w = Worker.register("w1", fakeWs());
+      w.assign("42");
+      w.markDisconnected();
       expect(w.status).toBe("disconnected");
       expect(w.currentTaskId).toBe("42");
       expect(w.disconnectedAt).toBeInstanceOf(Date);
     });
 
-    it("is a no-op for unknown worker", () => {
-      expect(() => reg.markDisconnected("unknown")).not.toThrow();
+    it("getIdle does not return a disconnected worker", () => {
+      const w = Worker.register("w1", fakeWs());
+      w.markDisconnected();
+      expect(Worker.getIdle()).toHaveLength(0);
     });
 
-    it("getIdleWorker does not return a disconnected worker", () => {
-      reg.register("w1", fakeWs(), "idle");
-      reg.markDisconnected("w1");
-      expect(reg.getIdleWorker()).toBeNull();
-    });
-
-    it("send does not call ws.send on a disconnected worker", () => {
+    it("send does not call ws.send on a closed socket", () => {
       const ws = fakeWs();
       ws.readyState = 3; // CLOSED
-      reg.register("w1", ws, "busy");
-      reg.markDisconnected("w1");
-      reg.send("w1", { type: "task_assigned", taskId: "1", issue: { number: 1, title: "T", body: "", labels: [], repoUrl: "https://github.com/o/r" } });
+      const w = Worker.register("w1", ws);
+      w.markDisconnected();
+      w.send({ type: "task_assigned", taskId: "1", issue: { number: 1, title: "T", body: "", labels: [], repoUrl: "https://github.com/o/r" } });
       expect(ws.send).not.toHaveBeenCalled();
     });
 
-    it("getWorkerSnapshots includes disconnected workers", () => {
-      reg.register("w1", fakeWs(), "busy");
-      reg.assignTask("w1", "42");
-      reg.markDisconnected("w1");
-      const snapshots = reg.getWorkerSnapshots();
+    it("send returns false when socket is closed", () => {
+      const ws = fakeWs();
+      ws.readyState = 3;
+      const w = Worker.register("w1", ws);
+      const result = w.send({ type: "task_assigned", taskId: "1", issue: { number: 1, title: "T", body: "", labels: [], repoUrl: "https://github.com/o/r" } });
+      expect(result).toBe(false);
+    });
+
+    it("all includes disconnected workers", () => {
+      const w = Worker.register("w1", fakeWs());
+      w.assign("42");
+      w.markDisconnected();
+      const snapshots = Worker.all().map(x => x.toSnapshot());
       expect(snapshots).toHaveLength(1);
       expect(snapshots[0].status).toBe("disconnected");
       expect(snapshots[0].currentTaskId).toBe("42");
     });
   });
+
+  it("isCurrentSocket returns true for the registered socket", () => {
+    const ws = fakeWs();
+    const w = Worker.register("w1", ws);
+    expect(w.isCurrentSocket(ws)).toBe(true);
+  });
+
+  it("isCurrentSocket returns false for a different socket", () => {
+    const ws1 = fakeWs();
+    const ws2 = fakeWs();
+    const w = Worker.register("w1", ws1);
+    expect(w.isCurrentSocket(ws2)).toBe(false);
+  });
+
+  it("re-registering with a new socket replaces the entry", () => {
+    const ws1 = fakeWs();
+    const ws2 = fakeWs();
+    Worker.register("w1", ws1);
+    const w = Worker.register("w1", ws2);
+    expect(Worker.get("w1")).toBe(w);
+    expect(w.isCurrentSocket(ws2)).toBe(true);
+  });
 });
 
 
-describe("WorkerRegistry changed events", () => {
-  let reg: WorkerRegistry;
-  beforeEach(() => { reg = new WorkerRegistry(); });
+describe("Worker changed events", () => {
+  beforeEach(() => { Worker._reset(); });
 
   it("register emits changed", () => {
     const changed = vi.fn();
-    reg.on("changed", changed);
-    reg.register("w1", fakeWs(), "idle");
+    Worker.events.on("changed", changed);
+    Worker.register("w1", fakeWs());
     expect(changed).toHaveBeenCalledOnce();
+    Worker.events.off("changed", changed);
   });
 
   it("remove emits changed", () => {
-    reg.register("w1", fakeWs(), "idle");
+    const w = Worker.register("w1", fakeWs());
     const changed = vi.fn();
-    reg.on("changed", changed);
-    reg.remove("w1");
+    Worker.events.on("changed", changed);
+    w.remove();
     expect(changed).toHaveBeenCalledOnce();
+    Worker.events.off("changed", changed);
   });
 
   it("markDisconnected emits changed", () => {
-    reg.register("w1", fakeWs(), "busy");
+    const w = Worker.register("w1", fakeWs());
     const changed = vi.fn();
-    reg.on("changed", changed);
-    reg.markDisconnected("w1");
+    Worker.events.on("changed", changed);
+    w.markDisconnected();
     expect(changed).toHaveBeenCalledOnce();
+    Worker.events.off("changed", changed);
   });
 
-  it("assignTask emits changed", () => {
-    reg.register("w1", fakeWs(), "idle");
+  it("assign emits changed", () => {
+    const w = Worker.register("w1", fakeWs());
     const changed = vi.fn();
-    reg.on("changed", changed);
-    reg.assignTask("w1", "42");
+    Worker.events.on("changed", changed);
+    w.assign("42");
     expect(changed).toHaveBeenCalledOnce();
+    Worker.events.off("changed", changed);
   });
 
-  it("releaseWorker emits changed", () => {
-    reg.register("w1", fakeWs(), "busy");
-    reg.assignTask("w1", "42");
+  it("release emits changed", () => {
+    const w = Worker.register("w1", fakeWs());
+    w.assign("42");
     const changed = vi.fn();
-    reg.on("changed", changed);
-    reg.releaseWorker("w1");
+    Worker.events.on("changed", changed);
+    w.release();
     expect(changed).toHaveBeenCalledOnce();
+    Worker.events.off("changed", changed);
   });
 });

--- a/tests/foreman.startup.test.ts
+++ b/tests/foreman.startup.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { WorkerRegistry } from "../src/foreman/models/worker-registry.js";
+import { Worker } from "../src/foreman/models/worker-registry.js";
 import { createForemanWss } from "../src/foreman/controllers/wss.js";
 import { TaskManager } from "../src/foreman/models/task-manager.js";
 import { Task } from "../src/foreman/models/task.js";
@@ -71,7 +71,7 @@ function closeClient(ws: WebSocket): Promise<void> {
 // ── Test harness ──────────────────────────────────────────────────────────────
 
 let taskManager: TaskManager;
-let registry: WorkerRegistry;
+
 let httpServer: http.Server;
 let wss: WebSocketServer;
 let port: number;
@@ -82,7 +82,7 @@ function connect(msg: object): Promise<WebSocket> {
 }
 
 beforeEach(() => {
-  registry = new WorkerRegistry();
+  Worker._reset();
   httpServer = http.createServer();
   taskManager = new TaskManager();
   setupInMemoryTasks(taskManager);
@@ -121,7 +121,7 @@ describe("tryAssignWork — assign persistence", () => {
   it("task.assign is called and task status becomes assigned before task_assigned is sent", async () => {
     await registerReady(taskManager, "42", 42, "owner/repo", "Test task", "body", []);
 
-    ({ wss } = createForemanWss(taskManager, registry, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" }));
+    ({ wss } = createForemanWss(taskManager, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" }));
 
     port = await startServer();
     const ws = await connect({ type: "worker_hello", workerId: "w1", status: "idle" });
@@ -142,18 +142,18 @@ describe("tryAssignWork — assign persistence", () => {
     const task = await Task.get("42");
     vi.spyOn(task!, "assign").mockRejectedValue(new Error("db down"));
 
-    ({ wss } = createForemanWss(taskManager, registry, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" }));
+    ({ wss } = createForemanWss(taskManager, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" }));
 
     port = await startServer();
     const ws = await connect({ type: "worker_hello", workerId: "w1", status: "idle" });
-    await waitUntil(() => registry.get("w1")?.status === "idle");
+    await waitUntil(() => Worker.get("w1")?.status === "idle");
 
     expect((await Task.get("42"))?.status).toBe("pending");
   });
 
   it("works transparently with in-memory task store", async () => {
     await registerReady(taskManager, "42", 42, "owner/repo", "Test task", "body", []);
-    ({ wss } = createForemanWss(taskManager, registry, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" }));
+    ({ wss } = createForemanWss(taskManager, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" }));
 
     port = await startServer();
     const ws = await connect({ type: "worker_hello", workerId: "w1", status: "idle" });
@@ -174,7 +174,7 @@ describe("startup reconnect behaviour", () => {
     const t = await Task.get("42");
     await t!.assign("w1"); // simulate what main block does after startup restore
 
-    ({ wss } = createForemanWss(taskManager, registry, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" }));
+    ({ wss } = createForemanWss(taskManager, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" }));
 
     port = await startServer();
     const ws = await connect({ type: "worker_hello", workerId: "w1", status: "idle" });
@@ -191,11 +191,11 @@ describe("startup reconnect behaviour", () => {
     const t = await Task.get("42");
     await t!.assign("original-worker"); // simulate startup loading
 
-    ({ wss } = createForemanWss(taskManager, registry, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" }));
+    ({ wss } = createForemanWss(taskManager, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" }));
 
     port = await startServer();
     const ws = await connect({ type: "worker_hello", workerId: "new-worker", status: "idle" });
-    await waitUntil(() => registry.get("new-worker")?.status === "idle");
+    await waitUntil(() => Worker.get("new-worker")?.status === "idle");
 
     // new-worker should NOT get task 42 — it belongs to original-worker
     expect((await Task.get("42"))?.status).toBe("assigned");
@@ -207,12 +207,12 @@ describe("startup reconnect behaviour", () => {
     const t = await Task.get("42");
     await t!.assign("w1");
 
-    ({ wss } = createForemanWss(taskManager, registry, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" }));
+    ({ wss } = createForemanWss(taskManager, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" }));
 
     port = await startServer();
     await connect({ type: "worker_hello", workerId: "w1", status: "busy", taskId: "42" });
 
-    await waitUntil(() => registry.get("w1")?.status === "busy");
+    await waitUntil(() => Worker.get("w1")?.status === "busy");
     expect((await Task.get("42"))?.status).toBe("assigned");
     expect((await Task.get("42"))?.workerId).toBe("w1");
   });
@@ -227,7 +227,7 @@ describe("PR tracking persistence", () => {
     await t!.assign("w1");
     const spyRegisterPr = vi.spyOn(t!, "registerPr");
 
-    const result = createForemanWss(taskManager, registry, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" });
+    const result = createForemanWss(taskManager, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" });
     ({ wss } = result);
 
     await result.routeEvent("evt-1", "pull_request", {
@@ -248,7 +248,7 @@ describe("PR tracking persistence", () => {
     await t!.assign("w1");
     const spyRegisterPr = vi.spyOn(t!, "registerPr");
 
-    const result = createForemanWss(taskManager, registry, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" });
+    const result = createForemanWss(taskManager, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" });
     ({ wss } = result);
 
     await result.routeEvent("evt-1", "pull_request", {
@@ -294,7 +294,7 @@ async function restoreTasksFromDb(rows: Array<{
 
 describe("startup — restore tasks from tasks table (DB is source of truth)", () => {
   it("assigned task from store is visible in the snapshot", async () => {
-    ({ wss } = createForemanWss(taskManager, registry, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" }));
+    ({ wss } = createForemanWss(taskManager, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" }));
 
     port = await startServer();
 
@@ -312,7 +312,7 @@ describe("startup — restore tasks from tasks table (DB is source of truth)", (
   });
 
   it("pending task from store can be assigned by nextPending", async () => {
-    ({ wss } = createForemanWss(taskManager, registry, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" }));
+    ({ wss } = createForemanWss(taskManager, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" }));
 
     port = await startServer();
 
@@ -329,7 +329,7 @@ describe("startup — restore tasks from tasks table (DB is source of truth)", (
   });
 
   it("PR number and branch are restored from store", async () => {
-    ({ wss } = createForemanWss(taskManager, registry, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" }));
+    ({ wss } = createForemanWss(taskManager, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" }));
 
     port = await startServer();
 
@@ -345,7 +345,7 @@ describe("startup — restore tasks from tasks table (DB is source of truth)", (
   });
 
   it("complete tasks from store are skipped", async () => {
-    ({ wss } = createForemanWss(taskManager, registry, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" }));
+    ({ wss } = createForemanWss(taskManager, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" }));
 
     port = await startServer();
 
@@ -365,7 +365,7 @@ describe("startup — restore tasks from tasks table (DB is source of truth)", (
     // 2. GitHub data is loaded into labeledIssues (via loadIssuesToQueue)
     // 3. reconcile() is called to sync labeledIssues → taskQueue
     // 4. Worker connects and must receive the real body/labels in task_assigned
-    const { wss: fwss, reconcile } = createForemanWss(taskManager, registry, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" });
+    const { wss: fwss, reconcile } = createForemanWss(taskManager, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" });
     wss = fwss;
 
     port = await startServer();
@@ -399,7 +399,7 @@ describe("startup — restore tasks from tasks table (DB is source of truth)", (
     // 1. Task is restored from DB with worker_id set (loadActiveTasksFromDb)
     // 2. GitHub sync calls Task.upsert() again for the same task (loadIssuesFromGithub)
     // 3. reconcile() runs — MUST NOT assign the task to a different idle worker
-    const { wss: fwss, reconcile } = createForemanWss(taskManager, registry, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" });
+    const { wss: fwss, reconcile } = createForemanWss(taskManager, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" });
     wss = fwss;
 
     port = await startServer();
@@ -425,7 +425,7 @@ describe("startup — restore tasks from tasks table (DB is source of truth)", (
 
     // Step 4: an idle worker connects — must NOT receive the already-assigned task
     const ws = await connect({ type: "worker_hello", workerId: "new-worker", status: "idle" });
-    await waitUntil(() => registry.get("new-worker")?.status === "idle");
+    await waitUntil(() => Worker.get("new-worker")?.status === "idle");
 
     expect((await Task.get("42"))?.workerId).toBe("original-worker");
   });
@@ -477,14 +477,14 @@ describe("startup reconnect — worker reconnects to complete task", () => {
     await t!.assign("w1");
     await t!.complete(); // issue closed while worker was active
 
-    ({ wss } = createForemanWss(taskManager, registry, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" }));
+    ({ wss } = createForemanWss(taskManager, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" }));
 
     port = await startServer();
     await connect({ type: "worker_hello", workerId: "w1", status: "busy", taskId: "42" });
 
-    await waitUntil(() => registry.get("w1") !== undefined);
+    await waitUntil(() => Worker.get("w1") !== undefined);
     // Worker should be reclaimed as busy to allow finalization work
-    expect(registry.get("w1")?.status).toBe("busy");
+    expect(Worker.get("w1")?.status).toBe("busy");
     // Task should stay complete
     expect((await Task.get("42"))?.status).toBe("complete");
   });
@@ -495,21 +495,21 @@ describe("startup reconnect — worker reconnects to complete task", () => {
     await t!.assign("w1");
     await t!.complete();
 
-    ({ wss } = createForemanWss(taskManager, registry, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" }));
+    ({ wss } = createForemanWss(taskManager, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" }));
 
     port = await startServer();
     const ws = await connect({ type: "worker_hello", workerId: "w1", status: "busy", taskId: "42" });
 
-    await waitUntil(() => registry.get("w1") !== undefined);
+    await waitUntil(() => Worker.get("w1") !== undefined);
     // Spy on complete after the task is already obtained
     const t2 = await Task.get("42");
     const spyComplete = vi.spyOn(t2!, "complete");
 
     ws.send(JSON.stringify({ type: "task_complete", workerId: "w1", taskId: "42" }));
-    await waitUntil(() => registry.get("w1")?.status === "idle");
+    await waitUntil(() => Worker.get("w1")?.status === "idle");
 
     // The task was already complete; task_complete is still a no-op (idempotent)
-    expect(registry.get("w1")?.status).toBe("idle");
+    expect(Worker.get("w1")?.status).toBe("idle");
   });
 });
 
@@ -521,19 +521,19 @@ describe("task_complete marks task complete", () => {
     const t = await Task.get("42");
     await t!.assign("w1");
 
-    ({ wss } = createForemanWss(taskManager, registry, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" }));
+    ({ wss } = createForemanWss(taskManager, httpServer, { ...defaultCfg, taskLabel: "brunel:ready" }));
 
     port = await startServer();
     const ws = await connect({ type: "worker_hello", workerId: "w1", status: "busy", taskId: "42" });
 
-    await waitUntil(() => registry.get("w1")?.status === "busy");
+    await waitUntil(() => Worker.get("w1")?.status === "busy");
 
     // Get fresh task reference and spy on complete
     const t2 = await Task.get("42");
     const spyComplete = vi.spyOn(t2!, "complete");
 
     ws.send(JSON.stringify({ type: "task_complete", workerId: "w1", taskId: "42" }));
-    await waitUntil(() => registry.get("w1")?.status === "idle");
+    await waitUntil(() => Worker.get("w1")?.status === "idle");
 
     expect(spyComplete).toHaveBeenCalled();
   });

--- a/tests/foreman.timestamps.test.ts
+++ b/tests/foreman.timestamps.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import http from "http";
 import { WebSocket, WebSocketServer } from "ws";
 import type { AddressInfo } from "net";
-import { WorkerRegistry } from "../src/foreman/models/worker-registry.js";
+import { Worker } from "../src/foreman/models/worker-registry.js";
 import { createForemanWss } from "../src/foreman/controllers/wss.js";
 import { TaskManager } from "../src/foreman/models/task-manager.js";
 import { Task } from "../src/foreman/models/task.js";
@@ -70,7 +70,6 @@ const ISO_TIMESTAMP_PREFIX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z /;
 // ── Test harness ──────────────────────────────────────────────────────────────
 
 let taskManager: TaskManager;
-let registry: WorkerRegistry;
 let httpServer: http.Server;
 let wss: WebSocketServer;
 let routeEvent: (id: string, name: string, payload: unknown) => Promise<void>;
@@ -83,6 +82,7 @@ function connect(): Promise<WebSocket> {
 }
 
 beforeEach(() => {
+  Worker._reset();
   vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
   process.env.GITHUB_REPO = "owner/repo";
   process.env.GITHUB_TOKEN = "token";
@@ -94,9 +94,8 @@ beforeEach(() => {
 
   taskManager = new TaskManager();
   setupInMemoryTasks(taskManager);
-  registry = new WorkerRegistry();
   httpServer = http.createServer();
-  ({ wss, routeEvent } = createForemanWss(taskManager, registry, httpServer, defaultCfg));
+  ({ wss, routeEvent } = createForemanWss(taskManager, httpServer, defaultCfg));
 
   return new Promise<void>((resolve) => {
     httpServer.listen(0, () => {
@@ -140,7 +139,7 @@ describe("foreman log timestamps", () => {
   it("worker hello log lines start with ISO 8601 timestamp", async () => {
     const ws = await connect();
     send(ws, { type: "worker_hello", workerId: "worker-abc123", status: "idle" });
-    await waitUntil(() => !!registry.get("worker-abc123"));
+    await waitUntil(() => !!Worker.get("worker-abc123"));
 
     expect(logLines.length).toBeGreaterThan(0);
     for (const line of logLines) {
@@ -181,7 +180,7 @@ describe("foreman log timestamps", () => {
   it("task enqueue log line starts with ISO 8601 timestamp", async () => {
     const ws = await connect();
     send(ws, { type: "worker_hello", workerId: "worker-abc123", status: "idle" });
-    await waitUntil(() => !!registry.get("worker-abc123"));
+    await waitUntil(() => !!Worker.get("worker-abc123"));
 
     logLines.length = 0;
     routeEvent("evt-1", "issues", {

--- a/tests/foreman.webhook-routing.test.ts
+++ b/tests/foreman.webhook-routing.test.ts
@@ -9,7 +9,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import http from "http";
 import { WebSocket, WebSocketServer } from "ws";
 import type { AddressInfo } from "net";
-import { WorkerRegistry } from "../src/foreman/models/worker-registry.js";
+import { Worker } from "../src/foreman/models/worker-registry.js";
 import { createForemanWss } from "../src/foreman/controllers/wss.js";
 import { TaskManager } from "../src/foreman/models/task-manager.js";
 import { Task } from "../src/foreman/models/task.js";
@@ -210,7 +210,6 @@ function checkSuitePayload(prNumber: number, conclusion: string) {
 // ── Test harness ──────────────────────────────────────────────────────────────
 
 let taskManager: TaskManager;
-let registry: WorkerRegistry;
 let httpServer: http.Server;
 let wss: WebSocketServer;
 let routeEvent: (id: string, name: string, payload: unknown) => Promise<void>;
@@ -222,6 +221,7 @@ function connect(): Promise<WebSocket> {
 }
 
 beforeEach(() => {
+  Worker._reset();
   vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({ data: { repository: { issue: { blockedBy: { nodes: [] } } } } }) }));
   process.env.GITHUB_REPO = "owner/repo";
   process.env.GITHUB_TOKEN = "token";
@@ -229,9 +229,8 @@ beforeEach(() => {
 
   taskManager = new TaskManager();
   setupInMemoryTasks(taskManager);
-  registry = new WorkerRegistry();
   httpServer = http.createServer();
-  ({ wss, routeEvent } = createForemanWss(taskManager, registry, httpServer, defaultCfg));
+  ({ wss, routeEvent } = createForemanWss(taskManager, httpServer, defaultCfg));
 
   return new Promise<void>((resolve) => {
     httpServer.listen(0, () => {
@@ -277,7 +276,7 @@ describe("webhook-triggered task routing", () => {
     // Worker connects idle (no tasks yet)
     const ws = await connect();
     send(ws, { type: "worker_hello", workerId: "w1", status: "idle" });
-    await waitUntil(() => !!registry.get("w1"));
+    await waitUntil(() => !!Worker.get("w1"));
 
     // Webhook fires: issue #42 gets labeled brunel:ready.
     // then startDepsLoad completes async → reconcile() assigns the task.
@@ -291,7 +290,7 @@ describe("webhook-triggered task routing", () => {
     expect((msg as any).issue.title).toBe("Issue 42");
     expect((msg as any).issue.repoUrl).toBe("https://github.com/owner/repo");
     expect((await Task.get("42"))?.status).toBe("assigned");
-    expect(registry.get("w1")?.status).toBe("busy");
+    expect(Worker.get("w1")?.status).toBe("busy");
   });
 
   it("issues/labeled with non-task label does not enqueue or assign", async () => {
@@ -360,7 +359,7 @@ describe("webhook-triggered task routing", () => {
   it("issues/opened with task label in issue labels assigns task to idle worker", async () => {
     const ws = await connect();
     send(ws, { type: "worker_hello", workerId: "w1", status: "idle" });
-    await waitUntil(() => !!registry.get("w1"));
+    await waitUntil(() => !!Worker.get("w1"));
 
     // Webhook fires: issue #99 opened with task label.
     // then startDepsLoad completes async → reconcile() assigns the task.
@@ -372,7 +371,7 @@ describe("webhook-triggered task routing", () => {
     expect(msg.type).toBe("task_assigned");
     expect((msg as any).issue.number).toBe(99);
     expect((await Task.get("99"))?.status).toBe("assigned");
-    expect(registry.get("w1")?.status).toBe("busy");
+    expect(Worker.get("w1")?.status).toBe("busy");
   });
 
   it("issues/opened without task label does not enqueue", async () => {
@@ -704,7 +703,7 @@ describe("foreman event filtering", () => {
   it('issues/unlabeled with task label does not remove an already-assigned task', async () => {
     const ws = await connect();
     send(ws, { type: "worker_hello", workerId: "w1", status: "idle" });
-    await waitUntil(() => !!registry.get("w1"));
+    await waitUntil(() => !!Worker.get("w1"));
 
     const reply = nextMsgWhere(ws, (m) => m.type === "task_assigned");
     routeEvent("evt-labeled", "issues", labeledPayload(42, "brunel:ready"));

--- a/tests/foreman.websocket.test.ts
+++ b/tests/foreman.websocket.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert";
 import http from "http";
 import { WebSocket, WebSocketServer } from "ws";
 import type { AddressInfo } from "net";
-import { WorkerRegistry } from "../src/foreman/models/worker-registry.js";
+import { Worker } from "../src/foreman/models/worker-registry.js";
 import { createForemanWss } from "../src/foreman/controllers/wss.js";
 import { TaskManager } from "../src/foreman/models/task-manager.js";
 import { Task } from "../src/foreman/models/task.js";
@@ -74,7 +74,6 @@ function closeClient(ws: WebSocket): Promise<void> {
 // ── Test harness ──────────────────────────────────────────────────────────────
 
 let taskManager: TaskManager;
-let registry: WorkerRegistry;
 let httpServer: http.Server;
 let wss: WebSocketServer;
 let routeEvent: (id: string, name: string, payload: unknown) => Promise<void>;
@@ -88,11 +87,11 @@ function connect(): Promise<WebSocket> {
 }
 
 beforeEach(() => {
+  Worker._reset();
   taskManager = new TaskManager();
   setupInMemoryTasks(taskManager);
-  registry = new WorkerRegistry();
   httpServer = http.createServer();
-  ({ wss, routeEvent, reconcile, shutdown } = createForemanWss(taskManager, registry, httpServer, defaultCfg));
+  ({ wss, routeEvent, reconcile, shutdown } = createForemanWss(taskManager, httpServer, defaultCfg));
 
   return new Promise<void>((resolve) => {
     httpServer.listen(0, () => {
@@ -134,7 +133,7 @@ describe("foreman WebSocket protocol", () => {
       new Promise<"timeout">((r) => setTimeout(() => r("timeout"), 50)),
     ]);
     expect(raceResult).toBe("timeout");
-    expect(registry.get("w1")?.status).toBe("idle");
+    expect(Worker.get("w1")?.status).toBe("idle");
   });
 
   it("idle worker with pending task receives task_assigned", async () => {
@@ -148,7 +147,7 @@ describe("foreman WebSocket protocol", () => {
     expect(msg.issue.number).toBe(1);
     expect(msg.taskId).toBe("1");
     expect((await Task.get("1"))?.status).toBe("assigned");
-    expect(registry.get("w1")?.status).toBe("busy");
+    expect(Worker.get("w1")?.status).toBe("busy");
   });
 
   it("second idle worker gets no message when only task is already assigned", async () => {
@@ -182,8 +181,8 @@ describe("foreman WebSocket protocol", () => {
     await makeTask(taskManager, 42);
     await reconcile();
 
-    const w1Status = registry.get("w1")?.status;
-    const w2Status = registry.get("w2")?.status;
+    const w1Status = Worker.get("w1")?.status;
+    const w2Status = Worker.get("w2")?.status;
     const busyCount = [w1Status, w2Status].filter((s) => s === "busy").length;
     expect(busyCount).toBe(1);
 
@@ -205,8 +204,8 @@ describe("foreman WebSocket protocol", () => {
     await makeTask(taskManager, 99);
     await Promise.all([reconcile(), reconcile()]);
 
-    const w1Status = registry.get("w1")?.status;
-    const w2Status = registry.get("w2")?.status;
+    const w1Status = Worker.get("w1")?.status;
+    const w2Status = Worker.get("w2")?.status;
     const busyCount = [w1Status, w2Status].filter((s) => s === "busy").length;
     expect(busyCount).toBe(1);
 
@@ -268,8 +267,8 @@ describe("foreman WebSocket protocol", () => {
     ]);
 
     expect(raceResult).toBe("timeout"); // no task_assigned (would reset in-progress session)
-    expect(registry.get("w1")?.status).toBe("busy");
-    expect(registry.get("w1")?.currentTaskId).toBe("1");
+    expect(Worker.get("w1")?.status).toBe("busy");
+    expect(Worker.get("w1")?.currentTaskId).toBe("1");
     expect((await Task.get("1"))?.status).toBe("assigned");
   });
 
@@ -337,7 +336,7 @@ describe("foreman WebSocket protocol", () => {
       new Promise<"timeout">((r) => setTimeout(() => r("timeout"), 50)),
     ]);
     expect(raceResult2).toBe("timeout");
-    expect(registry.get("worker-a")?.status).toBe("busy");
+    expect(Worker.get("worker-a")?.status).toBe("busy");
   });
 
   it("task_complete releases worker to idle", async () => {
@@ -346,7 +345,7 @@ describe("foreman WebSocket protocol", () => {
     send(ws, { type: "worker_hello", workerId: "w1", status: "idle" });
     await nextMsg(ws); // task_assigned
     send(ws, { type: "task_complete", workerId: "w1", taskId: "1" });
-    await waitUntil(() => registry.get("w1")?.status === "idle");
+    await waitUntil(() => Worker.get("w1")?.status === "idle");
     expect((await Task.get("1"))?.status).toBe("complete");
   });
 
@@ -358,9 +357,9 @@ describe("foreman WebSocket protocol", () => {
 
     const ws = await connect();
     send(ws, { type: "worker_hello", workerId: "w1", taskId: "1", status: "busy" });
-    await waitUntil(() => registry.get("w1") !== undefined);
-    expect(registry.get("w1")?.status).toBe("busy");
-    expect(registry.get("w1")?.currentTaskId).toBe("1");
+    await waitUntil(() => Worker.get("w1") !== undefined);
+    expect(Worker.get("w1")?.status).toBe("busy");
+    expect(Worker.get("w1")?.currentTaskId).toBe("1");
   });
 
   it("events are routed to the correct worker when multiple workers have different tasks", async () => {
@@ -446,7 +445,7 @@ describe("hello_ack handshake", () => {
     send(wsB, { type: "worker_hello", workerId: "worker-b", taskId: "1", status: "busy" });
     const ack = await ackPromise;
     expect(ack).toEqual({ type: "hello_ack", workerId: "worker-b", status: "cancelled" });
-    expect(registry.get("worker-b")?.status).toBe("idle");
+    expect(Worker.get("worker-b")?.status).toBe("idle");
   });
 
   it("worker reconnecting busy with nonexistent taskId receives cancelled status", async () => {
@@ -455,7 +454,7 @@ describe("hello_ack handshake", () => {
     send(ws, { type: "worker_hello", workerId: "w1", taskId: "nonexistent", status: "busy" });
     const ack = await ackPromise;
     expect(ack).toEqual({ type: "hello_ack", workerId: "w1", status: "cancelled" });
-    expect(registry.get("w1")?.status).toBe("idle");
+    expect(Worker.get("w1")?.status).toBe("idle");
   });
 
   it("allows worker to reclaim task even if complete (issue closed, same worker)", async () => {
@@ -469,8 +468,8 @@ describe("hello_ack handshake", () => {
     send(ws, { type: "worker_hello", workerId: "w1", taskId: "1", status: "busy" });
     const ack = await ackPromise;
     expect(ack).toEqual({ type: "hello_ack", workerId: "w1", status: "busy" });
-    expect(registry.get("w1")?.status).toBe("busy");
-    expect(registry.get("w1")?.currentTaskId).toBe("1");
+    expect(Worker.get("w1")?.status).toBe("busy");
+    expect(Worker.get("w1")?.currentTaskId).toBe("1");
   });
 
   it("cancels worker when task is assigned to a different worker", async () => {
@@ -484,15 +483,14 @@ describe("hello_ack handshake", () => {
     send(ws, { type: "worker_hello", workerId: "w1", taskId: "1", status: "busy" });
     const ack = await ackPromise;
     expect(ack).toEqual({ type: "hello_ack", workerId: "w1", status: "cancelled" });
-    expect(registry.get("w1")?.status).toBe("idle");
+    expect(Worker.get("w1")?.status).toBe("idle");
   });
 
   it("queued events are sent after hello_ack on reclaim", async () => {
     await makeTask(taskManager, 1);
     const t = await Task.get("1");
     await t!.assign("w1");
-    registry.register("w1", {} as ReturnType<typeof connect> extends Promise<infer T> ? T : never, "busy", "1");
-    registry.markDisconnected("w1");
+    { const w = Worker.register("w1", {} as ReturnType<typeof connect> extends Promise<infer T> ? T : never); w.assign("1"); w.markDisconnected(); }
     await routeEvent("evt-1", "issue_comment", { issue: { number: 1 } });
 
     const ws = await connect();
@@ -614,7 +612,7 @@ describe("worker secret enforcement", () => {
     const tm = new TaskManager();
     setupInMemoryTasks(tm);
     const { wss: secretWss } = createForemanWss(
-      tm, new WorkerRegistry(), server,
+      tm, server,
       { ...defaultCfg, workerSecret: secret },
     );
     const p = await new Promise<number>((r) => server.listen(0, () => r((server.address() as AddressInfo).port)));
@@ -648,8 +646,8 @@ describe("worker secret enforcement", () => {
   it("accepts any worker when workerSecret is not configured", async () => {
     const ws = await connect();
     send(ws, { type: "worker_hello", workerId: "w1", status: "idle" });
-    await waitUntil(() => registry.get("w1")?.status === "idle");
-    expect(registry.get("w1")?.status).toBe("idle");
+    await waitUntil(() => Worker.get("w1")?.status === "idle");
+    expect(Worker.get("w1")?.status).toBe("idle");
   });
 });
 
@@ -658,7 +656,7 @@ describe("worker WebSocket connection", () => {
     const server = http.createServer();
     const tm = new TaskManager();
     setupInMemoryTasks(tm);
-    const { wss } = createForemanWss(tm, new WorkerRegistry(), server, defaultCfg);
+    const { wss } = createForemanWss(tm, server, defaultCfg);
     const testPort = await new Promise<number>((resolve) => {
       server.listen(0, () => resolve((server.address() as AddressInfo).port));
     });
@@ -684,7 +682,7 @@ describe("worker WebSocket connection", () => {
     const server = http.createServer();
     const tm = new TaskManager();
     setupInMemoryTasks(tm);
-    const { wss } = createForemanWss(tm, new WorkerRegistry(), server, defaultCfg);
+    const { wss } = createForemanWss(tm, server, defaultCfg);
     const testPort = await new Promise<number>((resolve) => {
       server.listen(0, () => resolve((server.address() as AddressInfo).port));
     });
@@ -711,12 +709,11 @@ describe("worker disconnect DB logging", () => {
       queryWorkerMessages: vi.fn().mockResolvedValue([]),
     };
 
-    const localRegistry1 = new WorkerRegistry();
     const server = http.createServer();
     const localTm = new TaskManager();
     setupInMemoryTasks(localTm);
     const { wss: testWss } = createForemanWss(
-      localTm, localRegistry1, server,
+      localTm, server,
       defaultCfg, { dbLogger: mockDbLogger },
     );
     const testPort = await new Promise<number>((r) => server.listen(0, () => r((server.address() as AddressInfo).port)));
@@ -724,13 +721,13 @@ describe("worker disconnect DB logging", () => {
     const ws = new WebSocket(`ws://localhost:${testPort}/worker`);
     await new Promise<void>((resolve, reject) => { ws.once("open", resolve); ws.once("error", reject); });
     ws.send(JSON.stringify({ type: "worker_hello", workerId: "w-disc-1", status: "idle" }));
-    await waitUntil(() => !!localRegistry1.get("w-disc-1"));
+    await waitUntil(() => !!Worker.get("w-disc-1"));
 
     await new Promise<void>((resolve) => {
       ws.once("close", resolve);
       ws.close();
     });
-    await waitUntil(() => !localRegistry1.get("w-disc-1") || localRegistry1.get("w-disc-1")?.status === "disconnected");
+    await waitUntil(() => !Worker.get("w-disc-1") || Worker.get("w-disc-1")?.status === "disconnected");
 
     const calls = (mockDbLogger.logForemanMessage as ReturnType<typeof vi.fn>).mock.calls;
     const disconnectCall = calls.find((c) => c[0].msgType === "worker_disconnected");
@@ -761,10 +758,9 @@ describe("worker disconnect DB logging", () => {
     localTm.trackIssue(42);
     localTm.markBlockersLoaded(42);
 
-    const localRegistry2 = new WorkerRegistry();
     const server = http.createServer();
     const { wss: testWss } = createForemanWss(
-      localTm, localRegistry2, server,
+      localTm, server,
       defaultCfg, { dbLogger: mockDbLogger },
     );
     const testPort = await new Promise<number>((r) => server.listen(0, () => r((server.address() as AddressInfo).port)));
@@ -782,7 +778,7 @@ describe("worker disconnect DB logging", () => {
       ws.once("close", resolve);
       ws.close();
     });
-    await waitUntil(() => localRegistry2.get("w-disc-2")?.status === "disconnected");
+    await waitUntil(() => Worker.get("w-disc-2")?.status === "disconnected");
 
     const calls = (mockDbLogger.logForemanMessage as ReturnType<typeof vi.fn>).mock.calls;
     const disconnectCall = calls.find((c) => c[0].msgType === "worker_disconnected");
@@ -801,9 +797,9 @@ describe("disconnected worker state", () => {
     await nextMsg(ws); // task_assigned
 
     await closeClient(ws);
-    await waitUntil(() => registry.get("w1")?.status === "disconnected");
+    await waitUntil(() => Worker.get("w1")?.status === "disconnected");
 
-    const entry = registry.get("w1");
+    const entry = Worker.get("w1");
     expect(entry).toBeDefined();
     expect(entry!.status).toBe("disconnected");
     expect(entry!.currentTaskId).toBe("1");
@@ -813,12 +809,12 @@ describe("disconnected worker state", () => {
   it("idle worker is removed from registry on close", async () => {
     const ws = await connect();
     send(ws, { type: "worker_hello", workerId: "w1", status: "idle" });
-    await waitUntil(() => !!registry.get("w1"));
+    await waitUntil(() => !!Worker.get("w1"));
 
     await closeClient(ws);
-    await waitUntil(() => !registry.get("w1"));
+    await waitUntil(() => !Worker.get("w1"));
 
-    expect(registry.get("w1")).toBeUndefined();
+    expect(Worker.get("w1")).toBeUndefined();
   });
 
   it("events are queued (not dropped) when assigned worker is disconnected", async () => {
@@ -828,7 +824,7 @@ describe("disconnected worker state", () => {
     await nextMsg(ws); // task_assigned
 
     await closeClient(ws);
-    await waitUntil(() => registry.get("w1")?.status === "disconnected");
+    await waitUntil(() => Worker.get("w1")?.status === "disconnected");
 
     await routeEvent("evt-1", "issue_comment", { issue: { number: 1 }, comment: { body: "hi" } });
 
@@ -844,7 +840,7 @@ describe("disconnected worker state", () => {
     await nextMsg(ws1); // hello_ack (task is assigned server-side regardless)
 
     await closeClient(ws1);
-    await waitUntil(() => registry.get("w1")?.status === "disconnected");
+    await waitUntil(() => Worker.get("w1")?.status === "disconnected");
 
     await routeEvent("evt-1", "issue_comment", { issue: { number: 1 }, comment: { body: "hi" } });
 
@@ -859,7 +855,7 @@ describe("disconnected worker state", () => {
       expect(msg.event.name).toBe("issue_comment");
     }
 
-    expect(registry.get("w1")?.status).toBe("busy");
+    expect(Worker.get("w1")?.status).toBe("busy");
     expect((await Task.get("1"))?.status).toBe("assigned");
   });
 
@@ -870,7 +866,7 @@ describe("disconnected worker state", () => {
     await nextMsg(ws1); // hello_ack (task is assigned server-side regardless)
 
     await closeClient(ws1);
-    await waitUntil(() => registry.get("w1")?.status === "disconnected");
+    await waitUntil(() => Worker.get("w1")?.status === "disconnected");
 
     const ws2 = await connect();
     const q2 = makeQueue(ws2);
@@ -880,7 +876,7 @@ describe("disconnected worker state", () => {
     expect(msg.type).toBe("task_assigned");
     if (msg.type === "task_assigned") expect(msg.taskId).toBe("1");
 
-    expect(registry.get("w1")?.status).toBe("busy");
+    expect(Worker.get("w1")?.status).toBe("busy");
     expect((await Task.get("1"))?.status).toBe("assigned");
     expect((await Task.get("1"))?.workerId).toBe("w1");
   });
@@ -893,7 +889,7 @@ describe("disconnected worker state", () => {
     await nextMsg(wsA); // hello_ack (task is assigned server-side regardless)
 
     await closeClient(wsA);
-    await waitUntil(() => registry.get("worker-a")?.status === "disconnected");
+    await waitUntil(() => Worker.get("worker-a")?.status === "disconnected");
 
     const wsB = await connect();
     const ackPB = nextMsg(wsB);
@@ -918,21 +914,21 @@ describe("worker_goodbye", () => {
     await nextMsg(ws); // task_assigned
 
     send(ws, { type: "worker_goodbye", workerId: "w1", taskId: "1" });
-    await waitUntil(() => !registry.get("w1"));
+    await waitUntil(() => !Worker.get("w1"));
 
-    expect(registry.get("w1")).toBeUndefined();
+    expect(Worker.get("w1")).toBeUndefined();
     expect((await Task.get("1"))?.status).toBe("pending");
   });
 
   it("removes idle worker from registry when goodbye has no taskId", async () => {
     const ws = await connect();
     send(ws, { type: "worker_hello", workerId: "w1", status: "idle" });
-    await waitUntil(() => !!registry.get("w1"));
+    await waitUntil(() => !!Worker.get("w1"));
 
     send(ws, { type: "worker_goodbye", workerId: "w1" });
-    await waitUntil(() => !registry.get("w1"));
+    await waitUntil(() => !Worker.get("w1"));
 
-    expect(registry.get("w1")).toBeUndefined();
+    expect(Worker.get("w1")).toBeUndefined();
   });
 
   it("reverted task is immediately assigned to a waiting idle worker", async () => {
@@ -955,7 +951,7 @@ describe("worker_goodbye", () => {
     expect(msg.type).toBe("task_assigned");
     if (msg.type === "task_assigned") expect(msg.taskId).toBe("1");
 
-    expect(registry.get("worker-a")).toBeUndefined();
+    expect(Worker.get("worker-a")).toBeUndefined();
     expect((await Task.get("1"))?.status).toBe("assigned");
     expect((await Task.get("1"))?.workerId).toBe("worker-b");
   });
@@ -976,10 +972,10 @@ describe("worker_goodbye — revert persistence", () => {
 
     const ws = await connect();
     send(ws, { type: "worker_hello", workerId: "w1", status: "idle" });
-    await waitUntil(() => registry.get("w1")?.status === "busy");
+    await waitUntil(() => Worker.get("w1")?.status === "busy");
 
     send(ws, { type: "worker_goodbye", workerId: "w1", taskId: "1" });
-    await waitUntil(() => registry.get("w1") === undefined);
+    await waitUntil(() => Worker.get("w1") === undefined);
 
     expect(spyRevert).toHaveBeenCalled();
   });
@@ -989,10 +985,10 @@ describe("worker_goodbye — revert persistence", () => {
 
     const ws = await connect();
     send(ws, { type: "worker_hello", workerId: "w1", status: "idle" });
-    await waitUntil(() => registry.get("w1") !== undefined);
+    await waitUntil(() => Worker.get("w1") !== undefined);
 
     send(ws, { type: "worker_goodbye", workerId: "w1" });
-    await waitUntil(() => registry.get("w1") === undefined);
+    await waitUntil(() => Worker.get("w1") === undefined);
 
     // Task.get should not be called for goodbye without taskId
     expect(spyGet).not.toHaveBeenCalled();
@@ -1029,8 +1025,8 @@ describe("worker_hello — reclaim complete task for finalization work", () => {
     send(ws, { type: "worker_hello", workerId: "w1", taskId: "1", status: "busy" });
     const ack = await ackPromise;
     expect(ack).toEqual({ type: "hello_ack", workerId: "w1", status: "busy" });
-    expect(registry.get("w1")?.status).toBe("busy");
-    expect(registry.get("w1")?.currentTaskId).toBe("1");
+    expect(Worker.get("w1")?.status).toBe("busy");
+    expect(Worker.get("w1")?.currentTaskId).toBe("1");
   });
 });
 
@@ -1038,9 +1034,8 @@ describe("keepalive ping", () => {
   it("sends WebSocket ping to connected clients on interval", async () => {
     const tm = new TaskManager();
     setupInMemoryTasks(tm);
-    const r = new WorkerRegistry();
     const srv = http.createServer();
-    const { wss: testWss } = createForemanWss(tm, r, srv, { ...defaultCfg, pingIntervalMs: 50 });
+    const { wss: testWss } = createForemanWss(tm, srv, { ...defaultCfg, pingIntervalMs: 50 });
     await new Promise<void>((resolve) => srv.listen(0, resolve));
     const testPort = (srv.address() as AddressInfo).port;
 
@@ -1067,7 +1062,7 @@ describe("stale close from old connection", () => {
     send(wsA, { type: "worker_hello", workerId: "worker-a", status: "idle" });
     await qA.next(); // hello_ack
     await qA.next(); // task_assigned
-    await waitUntil(() => registry.get("worker-a")?.status === "busy");
+    await waitUntil(() => Worker.get("worker-a")?.status === "busy");
 
     const wsA2 = await connect();
     const qA2 = makeQueue(wsA2);
@@ -1079,8 +1074,8 @@ describe("stale close from old connection", () => {
     await new Promise<void>((r) => wsA.once("close", r));
     for (let i = 0; i < 10; i++) await new Promise((r) => setImmediate(r));
 
-    expect(registry.get("worker-a")?.status).toBe("busy");
-    expect(registry.get("worker-a")?.currentTaskId).toBe("1");
+    expect(Worker.get("worker-a")?.status).toBe("busy");
+    expect(Worker.get("worker-a")?.currentTaskId).toBe("1");
 
     wsA2.close();
     await new Promise<void>((r) => wsA2.once("close", r));
@@ -1097,7 +1092,7 @@ describe("graceful shutdown", () => {
     const ws2 = await connect();
     send(ws1, { type: "worker_hello", workerId: "w1", status: "idle" });
     send(ws2, { type: "worker_hello", workerId: "w2", status: "idle" });
-    await waitUntil(() => !!registry.get("w1") && !!registry.get("w2"));
+    await waitUntil(() => !!Worker.get("w1") && !!Worker.get("w2"));
 
     const close1 = new Promise<number>((resolve) => { ws1.once("close", (code) => resolve(code)); });
     const close2 = new Promise<number>((resolve) => { ws2.once("close", (code) => resolve(code)); });
@@ -1116,12 +1111,11 @@ describe("graceful shutdown", () => {
       queryTaskEvents: vi.fn().mockResolvedValue([]),
       queryWorkerMessages: vi.fn().mockResolvedValue([]),
     };
-    const localRegistry = new WorkerRegistry();
     const srv = http.createServer();
     const localTm = new TaskManager();
     setupInMemoryTasks(localTm);
     const { wss: testWss, shutdown: localShutdown } = createForemanWss(
-      localTm, localRegistry, srv,
+      localTm, srv,
       defaultCfg, { dbLogger: mockDbLogger },
     );
     const testPort = await new Promise<number>((r) => srv.listen(0, () => r((srv.address() as AddressInfo).port)));
@@ -1129,7 +1123,7 @@ describe("graceful shutdown", () => {
     const ws = new WebSocket(`ws://localhost:${testPort}/worker`);
     await new Promise<void>((resolve, reject) => { ws.once("open", resolve); ws.once("error", reject); });
     ws.send(JSON.stringify({ type: "worker_hello", workerId: "w-shutdown", status: "idle" }));
-    await waitUntil(() => !!localRegistry.get("w-shutdown"));
+    await waitUntil(() => !!Worker.get("w-shutdown"));
 
     await localShutdown();
 

--- a/tests/pipeline.test.ts
+++ b/tests/pipeline.test.ts
@@ -18,7 +18,7 @@ import http from "http";
 import { WebSocket, WebSocketServer } from "ws";
 import type { AddressInfo } from "net";
 import type { ForemanMessage } from "../src/types.js";
-import { WorkerRegistry } from "../src/foreman/models/worker-registry.js";
+import { Worker } from "../src/foreman/models/worker-registry.js";
 import { createForemanWss } from "../src/foreman/controllers/wss.js";
 import { TaskManager } from "../src/foreman/models/task-manager.js";
 import { Task } from "../src/foreman/models/task.js";
@@ -212,7 +212,6 @@ function buildForeman(opts: {
   dbLogger?: DbLogger;
 } = {}): {
   taskModel: TaskManager;
-  registry: WorkerRegistry;
   httpServer: http.Server;
   wss: WebSocketServer;
   routeEvent: (id: string, name: string, payload: unknown) => Promise<void>;
@@ -221,12 +220,12 @@ function buildForeman(opts: {
   connect: () => Promise<WebSocket>;
   teardown: () => Promise<void>;
 } {
+  Worker._reset();
   const taskModel = new TaskManager();
-  const registry = new WorkerRegistry();
   const httpServer = http.createServer();
   const openClients: WebSocket[] = [];
 
-  const { wss, routeEvent } = createForemanWss(taskModel, registry, httpServer, {
+  const { wss, routeEvent } = createForemanWss(taskModel, httpServer, {
     ...defaultCfg,
     githubRepo: "owner/repo",
     githubToken: "token",
@@ -271,7 +270,7 @@ function buildForeman(opts: {
   }
 
   // Expose everything; caller must await `ready` before using `port`.
-  const result = { taskModel, registry, httpServer, wss, routeEvent, port, openClients, connect, teardown };
+  const result = { taskModel, httpServer, wss, routeEvent, port, openClients, connect, teardown };
   // Patch port lazily via a getter so callers don't have to await ready separately
   Object.defineProperty(result, "port", { get: () => port });
   void ready; // ensure listen is called (it is already)


### PR DESCRIPTION
## Summary

- Replaces `WorkerState` interface and `WorkerRegistry` class with a single `Worker` active-record class in `src/foreman/models/worker-registry.ts`, following the same pattern as `Task`
- A module-level `Map` serves as the in-memory registry, exposed through static methods (`Worker.register`, `Worker.get`, `Worker.getIdle`, `Worker.getByTask`, `Worker.all`, `Worker._reset`)
- Instance methods: `assign`, `release`, `markDisconnected`, `remove`, `send`, `isCurrentSocket`, `toSnapshot`
- `Worker.events` static EventEmitter fires `"changed"` after every mutation
- `createForemanWss` no longer takes a `registry` parameter; `EventRouterDeps` also drops `registry` — both import `Worker` directly
- All foreman tests updated to use `Worker._reset()` in `beforeEach` for test isolation

Pure structural cleanup — no behavior change.

## Test plan

- [x] `npm test` — all 1318 unit tests pass (3 DB tests fail as expected without Supabase)
- [x] `npx tsc --noEmit` — clean type check
- [x] `npm run lint` — no lint errors

Closes #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)