### PR TITLE
docs: add type system design guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,10 @@ supabase gen types typescript --local > src/database.types.ts
 
 Most tests run without Supabase. DB tests (`db.*.test.ts`, `pipeline.test.ts`) require `supabase start`.
 
+## Type system
+
+See **`docs/type-system.md`** for the full design. In brief: one server model class per concept, one `Wire.*` interface per concept in `src/wire.ts` (imported as `import * as Wire from "./wire.js"`), shared domain types in `shared/types.ts`. Prefer a single wire type with optional fields over multiple types for the same concept. Name things after the concept, not the form — `Wire.Task` not `Wire.TaskSnapshot`.
+
 ## Key conventions
 
 - Use `display.print()` (not `console.log`) for output in agent/worker code — it routes through the status-bar-aware renderer so messages don't corrupt the TUI.

--- a/docs/type-system.md
+++ b/docs/type-system.md
@@ -1,0 +1,104 @@
+# Type System Design
+
+How model objects, wire types, and client types are organized in this codebase.
+
+## Core pattern
+
+Every domain concept has at most two types:
+
+1. **A server model class** — rich, may persist to the DB, owns behavior
+2. **A `Wire.*` interface** — the shape of data as it crosses any wire boundary (WebSocket, HTTP)
+
+Shared domain types (enums, value objects used on both sides) live in `shared/types.ts`.
+
+## The Wire namespace
+
+All wire types live in `src/wire.ts` and are imported with a namespace alias:
+
+```ts
+import * as Wire from "./wire.js";
+```
+
+This gives you `Wire.Task`, `Wire.WebhookEvent`, `Wire.ForemanMessage`, etc. — clearly distinct from the server model classes of the same name, with zero runtime cost (interfaces are erased by TypeScript).
+
+Use TypeScript `interface` or `type` in `wire.ts`, never `class`. The `namespace` keyword is not used — the module alias achieves the same thing more idiomatically.
+
+## Server model classes
+
+Model classes are active records. They own DB reads/writes, hold in-memory state, and emit change events. See the `Task` class for the canonical example.
+
+Each model class that needs to send data over a wire has a serialization method typed against the corresponding Wire interface:
+
+```ts
+class Task {
+  toWire(): Wire.Task {
+    return { taskId: this.taskId, title: this.title, status: this.status, ... };
+  }
+}
+```
+
+Typing the return value against `Wire.Task` means the compiler catches mismatches if either side changes.
+
+**Unsaved records:** if a model instance may exist before being persisted, use `id: number | undefined`, not `id: 0` as a placeholder. An undefined `id` simply means the record is new and hasn't been saved yet — that's a valid state, not something to hide.
+
+## Wire type design
+
+**One type per concept.** Don't create multiple wire types for the same thing (`TaskSnapshot`, `TaskRow`, `TaskDetail`). Use a single `Wire.Task` with optional fields for data that isn't always present:
+
+```ts
+// wire.ts
+export interface Task {
+  taskId: string;
+  issueNumber: number;
+  title: string;
+  status: TaskStatus;
+  assignedWorkerId?: string;
+  prNumber?: number;
+  prUrl?: string;
+  blockers?: BlockerInfo[];
+  // detail fields only present in REST responses:
+  body?: string;
+  branch?: string;
+  assignedAt?: string;
+  completedAt?: string;
+}
+```
+
+This avoids separate HTTP and WebSocket types for the same concept. Clients use what they need; absent fields are just absent.
+
+**Naming:** use the unadorned concept name (`Wire.Task`, `Wire.WebhookEvent`). Add a suffix only when two genuinely distinct shapes of the same concept must coexist in the same scope — which should be rare.
+
+**No input/create interfaces.** Don't write `TaskData` or `TaskInput` interfaces that mirror a model class's fields. Use named constructor params or the class directly.
+
+## Protocol union types
+
+The foreman↔worker WebSocket protocol is defined as union types in `wire.ts`:
+
+```ts
+export type ForemanMessage =
+  | { type: "task_assigned"; taskId: string; task: Task }
+  | { type: "event_notification"; taskId: string; event: WebhookEvent }
+  | { type: "hello_ack"; workerId: string; status: "idle" | "busy" | "cancelled" };
+
+export type WorkerMessage =
+  | { type: "worker_hello"; workerId: string; claimedTaskId?: string }
+  | { type: "task_complete"; taskId: string }
+  | { type: "worker_goodbye"; taskId: string };
+```
+
+Payload types within the union reference the shared Wire interfaces directly rather than duplicating field definitions.
+
+## Client-side types
+
+**Use the Wire interface directly** when the client just renders or reads data — no class needed. The browser dashboard uses `Wire.Task` for both WebSocket snapshots and REST responses (same type, two delivery mechanisms).
+
+**Create a client model class** when the client side needs behavior: methods, accumulated state, derived properties, or `instanceof` checks. This applies equally to the browser and the worker agent. A client model class typically takes a `Wire.*` object as its constructor input and adds the behavior on top. When a client model class exists, the Wire interface is its input contract, not a parallel type.
+
+## Where things live
+
+| What | Where |
+|---|---|
+| Server model classes | `src/foreman/models/*.ts` |
+| Wire interfaces and protocol unions | `src/wire.ts` |
+| Shared domain types (enums, value objects) | `shared/types.ts` |
+| Frontend-only UI state | `frontend/src/` (local, not in wire.ts) |

--- a/docs/type-system.md
+++ b/docs/type-system.md
@@ -2,6 +2,8 @@
 
 How model objects, wire types, and client types are organized in this codebase.
 
+> **This is the target design.** The codebase is being incrementally refactored toward it. Existing code may not yet follow these conventions — when it doesn't, the direction of travel is here.
+
 ## Core pattern
 
 Every domain concept has at most two types:


### PR DESCRIPTION
## Summary

- Adds `docs/type-system.md` — a design guide covering server model classes, `Wire.*` interfaces, and client-side types
- Adds a "Type system" section to `CLAUDE.md` with a five-line summary and pointer to the doc

## What the guide covers

- One server model class + one `Wire.*` interface per concept
- The `import * as Wire` namespace pattern (not TypeScript `namespace`)
- Single wire type with optional fields rather than multiple parallel types
- Unadorned names by default (`Wire.Task` not `Wire.TaskSnapshot`); suffixes only when disambiguation is genuinely needed
- `toWire()` serialization methods typed against the Wire interface
- When client-side model classes are warranted (behavior needed) vs. using the Wire interface directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)