### PR TITLE
refactor: rename WorkerStatusModel to AgentStatus; always generate agentId at startup

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -13,7 +13,7 @@ import { AgentStatus, WorkerSession, registerWorkerCommands, startWorkerMode } f
 import type { RunQuery, WorkerModeConfig } from "./worker.js";
 import { loadConfig } from "../config.js";
 import { Workspace, confirmIfUnsafe, registerWorkspaceCommands } from "./workspace.js";
-import { fmtError, generateWorkerId } from "../utils.js";
+import { fmtError, generateAgentId } from "../utils.js";
 import { handleModelCommand, getCachedModels, _resetCachedModels, setCachedModels } from "./model.js";
 import type { ModelInfo, FetchModelsFn } from "./model.js";
 import { handleEffortCommand } from "./effort.js";
@@ -251,9 +251,8 @@ export async function main(
   initialEffort?: EffortValue,
 ): Promise<void> {
   // Generate agentId unconditionally — used as both workspace identity and foreman identity.
-  const agentId = generateWorkerId();
-  const agentStatus = new AgentStatus(agentId);
-  agentStatus.update({ model: initialModel, effort: initialEffort });
+  const agentId = generateAgentId();
+  const agentStatus = new AgentStatus(agentId, { model: initialModel, effort: initialEffort });
 
   // Worker mode setup: create workspace, session, signal handlers.
   const workerCtx = workerConfig ? await startWorkerMode(workerConfig, agentStatus) : undefined;

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1,5 +1,4 @@
 import "dotenv/config";
-import crypto from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 import fs from "fs";
@@ -10,11 +9,11 @@ import * as display from "./display.js";
 import { setVerbose, setThinkOutLoud } from "./display.js";
 import { ask, dispatchInput, pick, pickMultiple, pickQuestion } from "./input.js";
 import type { PickQuestionResult } from "./input.js";
-import { WorkerSession, registerWorkerCommands, startWorkerMode } from "./worker.js";
+import { AgentStatus, WorkerSession, registerWorkerCommands, startWorkerMode } from "./worker.js";
 import type { RunQuery, WorkerModeConfig } from "./worker.js";
 import { loadConfig } from "../config.js";
 import { Workspace, confirmIfUnsafe, registerWorkspaceCommands } from "./workspace.js";
-import { fmtError } from "../utils.js";
+import { fmtError, generateWorkerId } from "../utils.js";
 import { handleModelCommand, getCachedModels, _resetCachedModels, setCachedModels } from "./model.js";
 import type { ModelInfo, FetchModelsFn } from "./model.js";
 import { handleEffortCommand } from "./effort.js";
@@ -251,18 +250,21 @@ export async function main(
   initialModel?: string,
   initialEffort?: EffortValue,
 ): Promise<void> {
+  // Generate agentId unconditionally — used as both workspace identity and foreman identity.
+  const agentId = generateWorkerId();
+  const agentStatus = new AgentStatus(agentId);
+  agentStatus.update({ model: initialModel, effort: initialEffort });
+
   // Worker mode setup: create workspace, session, signal handlers.
-  const workerCtx = workerConfig ? await startWorkerMode(workerConfig) : undefined;
+  const workerCtx = workerConfig ? await startWorkerMode(workerConfig, agentStatus) : undefined;
   const session = workerCtx?.session;
 
   const fetchModelsFn = createFetchModelsFn(permConfig);
-  let currentModel: string | undefined = workerConfig?.model ?? initialModel;
-  let currentEffort: EffortValue | undefined = workerConfig?.effort ?? initialEffort;
 
   // Print the startup banner.
   display.print(display.c.sageGreen(display.hr("═")));
   display.print(display.c.skyBlue(display.s.bold("  Brunel Agent")));
-  display.print(display.c.lavender(`  Permissions: ${permConfig.permissionMode} | Model: ${currentModel ?? "default"} | Effort: ${currentEffort ?? "auto"} | Output: ${display.verbose ? "verbose" : "quiet"} | Log: ${workerConfig?.logFile ?? LOG_FILE}`));
+  display.print(display.c.lavender(`  Permissions: ${permConfig.permissionMode} | Model: ${agentStatus.model ?? "default"} | Effort: ${agentStatus.effort ?? "auto"} | Output: ${display.verbose ? "verbose" : "quiet"} | Log: ${workerConfig?.logFile ?? LOG_FILE}`));
   display.print(display.c.sageGreen(display.hr("═")));
 
   process.stdout.write("\x1b[?2004h"); // enable bracketed paste mode
@@ -271,7 +273,6 @@ export async function main(
   process.stdin.setEncoding("utf8");
 
   let sessionId: string | undefined;
-  const sessionId_ = crypto.randomUUID();
   const originalCwd = process.cwd();
   const workspaceRef: { current: Workspace | undefined } = { current: undefined };
 
@@ -300,7 +301,7 @@ export async function main(
   registerWorkspaceCommands(
     session
       ? session.workspaceCommandDeps
-      : { workspace: workspaceRef, config: workspaceCfg ? { ...workspaceCfg, sessionId: sessionId_ } : undefined, originalCwd, confirm },
+      : { workspace: workspaceRef, config: workspaceCfg ? { ...workspaceCfg, sessionId: agentId } : undefined, originalCwd, confirm },
     registry.scoped("workspace"),
     !!session,
   );
@@ -324,13 +325,12 @@ export async function main(
     handler: async (args) => {
       const newModel = await handleModelCommand(
         args,
-        currentModel,
+        agentStatus.model,
         (opts, idx) => pick(opts, { currentIdx: idx, escapable: true }),
         fetchModelsFn,
         display.print,
       );
-      currentModel = newModel;
-      if (session) session.currentModel = newModel;
+      agentStatus.update({ model: newModel });
     },
   });
   registry.register("effort", {
@@ -338,12 +338,11 @@ export async function main(
     handler: async (args) => {
       const newEffort = await handleEffortCommand(
         args,
-        currentEffort,
+        agentStatus.effort,
         (opts, idx) => pick(opts, { currentIdx: idx, escapable: true }),
         display.print,
       );
-      currentEffort = newEffort;
-      if (session) session.currentEffort = newEffort;
+      agentStatus.update({ effort: newEffort });
     },
   });
 
@@ -357,7 +356,7 @@ export async function main(
     const ac = new AbortController();
     session?.notifyQueryStart(ac);
     try {
-      sessionId = await runQueryFn(prompt, sessionId, ac, currentModel, currentEffort) ?? sessionId;
+      sessionId = await runQueryFn(prompt, sessionId, ac, agentStatus.model, agentStatus.effort) ?? sessionId;
       return !ac.signal.aborted;
     } catch (err) {
       console.error(display.c.boldRed(`\nERROR: ${fmtError(err)}`));

--- a/src/agent/worker.ts
+++ b/src/agent/worker.ts
@@ -10,7 +10,7 @@ import type { EffortValue } from "./effort.js";
 import * as Wire from "../wire.js";
 import { Workspace, confirmIfUnsafe } from "./workspace.js";
 import type { WorkspaceCommandDeps } from "./workspace.js";
-import { fmtError, generateWorkerId } from "../utils.js";
+import { fmtError } from "../utils.js";
 import type { CommandRegistry } from "./command-registry.js";
 import { pick } from "./input.js";
 
@@ -68,7 +68,7 @@ export function debounceMs(events: Wire.WebhookEvent[]): number {
   return 3000;
 }
 
-// ── WorkerStatusModel ─────────────────────────────────────────────────────────
+// ── AgentStatus ───────────────────────────────────────────────────────────────
 
 export type WorkerConnectionStatus = "connected" | "disconnected" | "reconnecting" | "handshaking";
 
@@ -80,16 +80,16 @@ export type WorkerStatusPatch = {
   prNumber?: number | undefined;
   branch?: string;
   model?: string | undefined;
-  effort?: string | undefined;
+  effort?: EffortValue | undefined;
 };
 
 /**
- * Reactive model for worker status bar state. Emits "change" whenever state
+ * Reactive model for agent status bar state. Emits "change" whenever state
  * changes so the display can subscribe and refresh without manual refresh calls.
  * When reconnectAt is set the model starts a 1-second interval to emit "change"
  * (driving the countdown display); the interval stops when reconnectAt is cleared.
  */
-export class WorkerStatusModel extends EventEmitter {
+export class AgentStatus extends EventEmitter {
   private _connectionStatus: WorkerConnectionStatus = "disconnected";
   private _disconnectCode: number | undefined;
   private _reconnectAt: number | undefined;
@@ -97,10 +97,10 @@ export class WorkerStatusModel extends EventEmitter {
   private _prNumber: number | undefined;
   private _branch = "";
   private _model: string | undefined;
-  private _effort: string | undefined;
+  private _effort: EffortValue | undefined;
   private _countdownTimer: ReturnType<typeof setInterval> | null = null;
 
-  constructor(public readonly workerId: string) {
+  constructor(public readonly agentId: string) {
     super();
   }
 
@@ -111,7 +111,7 @@ export class WorkerStatusModel extends EventEmitter {
   get prNumber(): number | undefined { return this._prNumber; }
   get branch(): string { return this._branch; }
   get model(): string | undefined { return this._model; }
-  get effort(): string | undefined { return this._effort; }
+  get effort(): EffortValue | undefined { return this._effort; }
 
   /** Apply a partial update and emit "change". Multiple fields in one call = one event. */
   update(patch: WorkerStatusPatch): void {
@@ -147,7 +147,7 @@ export class WorkerStatusModel extends EventEmitter {
       ? Math.max(0, Math.ceil((this._reconnectAt - Date.now()) / 1000))
       : undefined;
     return display.fmtWorkerStatus({
-      workerId: this.workerId,
+      workerId: this.agentId,
       model: this._model,
       effort: this._effort,
       taskNumber: this._taskNumber,
@@ -162,7 +162,7 @@ export class WorkerStatusModel extends EventEmitter {
 
 // ── WorkerSession ─────────────────────────────────────────────────────────────
 
-export type WsFactory = (workerId: string, taskId?: string) => WebSocket;
+export type WsFactory = (agentId: string, taskId?: string) => WebSocket;
 export type RunQuery = (prompt: string, sessionId: string | undefined, abortController?: AbortController, model?: string, effort?: EffortValue) => Promise<string | undefined>;
 export type WorkerDisplay = {
   print: (line: string | null) => void;
@@ -240,37 +240,19 @@ export class WorkerSession {
   // behave as if already registered.
   private connectionState: "hello_sent" | "registered" = "registered";
   private bufferedMessages: BufferableMessage[] = [];
-  private _currentModel: string | undefined;
-  private _currentEffort: EffortValue | undefined;
-
-  // Reactive status bar model: emits "change" on any state mutation, so the
-  // display subscription in start() automatically refreshes without manual calls.
-  private statusModel: WorkerStatusModel;
 
   constructor(
-    public readonly workerId: string,
+    private agentStatus: AgentStatus,
     private wsFactory: WsFactory,
     private display: WorkerDisplay,
     private options: WorkerSessionOptions = {},
-  ) {
-    this.statusModel = new WorkerStatusModel(workerId);
-  }
+  ) {}
 
-  get currentModel(): string | undefined { return this._currentModel; }
-  set currentModel(model: string | undefined) {
-    this._currentModel = model;
-    this.statusModel.update({ model });
-  }
-
-  get currentEffort(): EffortValue | undefined { return this._currentEffort; }
-  set currentEffort(effort: EffortValue | undefined) {
-    this._currentEffort = effort;
-    this.statusModel.update({ effort });
-  }
+  get agentId(): string { return this.agentStatus.agentId; }
 
   /** Returns the formatted worker status bar text. Used by startPersistentStatus and tests. */
   getStatusText(): string {
-    return this.statusModel.getStatusText();
+    return this.agentStatus.getStatusText();
   }
 
   private async refreshBranch(): Promise<void> {
@@ -281,14 +263,14 @@ export class WorkerSession {
     } catch {
       branch = "";
     }
-    this.statusModel.update({ branch });
+    this.agentStatus.update({ branch });
   }
 
   start(): void {
     // Subscribe to model changes — the display refreshes automatically whenever
     // any status field changes, without needing explicit refreshStatus() calls.
-    this.statusModel.on("change", () => this.display.updatePersistentStatus?.());
-    this.display.startPersistentStatus?.(() => this.statusModel.getStatusText());
+    this.agentStatus.on("change", () => this.display.updatePersistentStatus?.());
+    this.display.startPersistentStatus?.(() => this.agentStatus.getStatusText());
     this.display.setOnToolResultCallback?.((toolName) => {
       // Refresh the branch display after each Bash tool completes so the status
       // bar reflects branch changes (e.g. git checkout) without waiting for the
@@ -351,12 +333,12 @@ export class WorkerSession {
     }
     this.sendTaskMessage({
       type: "task_complete",
-      workerId: this.workerId,
+      workerId: this.agentStatus.agentId,
       taskId: this.currentTaskId,
     });
     this.currentTaskId = undefined;
     this.currentIssue = undefined;
-    this.statusModel.update({ taskNumber: undefined, prNumber: undefined, branch: "" });
+    this.agentStatus.update({ taskNumber: undefined, prNumber: undefined, branch: "" });
     this.display.print(display.c.sageGreen("Task complete. Waiting for next task..."));
     return "task-complete";
   }
@@ -380,7 +362,7 @@ export class WorkerSession {
       config: this.options.workspaceCtx ? {
         workspaceDir: this.options.workspaceCtx.workspaceDir,
         repoUrl: this.options.workspaceCtx.repoUrl,
-        sessionId: this.workerId,
+        sessionId: this.agentStatus.agentId,
       } : undefined,
       originalCwd: this.options.workspaceCtx?.originalCwd ?? process.cwd(),
       confirm: this.options.workspaceCtx?.confirm ?? (() => Promise.resolve(false)),
@@ -424,7 +406,7 @@ export class WorkerSession {
     if (this.ws?.readyState === WebSocket.OPEN) {
       this.ws.send(JSON.stringify({
         type: "worker_goodbye",
-        workerId: this.workerId,
+        workerId: this.agentStatus.agentId,
         taskId: this.currentTaskId,
       }));
     }
@@ -476,8 +458,8 @@ export class WorkerSession {
 
   private connect(): void {
     // Clearing reconnectAt stops the countdown timer in the model.
-    this.statusModel.update({ connectionStatus: "reconnecting", reconnectAt: undefined });
-    const ws = this.wsFactory(this.workerId, this.currentTaskId);
+    this.agentStatus.update({ connectionStatus: "reconnecting", reconnectAt: undefined });
+    const ws = this.wsFactory(this.agentStatus.agentId, this.currentTaskId);
     this.ws = ws;
 
     const pingIntervalMs = this.options.pingIntervalMs ?? 25_000;
@@ -490,7 +472,7 @@ export class WorkerSession {
 
     ws.on("open", () => {
       this.connectionState = "hello_sent";
-      this.statusModel.update({ connectionStatus: "handshaking" });
+      this.agentStatus.update({ connectionStatus: "handshaking" });
 
       // Heartbeat: detect silent connection drops (network loss, laptop sleep, etc.)
       // Each tick sends a ping. If no pong/ping arrives before the next tick, the
@@ -533,7 +515,7 @@ export class WorkerSession {
       if (ws !== this.ws) return; // stale close from a previous connection
       const delay = 2000 + Math.random() * 3000;
       // Setting reconnectAt starts a 1-second countdown timer in the model.
-      this.statusModel.update({
+      this.agentStatus.update({
         connectionStatus: "disconnected",
         disconnectCode: code,
         reconnectAt: Date.now() + delay,
@@ -563,7 +545,7 @@ export class WorkerSession {
         this.pendingEvents = [];
         this.currentTaskId = undefined;
         this.currentIssue = undefined;
-        this.statusModel.update({
+        this.agentStatus.update({
           connectionStatus: "connected",
           disconnectCode: undefined,
           taskNumber: undefined,
@@ -582,7 +564,7 @@ export class WorkerSession {
       } else {
         // "idle" or "busy": transition to registered and flush buffered messages.
         this.connectionState = "registered";
-        this.statusModel.update({ connectionStatus: "connected", disconnectCode: undefined });
+        this.agentStatus.update({ connectionStatus: "connected", disconnectCode: undefined });
         this.flushBuffer();
       }
       return;
@@ -592,7 +574,7 @@ export class WorkerSession {
       this.currentTaskId = msg.taskId;
       this.currentIssue = msg.issue;
       this.prIsClosed = false;
-      this.statusModel.update({ taskNumber: msg.issue.number, prNumber: undefined });
+      this.agentStatus.update({ taskNumber: msg.issue.number, prNumber: undefined });
       void this.refreshBranch();
       const initialPrompt = buildInitialPrompt(msg.issue, !!this.options.workspaceCtx);
       this.display.print(display.c.sageGreen(initialPrompt));
@@ -612,9 +594,9 @@ export class WorkerSession {
         const pr = event.payload["pull_request"] as { number?: number; merged?: boolean } | undefined;
         if (action === "closed" && !pr?.merged) {
           // PR was closed without merging — clear the PR from the status bar.
-          this.statusModel.update({ prNumber: undefined });
+          this.agentStatus.update({ prNumber: undefined });
         } else if (pr?.number != null) {
-          this.statusModel.update({ prNumber: pr.number });
+          this.agentStatus.update({ prNumber: pr.number });
         }
       }
 
@@ -692,18 +674,17 @@ export function registerWorkerCommands(session: WorkerSession | undefined, regis
  * a cleanup function — does NOT call main(). The caller (main itself) owns
  * the query loop and calls cleanup() after the loop exits.
  */
-export async function startWorkerMode(config: WorkerModeConfig): Promise<{
+export async function startWorkerMode(config: WorkerModeConfig, agentStatus: AgentStatus): Promise<{
   session: WorkerSession;
   cleanup: () => Promise<void>;
 }> {
   display.setVerbose(config.verbose);
 
-  const workerId = generateWorkerId();
   const originalCwd = process.cwd();
   const workspaceDir = config.workspaceDir ?? path.join(os.homedir(), ".brunel", "workers");
   const repoUrl = config.repoUrl ?? `https://${config.githubToken}@github.com/${config.githubRepo}.git`;
 
-  const workspace = await Workspace.create(workspaceDir, workerId, repoUrl);
+  const workspace = await Workspace.create(workspaceDir, agentStatus.agentId, repoUrl);
   process.chdir(workspace.dir);
 
   const confirm = async (msg: string): Promise<boolean> => {
@@ -728,12 +709,12 @@ export async function startWorkerMode(config: WorkerModeConfig): Promise<{
 
   let shuttingDown = false;
 
-  const wsFactory: WsFactory = (wid, taskId) => {
+  const wsFactory: WsFactory = (agentId, taskId) => {
     const ws = new WebSocket(`${config.foremanUrl}/worker`);
     ws.on("open", () => {
       ws.send(JSON.stringify({
         type: "worker_hello",
-        workerId: wid,
+        workerId: agentId,
         taskId,
         status: taskId ? "busy" : "idle",
       }));
@@ -750,13 +731,13 @@ export async function startWorkerMode(config: WorkerModeConfig): Promise<{
     setOnToolResultCallback: display.setOnToolResultCallback,
   };
 
-  const session = new WorkerSession(workerId, wsFactory, workerDisplay, {
+  agentStatus.update({ model: config.model, effort: config.effort });
+
+  const session = new WorkerSession(agentStatus, wsFactory, workerDisplay, {
     afterTask,
     workspaceCtx: { workspace, originalCwd, workspaceDir, repoUrl, confirm },
     pingIntervalMs: config.pingIntervalMs,
   });
-  session.currentModel = config.model;
-  session.currentEffort = config.effort;
 
   const shutdown = async () => {
     if (shuttingDown) return;

--- a/src/agent/worker.ts
+++ b/src/agent/worker.ts
@@ -100,8 +100,17 @@ export class AgentStatus extends EventEmitter {
   private _effort: EffortValue | undefined;
   private _countdownTimer: ReturnType<typeof setInterval> | null = null;
 
-  constructor(public readonly agentId: string) {
+  constructor(public readonly agentId: string, initial?: Omit<WorkerStatusPatch, "reconnectAt">) {
     super();
+    if (initial) {
+      if ("connectionStatus" in initial) this._connectionStatus = initial.connectionStatus!;
+      if ("disconnectCode" in initial) this._disconnectCode = initial.disconnectCode;
+      if ("taskNumber" in initial) this._taskNumber = initial.taskNumber;
+      if ("prNumber" in initial) this._prNumber = initial.prNumber;
+      if ("branch" in initial) this._branch = initial.branch!;
+      if ("model" in initial) this._model = initial.model;
+      if ("effort" in initial) this._effort = initial.effort;
+    }
   }
 
   get connectionStatus(): WorkerConnectionStatus { return this._connectionStatus; }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -117,9 +117,9 @@ export const WORKER_NAMES = [
   "zephaniah",
 ];
 
-/** Generate a human-readable worker ID by prepending a random human name to a UUID.
+/** Generate a human-readable agent ID by prepending a random human name to a UUID.
  * E.g. "patience-a9bdda00-1234-5678-abcd-ef0123456789" */
-export function generateWorkerId(): string {
+export function generateAgentId(): string {
   const idx = randomInt(WORKER_NAMES.length);
   return `${WORKER_NAMES[idx]}-${crypto.randomUUID()}`;
 }

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { generateWorkerId, WORKER_NAMES } from "../src/utils.js";
+import { generateAgentId, WORKER_NAMES } from "../src/utils.js";
 import { shortWorkerId } from "../shared/utils.js";
 
-describe("generateWorkerId", () => {
-  it("returns a string with a worker name prefix followed by a UUID", () => {
-    const id = generateWorkerId();
+describe("generateAgentId", () => {
+  it("returns a string with an agent name prefix followed by a UUID", () => {
+    const id = generateAgentId();
     // Format: <name>-<uuid>
     const parts = id.split("-");
     // UUID has 5 parts; name adds 1 more at the front
@@ -13,7 +13,7 @@ describe("generateWorkerId", () => {
   });
 
   it("contains a valid UUID after the name prefix", () => {
-    const id = generateWorkerId();
+    const id = generateAgentId();
     const uuidPart = id.slice(id.indexOf("-") + 1);
     expect(uuidPart).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
@@ -22,14 +22,14 @@ describe("generateWorkerId", () => {
 
   it("uses lowercase names", () => {
     for (let i = 0; i < 20; i++) {
-      const id = generateWorkerId();
+      const id = generateAgentId();
       const name = id.split("-")[0];
       expect(name).toBe(name.toLowerCase());
     }
   });
 
   it("generates unique IDs", () => {
-    const ids = new Set(Array.from({ length: 100 }, () => generateWorkerId()));
+    const ids = new Set(Array.from({ length: 100 }, () => generateAgentId()));
     expect(ids.size).toBe(100);
   });
 
@@ -52,7 +52,7 @@ describe("shortWorkerId", () => {
   });
 
   it("works for generated worker IDs", () => {
-    const id = generateWorkerId();
+    const id = generateAgentId();
     const short = shortWorkerId(id);
     const namePart = id.split("-")[0];
     const uuidFirst8 = id.slice(namePart.length + 1, namePart.length + 9);

--- a/tests/worker.status-model.test.ts
+++ b/tests/worker.status-model.test.ts
@@ -1,26 +1,26 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { WorkerStatusModel } from "../src/agent/worker.js";
+import { AgentStatus } from "../src/agent/worker.js";
 import { stripAnsi } from "./helpers.js";
 
-describe("WorkerStatusModel", () => {
+describe("AgentStatus", () => {
   afterEach(() => {
     vi.useRealTimers();
   });
 
   it("has disconnected as default connection status", () => {
-    const model = new WorkerStatusModel("test-worker-id");
+    const model = new AgentStatus("test-worker-id");
     expect(model.connectionStatus).toBe("disconnected");
   });
 
   it("has undefined task/pr/branch by default", () => {
-    const model = new WorkerStatusModel("test-worker-id");
+    const model = new AgentStatus("test-worker-id");
     expect(model.taskNumber).toBeUndefined();
     expect(model.prNumber).toBeUndefined();
     expect(model.branch).toBe("");
   });
 
   it("emits change when connectionStatus is updated", () => {
-    const model = new WorkerStatusModel("test-worker-id");
+    const model = new AgentStatus("test-worker-id");
     const onChange = vi.fn();
     model.on("change", onChange);
     model.update({ connectionStatus: "connected" });
@@ -28,7 +28,7 @@ describe("WorkerStatusModel", () => {
   });
 
   it("emits change when taskNumber is updated", () => {
-    const model = new WorkerStatusModel("test-worker-id");
+    const model = new AgentStatus("test-worker-id");
     const onChange = vi.fn();
     model.on("change", onChange);
     model.update({ taskNumber: 42 });
@@ -36,7 +36,7 @@ describe("WorkerStatusModel", () => {
   });
 
   it("emits change when prNumber is updated", () => {
-    const model = new WorkerStatusModel("test-worker-id");
+    const model = new AgentStatus("test-worker-id");
     const onChange = vi.fn();
     model.on("change", onChange);
     model.update({ prNumber: 99 });
@@ -44,7 +44,7 @@ describe("WorkerStatusModel", () => {
   });
 
   it("emits change when branch is updated", () => {
-    const model = new WorkerStatusModel("test-worker-id");
+    const model = new AgentStatus("test-worker-id");
     const onChange = vi.fn();
     model.on("change", onChange);
     model.update({ branch: "feature-branch" });
@@ -52,13 +52,13 @@ describe("WorkerStatusModel", () => {
   });
 
   it("updates connectionStatus", () => {
-    const model = new WorkerStatusModel("test-worker-id");
+    const model = new AgentStatus("test-worker-id");
     model.update({ connectionStatus: "connected" });
     expect(model.connectionStatus).toBe("connected");
   });
 
   it("sets and clears taskNumber", () => {
-    const model = new WorkerStatusModel("test-worker-id");
+    const model = new AgentStatus("test-worker-id");
     model.update({ taskNumber: 42 });
     expect(model.taskNumber).toBe(42);
     model.update({ taskNumber: undefined });
@@ -66,7 +66,7 @@ describe("WorkerStatusModel", () => {
   });
 
   it("sets and clears prNumber", () => {
-    const model = new WorkerStatusModel("test-worker-id");
+    const model = new AgentStatus("test-worker-id");
     model.update({ prNumber: 77 });
     expect(model.prNumber).toBe(77);
     model.update({ prNumber: undefined });
@@ -74,7 +74,7 @@ describe("WorkerStatusModel", () => {
   });
 
   it("sets and clears disconnectCode", () => {
-    const model = new WorkerStatusModel("test-worker-id");
+    const model = new AgentStatus("test-worker-id");
     model.update({ disconnectCode: 1006 });
     expect(model.disconnectCode).toBe(1006);
     model.update({ disconnectCode: undefined });
@@ -82,7 +82,7 @@ describe("WorkerStatusModel", () => {
   });
 
   it("batches multiple field updates into one change event", () => {
-    const model = new WorkerStatusModel("test-worker-id");
+    const model = new AgentStatus("test-worker-id");
     const onChange = vi.fn();
     model.on("change", onChange);
     model.update({ connectionStatus: "connected", taskNumber: 5, prNumber: 10 });
@@ -91,7 +91,7 @@ describe("WorkerStatusModel", () => {
 
   it("starts emitting change every second when reconnectAt is set", () => {
     vi.useFakeTimers();
-    const model = new WorkerStatusModel("test-worker-id");
+    const model = new AgentStatus("test-worker-id");
     const onChange = vi.fn();
     model.on("change", onChange);
     onChange.mockClear();
@@ -109,7 +109,7 @@ describe("WorkerStatusModel", () => {
 
   it("stops countdown timer when reconnectAt is cleared", () => {
     vi.useFakeTimers();
-    const model = new WorkerStatusModel("test-worker-id");
+    const model = new AgentStatus("test-worker-id");
     const onChange = vi.fn();
     model.on("change", onChange);
 
@@ -124,49 +124,49 @@ describe("WorkerStatusModel", () => {
   });
 
   it("getStatusText includes worker ID prefix", () => {
-    const model = new WorkerStatusModel("abcdef12-rest-of-id");
+    const model = new AgentStatus("abcdef12-rest-of-id");
     const text = stripAnsi(model.getStatusText());
     expect(text).toContain("worker abcdef12");
   });
 
   it("getStatusText shows connection status", () => {
-    const model = new WorkerStatusModel("test-worker-id");
+    const model = new AgentStatus("test-worker-id");
     model.update({ connectionStatus: "connected" });
     expect(stripAnsi(model.getStatusText())).toContain("Connected");
   });
 
   it("getStatusText shows task number when set", () => {
-    const model = new WorkerStatusModel("test-worker-id");
+    const model = new AgentStatus("test-worker-id");
     model.update({ taskNumber: 42 });
     expect(stripAnsi(model.getStatusText())).toContain("task #42");
   });
 
   it("getStatusText shows 'no current task' when task is unset", () => {
-    const model = new WorkerStatusModel("test-worker-id");
+    const model = new AgentStatus("test-worker-id");
     expect(stripAnsi(model.getStatusText())).toContain("no current task");
   });
 
   it("getStatusText shows PR number when set", () => {
-    const model = new WorkerStatusModel("test-worker-id");
+    const model = new AgentStatus("test-worker-id");
     model.update({ prNumber: 77 });
     expect(stripAnsi(model.getStatusText())).toContain("PR #77");
   });
 
   it("getStatusText shows retry countdown when disconnected with reconnectAt", () => {
     vi.useFakeTimers();
-    const model = new WorkerStatusModel("test-worker-id");
+    const model = new AgentStatus("test-worker-id");
     model.update({ connectionStatus: "disconnected", reconnectAt: Date.now() + 4000 });
     expect(stripAnsi(model.getStatusText())).toContain("Retrying in 4s");
   });
 
   it("has undefined model and effort by default", () => {
-    const model = new WorkerStatusModel("test-worker-id");
+    const model = new AgentStatus("test-worker-id");
     expect(model.model).toBeUndefined();
     expect(model.effort).toBeUndefined();
   });
 
   it("sets and clears model", () => {
-    const model = new WorkerStatusModel("test-worker-id");
+    const model = new AgentStatus("test-worker-id");
     model.update({ model: "opus" });
     expect(model.model).toBe("opus");
     model.update({ model: undefined });
@@ -174,7 +174,7 @@ describe("WorkerStatusModel", () => {
   });
 
   it("sets and clears effort", () => {
-    const model = new WorkerStatusModel("test-worker-id");
+    const model = new AgentStatus("test-worker-id");
     model.update({ effort: "high" });
     expect(model.effort).toBe("high");
     model.update({ effort: undefined });
@@ -182,7 +182,7 @@ describe("WorkerStatusModel", () => {
   });
 
   it("emits change when model is updated", () => {
-    const model = new WorkerStatusModel("test-worker-id");
+    const model = new AgentStatus("test-worker-id");
     const onChange = vi.fn();
     model.on("change", onChange);
     model.update({ model: "haiku" });
@@ -190,18 +190,18 @@ describe("WorkerStatusModel", () => {
   });
 
   it("getStatusText shows sonnet when model is undefined", () => {
-    const model = new WorkerStatusModel("test-worker-id");
+    const model = new AgentStatus("test-worker-id");
     expect(stripAnsi(model.getStatusText())).toContain("sonnet");
   });
 
   it("getStatusText shows model name when set", () => {
-    const model = new WorkerStatusModel("test-worker-id");
+    const model = new AgentStatus("test-worker-id");
     model.update({ model: "opus" });
     expect(stripAnsi(model.getStatusText())).toContain("opus");
   });
 
   it("getStatusText shows effort in parens when set", () => {
-    const model = new WorkerStatusModel("test-worker-id");
+    const model = new AgentStatus("test-worker-id");
     model.update({ model: "opus", effort: "medium" });
     expect(stripAnsi(model.getStatusText())).toContain("opus (medium)");
   });

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { EventEmitter } from "events";
-import { WorkerSession, classifyEvent, debounceMs } from "../src/agent/worker.js";
+import { AgentStatus, WorkerSession, classifyEvent, debounceMs } from "../src/agent/worker.js";
 import * as Wire from "../src/wire.js";
 import { stripAnsi } from "./helpers.js";
 import * as displayModule from "../src/agent/display.js";
@@ -19,7 +19,7 @@ class FakeWs extends EventEmitter {
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
-const WORKER_ID = "test-worker-id";
+const AGENT_ID = "test-worker-id";
 
 function makeIssue(n = 1): Wire.TaskIssue {
   return { number: n, title: `Issue ${n}`, body: `Body ${n}`, labels: [], repoUrl: "https://github.com/owner/repo" };
@@ -58,7 +58,7 @@ beforeEach(() => {
     updatePersistentStatus: vi.fn(),
     setOnToolResultCallback: vi.fn(),
   };
-  session = new WorkerSession(WORKER_ID, wsFactory, display);
+  session = new WorkerSession(new AgentStatus(AGENT_ID), wsFactory, display);
   session.start();
 });
 
@@ -217,7 +217,7 @@ describe("completeCurrentTask", () => {
     await session.completeCurrentTask();
 
     const sent = JSON.parse(fakeWs.send.mock.calls[0][0]);
-    expect(sent).toEqual({ type: "task_complete", workerId: WORKER_ID, taskId: "42" });
+    expect(sent).toEqual({ type: "task_complete", workerId: AGENT_ID, taskId: "42" });
   });
 
   it("returns 'task-complete' so the main loop can hide the prompt", async () => {
@@ -344,7 +344,7 @@ describe("reconnect", () => {
     vi.advanceTimersByTime(5001);
 
     const secondCall = wsFactory.mock.calls[1];
-    expect(secondCall[0]).toBe(WORKER_ID);
+    expect(secondCall[0]).toBe(AGENT_ID);
     expect(secondCall[1]).toBe("42");
     vi.useRealTimers();
   });
@@ -519,7 +519,7 @@ describe("connection status bar", () => {
 describe("status bar content", () => {
   it("shows worker ID prefix in status text", () => {
     const text = stripAnsi(session.getStatusText());
-    expect(text).toContain(`worker ${WORKER_ID.slice(0, 8)}`);
+    expect(text).toContain(`worker ${AGENT_ID.slice(0, 8)}`);
   });
 
   it("shows no current task when no task assigned", () => {
@@ -647,10 +647,10 @@ describe("hello_ack handshake — buffering", () => {
       expect(newWs.send).not.toHaveBeenCalled();
 
       // Send hello_ack → buffer should be flushed
-      sendMsg(newWs, { type: "hello_ack", workerId: WORKER_ID, status: "busy" });
+      sendMsg(newWs, { type: "hello_ack", workerId: AGENT_ID, status: "busy" });
       expect(newWs.send).toHaveBeenCalledOnce();
       const sent = JSON.parse(newWs.send.mock.calls[0][0]);
-      expect(sent).toEqual({ type: "task_complete", workerId: WORKER_ID, taskId: "42" });
+      expect(sent).toEqual({ type: "task_complete", workerId: AGENT_ID, taskId: "42" });
     } finally {
       vi.restoreAllMocks();
       vi.useRealTimers();
@@ -672,7 +672,7 @@ describe("hello_ack handshake — buffering", () => {
       expect(newWs.send).not.toHaveBeenCalled();
 
       // Send hello_ack cancelled → buffer discarded, task state cleared
-      sendMsg(newWs, { type: "hello_ack", workerId: WORKER_ID, status: "cancelled" });
+      sendMsg(newWs, { type: "hello_ack", workerId: AGENT_ID, status: "cancelled" });
       expect(newWs.send).not.toHaveBeenCalled();
 
       // Verify task state cleared: subsequent completeCurrentTask sends nothing
@@ -695,7 +695,7 @@ describe("hello_ack handshake — buffering", () => {
       newWs.emit("open");
 
       display.print.mockClear();
-      sendMsg(newWs, { type: "hello_ack", workerId: WORKER_ID, status: "cancelled" });
+      sendMsg(newWs, { type: "hello_ack", workerId: AGENT_ID, status: "cancelled" });
 
       const printed = display.print.mock.calls.map(args => stripAnsi(String(args[0]))).join("\n");
       expect(printed).toContain("cancelled");
@@ -721,7 +721,7 @@ describe("hello_ack handshake — buffering", () => {
       let callCount = 0;
       const wsFactoryWs = vi.fn().mockImplementation(() => callCount++ === 0 ? wsA : wsB);
 
-      const sessionWithWs = new WorkerSession(WORKER_ID, wsFactoryWs, display, {
+      const sessionWithWs = new WorkerSession(new AgentStatus(AGENT_ID), wsFactoryWs, display, {
         workspaceCtx: { workspace, originalCwd: "/original", workspaceDir: "/tmp/workers", repoUrl: "https://github.com/owner/repo", confirm: vi.fn() },
       });
       sessionWithWs.start(); // uses wsA
@@ -737,7 +737,7 @@ describe("hello_ack handshake — buffering", () => {
       // wsB is now the active connection
       wsB.emit("open");
 
-      sendMsg(wsB, { type: "hello_ack", workerId: WORKER_ID, status: "cancelled" });
+      sendMsg(wsB, { type: "hello_ack", workerId: AGENT_ID, status: "cancelled" });
 
       await vi.waitFor(() => expect(workspace.reset).toHaveBeenCalledOnce());
     } finally {
@@ -758,7 +758,7 @@ describe("hello_ack handshake — buffering", () => {
       // Simulate reconnect and receive cancelled ack while query is still running
       const newWs = reconnectWithNewWs();
       newWs.emit("open");
-      sendMsg(newWs, { type: "hello_ack", workerId: WORKER_ID, status: "cancelled" });
+      sendMsg(newWs, { type: "hello_ack", workerId: AGENT_ID, status: "cancelled" });
 
       // The running query's AbortController must be aborted
       expect(ac.signal.aborted).toBe(true);
@@ -785,7 +785,7 @@ describe("hello_ack handshake — buffering", () => {
       expect(newWs.send).not.toHaveBeenCalled();
 
       // hello_ack idle — task was reverted on foreman side; but worker flushes anyway
-      sendMsg(newWs, { type: "hello_ack", workerId: WORKER_ID, status: "idle" });
+      sendMsg(newWs, { type: "hello_ack", workerId: AGENT_ID, status: "idle" });
       expect(newWs.send).toHaveBeenCalledOnce();
       const sent = JSON.parse(newWs.send.mock.calls[0][0]);
       expect(sent.type).toBe("task_complete");
@@ -796,9 +796,9 @@ describe("hello_ack handshake — buffering", () => {
   });
 
   it("hello_ack is passed to display.printForemanMessage", () => {
-    sendMsg(fakeWs, { type: "hello_ack", workerId: WORKER_ID, status: "idle" });
+    sendMsg(fakeWs, { type: "hello_ack", workerId: AGENT_ID, status: "idle" });
     expect(display.printForemanMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "hello_ack", workerId: WORKER_ID, status: "idle" })
+      expect.objectContaining({ type: "hello_ack", workerId: AGENT_ID, status: "idle" })
     );
   });
 });
@@ -1327,7 +1327,7 @@ describe("workspace slash commands in WorkerSession", () => {
   it("/workspace:reset calls workspace.reset() when clean", async () => {
     const workspace = makeWorkspace();
     const confirm = vi.fn().mockResolvedValue(true);
-    const sessionWs = new WorkerSession(WORKER_ID, wsFactory, display, {
+    const sessionWs = new WorkerSession(new AgentStatus(AGENT_ID), wsFactory, display, {
       workspaceCtx: {
         workspace,
         originalCwd: "/original",
@@ -1349,7 +1349,7 @@ describe("workspace slash commands in WorkerSession", () => {
       uncommittedFiles: ["M foo.ts"], unpushedCommits: [], noUpstream: false,
     });
     const confirm = vi.fn().mockResolvedValue(false);
-    const sessionWs = new WorkerSession(WORKER_ID, wsFactory, display, {
+    const sessionWs = new WorkerSession(new AgentStatus(AGENT_ID), wsFactory, display, {
       workspaceCtx: {
         workspace,
         originalCwd: "/original",
@@ -1369,7 +1369,7 @@ describe("workspace slash commands in WorkerSession", () => {
     const workspace = makeWorkspace();
     const confirm = vi.fn().mockResolvedValue(true);
     const originalCwd = process.cwd();
-    const sessionWs = new WorkerSession(WORKER_ID, wsFactory, display, {
+    const sessionWs = new WorkerSession(new AgentStatus(AGENT_ID), wsFactory, display, {
       workspaceCtx: {
         workspace,
         originalCwd,
@@ -1388,7 +1388,7 @@ describe("workspace slash commands in WorkerSession", () => {
   it("/workspace:create prints 'managed automatically' in worker mode", async () => {
     const printSpy = vi.spyOn(displayModule, "print").mockImplementation(() => {});
     try {
-      const sessionWs = new WorkerSession(WORKER_ID, wsFactory, display, {});
+      const sessionWs = new WorkerSession(new AgentStatus(AGENT_ID), wsFactory, display, {});
       sessionWs.start();
       const wsReg4 = new CommandRegistry();
       registerWorkspaceCommands(sessionWs.workspaceCommandDeps, wsReg4.scoped("workspace"), true);
@@ -1407,7 +1407,7 @@ describe("afterTask callback on /worker:complete", () => {
   it("calls afterTask before sending task_complete to foreman", async () => {
     const afterTask = vi.fn().mockResolvedValue(undefined);
     const sessionWithAfterTask = new WorkerSession(
-      WORKER_ID, wsFactory, display, { afterTask }
+      new AgentStatus(AGENT_ID), wsFactory, display, { afterTask }
     );
     sessionWithAfterTask.start();
 
@@ -1424,7 +1424,7 @@ describe("afterTask callback on /worker:complete", () => {
   it("does not send task_complete if afterTask throws", async () => {
     const afterTask = vi.fn().mockRejectedValue(new Error("reset failed"));
     const sessionWithAfterTask = new WorkerSession(
-      WORKER_ID, wsFactory, display, { afterTask }
+      new AgentStatus(AGENT_ID), wsFactory, display, { afterTask }
     );
     sessionWithAfterTask.start();
 
@@ -1463,7 +1463,7 @@ describe("sendGoodbye", () => {
 
     expect(fakeWs.send).toHaveBeenCalledOnce();
     const sent = JSON.parse(fakeWs.send.mock.calls[0][0]);
-    expect(sent).toEqual({ type: "worker_goodbye", workerId: WORKER_ID, taskId: "42" });
+    expect(sent).toEqual({ type: "worker_goodbye", workerId: AGENT_ID, taskId: "42" });
   });
 
   it("sends worker_goodbye with undefined taskId when no task is active", () => {
@@ -1473,7 +1473,7 @@ describe("sendGoodbye", () => {
     expect(fakeWs.send).toHaveBeenCalledOnce();
     const sent = JSON.parse(fakeWs.send.mock.calls[0][0]);
     expect(sent.type).toBe("worker_goodbye");
-    expect(sent.workerId).toBe(WORKER_ID);
+    expect(sent.workerId).toBe(AGENT_ID);
     expect(sent.taskId).toBeUndefined();
   });
 
@@ -1493,7 +1493,7 @@ describe("heartbeat", () => {
   function makeHeartbeatSession(pingIntervalMs = 100) {
     const ws = new FakeWs();
     const factory = vi.fn().mockReturnValue(ws);
-    const s = new WorkerSession(WORKER_ID, factory, display, { pingIntervalMs });
+    const s = new WorkerSession(new AgentStatus(AGENT_ID), factory, display, { pingIntervalMs });
     s.start();
     return { ws, factory, s };
   }


### PR DESCRIPTION
## Summary

- Renames `WorkerStatusModel` → `AgentStatus` (the model backs the status bar in both REPL and worker modes, not just worker mode)
- Renames `workerId` constructor param → `agentId` on `AgentStatus`; types `effort` as `EffortValue` throughout
- Generates `agentId` unconditionally at startup in `main()` before any mode fork, replacing both the separate `sessionId_` UUID (REPL workspace naming) and the `workerId` generated inside `startWorkerMode()`
- Creates `AgentStatus` unconditionally in `main()`; drops local `currentModel`/`currentEffort` vars — `main()` now reads from `agentStatus.model/effort` as the single source of truth
- `WorkerSession` receives the pre-built `AgentStatus` instead of creating its own and drops its own model/effort getters/setters
- `startWorkerMode()` accepts `AgentStatus` as a second parameter instead of generating a fresh workerId internally

## Test plan

- [ ] `npm test` — all 1313 non-DB unit tests pass
- [ ] `npx tsc --noEmit` — no type errors
- [ ] `npm run lint` — no lint errors
- [ ] `npm run smoke` — foreman + worker connect successfully

Closes #623

🤖 Generated with [Claude Code](https://claude.com/claude-code)