### PR TITLE
refactor: convert event-router free functions to EventRouter class

### DIFF
--- a/src/foreman/controllers/event-router.ts
+++ b/src/foreman/controllers/event-router.ts
@@ -7,19 +7,6 @@ import { Worker } from "../models/worker-registry.js";
 import { shortWorkerId } from "../../../shared/utils.js";
 import { fmtError } from "../../utils.js";
 
-// ── Dependencies interface ──────────────────────────────────────────────────
-
-export interface EventRouterDeps {
-  taskManager: TaskManager;
-  repo: string;
-  token: string;
-  githubApiUrl?: string;
-  taskLabel: string;
-  sendMsg(workerId: string, msg: Wire.ForemanMessage, logTaskId?: string): void;
-  flog(msg: string): void;
-  assignIdleWorkers(): Promise<void>;
-}
-
 // ── Pure helper functions ───────────────────────────────────────────────────
 
 function strProp(obj: unknown, key: string): string | null {
@@ -91,243 +78,278 @@ export function isMutedEvent(name: string): boolean {
   return name === "workflow_job" || name === "workflow_run";
 }
 
-// ── Event forwarding ─────────────────────────────────────────────────────────
-
-export function forwardEvent(deps: EventRouterDeps, task: Task, evt: WebhookEvent, ref: string): void {
-  if (task.workerId) {
-    const worker = Worker.get(task.workerId);
-    if (worker && worker.currentTaskId !== task.taskId) {
-      deps.flog(`[task ${ref}] ${evt.eventName} dropped — worker ${shortWorkerId(task.workerId)} is now on a different task`);
-      return;
-    }
-    if (worker?.status === "disconnected") {
-      deps.taskManager.queueEvent(task.taskId, evt);
-      deps.flog(`[task ${ref}] ${evt.eventName} queued (worker ${shortWorkerId(task.workerId)} disconnected)`);
-    } else if (worker) {
-      const evtMsg: Wire.ForemanMessage = { type: "event_notification", taskId: task.taskId, event: evt.toWorkerPayload() };
-      deps.sendMsg(task.workerId, evtMsg);
-      deps.flog(`[worker ${shortWorkerId(task.workerId)}] → event_notification ${ref} ${evt.eventName}`);
-    } else {
-      deps.flog(`[task ${ref}] ${evt.eventName} DROPPED — worker ${shortWorkerId(task.workerId)} not in registry (disconnected?)`);
-    }
-  } else if (task.status === "pending" || task.status === "blocked") {
-    deps.taskManager.queueEvent(task.taskId, evt);
-    deps.flog(`[task ${ref}] ${evt.eventName} queued (no worker assigned)`);
-  }
-}
-
-// ── Dependency loading ─────────────────────────────────────────────────────
-
-export function startDepsLoad(deps: EventRouterDeps, issueNumber: number, body: string): void {
-  Task.fetchBlockers(issueNumber, body, { repo: deps.repo, token: deps.token, apiUrl: deps.githubApiUrl })
-    .then(async (blockers) => {
-      deps.taskManager.setBlockers(issueNumber, blockers);
-      if (blockers.length > 0) {
-        const states = await fetchIssueStates(blockers, { repo: deps.repo, token: deps.token });
-        for (const [num, state] of states) {
-          deps.taskManager.setIssueOpenState(num, state === "open");
-        }
-      }
-      deps.taskManager.markBlockersLoaded(issueNumber);
-      await deps.assignIdleWorkers();
-    })
-    .catch((err) => deps.flog(`ERROR fetching deps for #${issueNumber}: ${fmtError(err)}`));
-}
-
-// ── Core event routing ──────────────────────────────────────────────────────
+// ── Route result ──────────────────────────────────────────────────────────────
 
 export interface RouteResult { taskId: string | null; workerId: string | null; }
 
-export async function doRouteEvent(deps: EventRouterDeps, name: string, p: Record<string, unknown>, evt: WebhookEvent): Promise<RouteResult> {
-  function result(task: { taskId: string; workerId: string | null } | null | undefined): RouteResult {
-    return { taskId: task?.taskId ?? null, workerId: task?.workerId ?? null };
+// ── EventRouter class ─────────────────────────────────────────────────────────
+
+export class EventRouter {
+  private taskManager: TaskManager;
+  private repo: string;
+  private token: string;
+  private githubApiUrl: string | undefined;
+  private taskLabel: string;
+  private sendMsg: (workerId: string, msg: Wire.ForemanMessage, logTaskId?: string) => void;
+  private flog: (msg: string) => void;
+  private assignIdleWorkers: () => Promise<void>;
+
+  constructor(deps: {
+    taskManager: TaskManager;
+    repo: string;
+    token: string;
+    githubApiUrl?: string;
+    taskLabel: string;
+    sendMsg(workerId: string, msg: Wire.ForemanMessage, logTaskId?: string): void;
+    flog(msg: string): void;
+    assignIdleWorkers(): Promise<void>;
+  }) {
+    this.taskManager = deps.taskManager;
+    this.repo = deps.repo;
+    this.token = deps.token;
+    this.githubApiUrl = deps.githubApiUrl;
+    this.taskLabel = deps.taskLabel;
+    this.sendMsg = deps.sendMsg;
+    this.flog = deps.flog;
+    this.assignIdleWorkers = deps.assignIdleWorkers;
   }
 
-  const { taskManager, flog, repo } = deps;
+  // ── Event forwarding ──────────────────────────────────────────────────────
 
-  // ── PR events: route by PR number ────────────────────────────────────────
+  private forwardEvent(task: Task, evt: WebhookEvent, ref: string): void {
+    if (task.workerId) {
+      const worker = Worker.get(task.workerId);
+      if (worker && worker.currentTaskId !== task.taskId) {
+        this.flog(`[task ${ref}] ${evt.eventName} dropped — worker ${shortWorkerId(task.workerId)} is now on a different task`);
+        return;
+      }
+      if (worker?.status === "disconnected") {
+        this.taskManager.queueEvent(task.taskId, evt);
+        this.flog(`[task ${ref}] ${evt.eventName} queued (worker ${shortWorkerId(task.workerId)} disconnected)`);
+      } else if (worker) {
+        const evtMsg: Wire.ForemanMessage = { type: "event_notification", taskId: task.taskId, event: evt.toWorkerPayload() };
+        this.sendMsg(task.workerId, evtMsg);
+        this.flog(`[worker ${shortWorkerId(task.workerId)}] → event_notification ${ref} ${evt.eventName}`);
+      } else {
+        this.flog(`[task ${ref}] ${evt.eventName} DROPPED — worker ${shortWorkerId(task.workerId)} not in registry (disconnected?)`);
+      }
+    } else if (task.status === "pending" || task.status === "blocked") {
+      this.taskManager.queueEvent(task.taskId, evt);
+      this.flog(`[task ${ref}] ${evt.eventName} queued (no worker assigned)`);
+    }
+  }
 
-  if (name === "pull_request") {
-    const pr = p.pull_request as Record<string, unknown> | undefined;
-    const prNumber = numProp(pr, "number");
-    if (prNumber === null) return result(null);
+  // ── Dependency loading ────────────────────────────────────────────────────
 
-    // Drop synchronize events — the worker pushed these commits itself.
-    if (p.action === "synchronize") return result(await Task.getByPr(prNumber));
+  private startDepsLoad(issueNumber: number, body: string): void {
+    Task.fetchBlockers(issueNumber, body, { repo: this.repo, token: this.token, apiUrl: this.githubApiUrl })
+      .then(async (blockers) => {
+        this.taskManager.setBlockers(issueNumber, blockers);
+        if (blockers.length > 0) {
+          const states = await fetchIssueStates(blockers, { repo: this.repo, token: this.token });
+          for (const [num, state] of states) {
+            this.taskManager.setIssueOpenState(num, state === "open");
+          }
+        }
+        this.taskManager.markBlockersLoaded(issueNumber);
+        await this.assignIdleWorkers();
+      })
+      .catch((err) => this.flog(`ERROR fetching deps for #${issueNumber}: ${fmtError(err)}`));
+  }
 
-    // When a PR is opened, register it against a task if the body links an issue.
-    if (p.action === "opened" && pr) {
-      const linkedIssue = extractLinkedIssueNumber(String(pr.body ?? ""));
-      if (linkedIssue !== null) {
-        const linkedTask = await Task.getByIssue(linkedIssue);
-        if (linkedTask) {
-          const branch = strProp(pr.head, "ref");
-          if (branch) taskManager.registerBranch(branch, linkedTask.taskId);
-          await linkedTask.registerPr(prNumber, branch ?? null).catch((err: unknown) =>
-            flog(`ERROR Failed to register PR for task #${linkedTask.taskId}: ${fmtError(err)}`)
-          );
-          flog(`[task #${linkedIssue}] PR #${prNumber} registered`);
+  // ── Core event routing ────────────────────────────────────────────────────
+
+  async routeEvent(name: string, p: Record<string, unknown>, evt: WebhookEvent): Promise<RouteResult> {
+    function result(task: { taskId: string; workerId: string | null } | null | undefined): RouteResult {
+      return { taskId: task?.taskId ?? null, workerId: task?.workerId ?? null };
+    }
+
+    const { taskManager, flog, repo } = this;
+
+    // ── PR events: route by PR number ──────────────────────────────────────
+
+    if (name === "pull_request") {
+      const pr = p.pull_request as Record<string, unknown> | undefined;
+      const prNumber = numProp(pr, "number");
+      if (prNumber === null) return result(null);
+
+      // Drop synchronize events — the worker pushed these commits itself.
+      if (p.action === "synchronize") return result(await Task.getByPr(prNumber));
+
+      // When a PR is opened, register it against a task if the body links an issue.
+      if (p.action === "opened" && pr) {
+        const linkedIssue = extractLinkedIssueNumber(String(pr.body ?? ""));
+        if (linkedIssue !== null) {
+          const linkedTask = await Task.getByIssue(linkedIssue);
+          if (linkedTask) {
+            const branch = strProp(pr.head, "ref");
+            if (branch) taskManager.registerBranch(branch, linkedTask.taskId);
+            await linkedTask.registerPr(prNumber, branch ?? null).catch((err: unknown) =>
+              flog(`ERROR Failed to register PR for task #${linkedTask.taskId}: ${fmtError(err)}`)
+            );
+            flog(`[task #${linkedIssue}] PR #${prNumber} registered`);
+          }
         }
       }
-    }
 
-    // When a PR is closed without merging, clear it from the task.
-    if (p.action === "closed" && pr && !pr.merged) {
-      const task = await Task.getByPr(prNumber);
-      if (task) {
-        flog(`[task #${task.issueNumber}] PR #${prNumber} unregistered (closed without merging)`);
-        await task.unregisterPr().catch((err: unknown) =>
-          flog(`ERROR Failed to unregister PR #${prNumber}: ${fmtError(err)}`)
-        );
-        forwardEvent(deps, task, evt, `PR #${prNumber}`);
-        return result(task);
-      }
-      return result(null);
-    }
-
-    // When a PR is closed with merging, record that it was merged.
-    if (p.action === "closed" && pr && pr.merged) {
-      const task = await Task.getByPr(prNumber);
-      if (task) {
-        flog(`[task #${task.issueNumber}] PR #${prNumber} merged`);
-        await task.mergePr().catch((err: unknown) =>
-          flog(`ERROR Failed to record PR #${prNumber} merge: ${fmtError(err)}`)
-        );
-        forwardEvent(deps, task, evt, `PR #${prNumber}`);
-        return result(task);
-      }
-      return result(null);
-    }
-
-    const task = await Task.getByPr(prNumber);
-    if (task) forwardEvent(deps, task, evt, `PR #${prNumber}`);
-    return result(task);
-  }
-
-  if (name === "pull_request_review" || name === "pull_request_review_comment") {
-    const pr = p.pull_request as Record<string, unknown> | undefined;
-    const prNumber = numProp(pr, "number");
-    if (prNumber === null) return result(null);
-    const task = await Task.getByPr(prNumber);
-    if (task) forwardEvent(deps, task, evt, `PR #${prNumber}`);
-    return result(task);
-  }
-
-  if (name === "check_run" || name === "check_suite") {
-    const inner = (name === "check_run" ? p.check_run : p.check_suite) as Record<string, unknown> | undefined;
-    const prs = inner?.pull_requests as Array<{ number: number }> | undefined;
-
-    if (prs && prs.length > 0) {
-      const task = await Task.getByPr(prs[0].number);
-      if (task) { forwardEvent(deps, task, evt, `PR #${prs[0].number}`); return result(task); }
-    }
-
-    const headBranch = name === "check_run"
-      ? strProp(inner?.check_suite, "head_branch") ?? ""
-      : strProp(inner, "head_branch") ?? "";
-    if (headBranch) {
-      const task = await taskManager.getTaskForBranch(headBranch);
-      if (task) { forwardEvent(deps, task, evt, `branch ${headBranch}`); return result(task); }
-    }
-    return result(null);
-  }
-
-  // ── Issue events: route by issue number ──────────────────────────────────
-
-  const issue = p.issue as Record<string, unknown> | undefined;
-  const issueNumber = numProp(issue, "number");
-  if (issueNumber === null) return result(null);
-
-  let task = await Task.getByIssue(issueNumber);
-
-  // GitHub issue_comment events on PRs have the PR number in issue.number.
-  if (!task) task = await Task.getByPr(issueNumber);
-
-  // If the issue isn't queued yet, check if this webhook should enqueue it.
-  if (!task && name === "issues" && issue) {
-    const action = p.action as string | undefined;
-    const labeledNow =
-      action === "labeled" &&
-      (p.label as Record<string, unknown> | undefined)?.name === deps.taskLabel;
-    const openedWithLabel =
-      action === "opened" &&
-      (issue.labels as Array<{ name: string }> | undefined)?.some((l) => l.name === deps.taskLabel);
-
-    if (labeledNow || openedWithLabel) {
-      const issueState = String(issue.state ?? "open");
-      if (issueState === "closed") {
-        flog(`[task #${issueNumber}] issues/${action}: ignoring — issue is closed (title: ${JSON.stringify(String(issue.title ?? ""))})`);
+      // When a PR is closed without merging, clear it from the task.
+      if (p.action === "closed" && pr && !pr.merged) {
+        const task = await Task.getByPr(prNumber);
+        if (task) {
+          flog(`[task #${task.issueNumber}] PR #${prNumber} unregistered (closed without merging)`);
+          await task.unregisterPr().catch((err: unknown) =>
+            flog(`ERROR Failed to unregister PR #${prNumber}: ${fmtError(err)}`)
+          );
+          this.forwardEvent(task, evt, `PR #${prNumber}`);
+          return result(task);
+        }
         return result(null);
       }
 
-      const repoUrl = strProp(p.repository, "html_url") ?? "";
-      const labels =
-        (issue.labels as Array<{ name: string }> | undefined)?.map((l) => l.name) ?? [];
-      const issueData: Wire.TaskIssue = {
-        number: issueNumber,
-        title: String(issue.title ?? ""),
-        body: String(issue.body ?? ""),
-        labels,
-        repoUrl,
-      };
+      // When a PR is closed with merging, record that it was merged.
+      if (p.action === "closed" && pr && pr.merged) {
+        const task = await Task.getByPr(prNumber);
+        if (task) {
+          flog(`[task #${task.issueNumber}] PR #${prNumber} merged`);
+          await task.mergePr().catch((err: unknown) =>
+            flog(`ERROR Failed to record PR #${prNumber} merge: ${fmtError(err)}`)
+          );
+          this.forwardEvent(task, evt, `PR #${prNumber}`);
+          return result(task);
+        }
+        return result(null);
+      }
 
-      // Track as open and persist to DB.
-      await taskManager.enqueueIssue(String(issueNumber), issueNumber, repo, issueData.title, issueData.body, issueData.labels)
-        .catch((err: unknown) => flog(`ERROR Failed to persist task #${issueNumber}: ${fmtError(err)}`));
-
-      startDepsLoad(deps, issueNumber, issueData.body);
-      await deps.assignIdleWorkers();
-      flog(`[task #${issueNumber}] enqueued via ${name}/${action}`);
-      return { taskId: String(issueNumber), workerId: null };
-    }
-  }
-
-  // ── Dependency graph updates ───────────────────────────────────────────────
-
-  if (name === "issues" && issue) {
-    const action = p.action as string | undefined;
-
-    if (
-      action === "unlabeled" &&
-      (p.label as Record<string, unknown> | undefined)?.name === deps.taskLabel
-    ) {
-      await taskManager.dequeueIssue(issueNumber)
-        .catch((err: unknown) => flog(`ERROR Failed to dequeue task #${issueNumber}: ${fmtError(err)}`));
-      flog(`[task #${issueNumber}] dequeued (label removed)`);
-      await deps.assignIdleWorkers();
+      const task = await Task.getByPr(prNumber);
+      if (task) this.forwardEvent(task, evt, `PR #${prNumber}`);
       return result(task);
     }
 
-    if (action === "closed") {
-      await taskManager.closeIssue(issueNumber).catch((err: unknown) =>
-        flog(`ERROR Failed to close issue #${issueNumber}: ${fmtError(err)}`)
-      );
-      await deps.assignIdleWorkers();
+    if (name === "pull_request_review" || name === "pull_request_review_comment") {
+      const pr = p.pull_request as Record<string, unknown> | undefined;
+      const prNumber = numProp(pr, "number");
+      if (prNumber === null) return result(null);
+      const task = await Task.getByPr(prNumber);
+      if (task) this.forwardEvent(task, evt, `PR #${prNumber}`);
       return result(task);
     }
 
-    if (action === "reopened") {
-      await taskManager.reopenIssue(issueNumber).catch((err: unknown) =>
-        flog(`ERROR Failed to reopen issue #${issueNumber}: ${fmtError(err)}`)
-      );
-      await deps.assignIdleWorkers();
-      return result(task);
+    if (name === "check_run" || name === "check_suite") {
+      const inner = (name === "check_run" ? p.check_run : p.check_suite) as Record<string, unknown> | undefined;
+      const prs = inner?.pull_requests as Array<{ number: number }> | undefined;
+
+      if (prs && prs.length > 0) {
+        const task = await Task.getByPr(prs[0].number);
+        if (task) { this.forwardEvent(task, evt, `PR #${prs[0].number}`); return result(task); }
+      }
+
+      const headBranch = name === "check_run"
+        ? strProp(inner?.check_suite, "head_branch") ?? ""
+        : strProp(inner, "head_branch") ?? "";
+      if (headBranch) {
+        const task = await taskManager.getTaskForBranch(headBranch);
+        if (task) { this.forwardEvent(task, evt, `branch ${headBranch}`); return result(task); }
+      }
+      return result(null);
     }
 
-    if (action === "edited") {
-      const changes = p.changes as Record<string, unknown> | undefined;
-      if (changes?.body) {
-        const trackedTask = await Task.getByIssue(issueNumber);
-        if (trackedTask) {
-          const newBody = String(issue.body ?? "");
-          taskManager.resetBlockers(issueNumber);
-          startDepsLoad(deps, issueNumber, newBody);
+    // ── Issue events: route by issue number ────────────────────────────────
+
+    const issue = p.issue as Record<string, unknown> | undefined;
+    const issueNumber = numProp(issue, "number");
+    if (issueNumber === null) return result(null);
+
+    let task = await Task.getByIssue(issueNumber);
+
+    // GitHub issue_comment events on PRs have the PR number in issue.number.
+    if (!task) task = await Task.getByPr(issueNumber);
+
+    // If the issue isn't queued yet, check if this webhook should enqueue it.
+    if (!task && name === "issues" && issue) {
+      const action = p.action as string | undefined;
+      const labeledNow =
+        action === "labeled" &&
+        (p.label as Record<string, unknown> | undefined)?.name === this.taskLabel;
+      const openedWithLabel =
+        action === "opened" &&
+        (issue.labels as Array<{ name: string }> | undefined)?.some((l) => l.name === this.taskLabel);
+
+      if (labeledNow || openedWithLabel) {
+        const issueState = String(issue.state ?? "open");
+        if (issueState === "closed") {
+          flog(`[task #${issueNumber}] issues/${action}: ignoring — issue is closed (title: ${JSON.stringify(String(issue.title ?? ""))})`);
+          return result(null);
+        }
+
+        const repoUrl = strProp(p.repository, "html_url") ?? "";
+        const labels =
+          (issue.labels as Array<{ name: string }> | undefined)?.map((l) => l.name) ?? [];
+        const issueData: Wire.TaskIssue = {
+          number: issueNumber,
+          title: String(issue.title ?? ""),
+          body: String(issue.body ?? ""),
+          labels,
+          repoUrl,
+        };
+
+        // Track as open and persist to DB.
+        await taskManager.enqueueIssue(String(issueNumber), issueNumber, repo, issueData.title, issueData.body, issueData.labels)
+          .catch((err: unknown) => flog(`ERROR Failed to persist task #${issueNumber}: ${fmtError(err)}`));
+
+        this.startDepsLoad(issueNumber, issueData.body);
+        await this.assignIdleWorkers();
+        flog(`[task #${issueNumber}] enqueued via ${name}/${action}`);
+        return { taskId: String(issueNumber), workerId: null };
+      }
+    }
+
+    // ── Dependency graph updates ───────────────────────────────────────────
+
+    if (name === "issues" && issue) {
+      const action = p.action as string | undefined;
+
+      if (
+        action === "unlabeled" &&
+        (p.label as Record<string, unknown> | undefined)?.name === this.taskLabel
+      ) {
+        await taskManager.dequeueIssue(issueNumber)
+          .catch((err: unknown) => flog(`ERROR Failed to dequeue task #${issueNumber}: ${fmtError(err)}`));
+        flog(`[task #${issueNumber}] dequeued (label removed)`);
+        await this.assignIdleWorkers();
+        return result(task);
+      }
+
+      if (action === "closed") {
+        await taskManager.closeIssue(issueNumber).catch((err: unknown) =>
+          flog(`ERROR Failed to close issue #${issueNumber}: ${fmtError(err)}`)
+        );
+        await this.assignIdleWorkers();
+        return result(task);
+      }
+
+      if (action === "reopened") {
+        await taskManager.reopenIssue(issueNumber).catch((err: unknown) =>
+          flog(`ERROR Failed to reopen issue #${issueNumber}: ${fmtError(err)}`)
+        );
+        await this.assignIdleWorkers();
+        return result(task);
+      }
+
+      if (action === "edited") {
+        const changes = p.changes as Record<string, unknown> | undefined;
+        if (changes?.body) {
+          const trackedTask = await Task.getByIssue(issueNumber);
+          if (trackedTask) {
+            const newBody = String(issue.body ?? "");
+            taskManager.resetBlockers(issueNumber);
+            this.startDepsLoad(issueNumber, newBody);
+          }
         }
       }
     }
-  }
 
-  if (!task) return result(null);
-  forwardEvent(deps, task, evt, `#${issueNumber}`);
-  return result(task);
+    if (!task) return result(null);
+    this.forwardEvent(task, evt, `#${issueNumber}`);
+    return result(task);
+  }
 }

--- a/src/foreman/controllers/wss.ts
+++ b/src/foreman/controllers/wss.ts
@@ -11,8 +11,7 @@ import type { BrunelConfig } from "../../config.js";
 import type { TaskManager } from "../models/task-manager.js";
 import { Task } from "../models/task.js";
 import { Worker } from "../models/worker-registry.js";
-import { doRouteEvent, isMutedEvent, summaryEvent, forwardEvent } from "./event-router.js";
-import type { EventRouterDeps } from "./event-router.js";
+import { EventRouter } from "./event-router.js";
 
 type R = Record<string, unknown>;
 
@@ -148,8 +147,7 @@ export function createForemanWss(
     }
   }
 
-  // Build the event router deps object
-  const routerDeps: EventRouterDeps = {
+  const eventRouter = new EventRouter({
     taskManager,
     repo,
     token,
@@ -158,13 +156,13 @@ export function createForemanWss(
     sendMsg,
     flog,
     assignIdleWorkers,
-  };
+  });
 
   async function routeEvent(id: string, name: string, payload: unknown) {
     const p = payload as Record<string, unknown>;
     const evt = WebhookEvent.fromIncoming(id, name, p);
 
-    const { taskId, workerId } = await doRouteEvent(routerDeps, name, p, evt);
+    const { taskId, workerId } = await eventRouter.routeEvent(name, p, evt);
 
     const action = typeof p.action === "string" ? p.action : null;
     const webhookIssueNumber = typeof (p.issue as R | undefined)?.number === "number" ? (p.issue as R).number as number : null;

--- a/tests/foreman.event-router.test.ts
+++ b/tests/foreman.event-router.test.ts
@@ -1,6 +1,6 @@
 /**
- * Unit tests for forwardEvent — the function that decides whether to send or
- * queue a GitHub event to a worker.
+ * Unit tests for EventRouter.forwardEvent — the method that decides whether to
+ * send or queue a GitHub event to a worker.
  *
  * Covers the bug reported in issue #601: comments on a completed task were
  * forwarded to the worker that had moved on to a new task. The fix checks the
@@ -8,8 +8,7 @@
  * guard — so any case where the worker has moved on is caught.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { forwardEvent } from "../src/foreman/controllers/event-router.js";
-import type { EventRouterDeps } from "../src/foreman/controllers/event-router.js";
+import { EventRouter } from "../src/foreman/controllers/event-router.js";
 import { Task } from "../src/foreman/models/task.js";
 import { Worker } from "../src/foreman/models/worker-registry.js";
 import { WebhookEvent } from "../src/foreman/models/webhook-event.js";
@@ -24,26 +23,31 @@ function makeEvent(name = "issue_comment"): WebhookEvent {
   return WebhookEvent.fromIncoming("evt-1", name, {});
 }
 
-function makeDeps(): EventRouterDeps & { sendMsg: ReturnType<typeof vi.fn>; flog: ReturnType<typeof vi.fn> } {
+function makeRouter(): EventRouter & { sendMsg: ReturnType<typeof vi.fn>; flog: ReturnType<typeof vi.fn> } {
   const queueEvent = vi.fn();
   const sendMsg = vi.fn();
   const flog = vi.fn();
-  return {
-    taskManager: { queueEvent } as unknown as EventRouterDeps["taskManager"],
+  const router = new EventRouter({
+    taskManager: { queueEvent } as unknown as ConstructorParameters<typeof EventRouter>[0]["taskManager"],
     repo: "owner/repo",
     token: "token",
     taskLabel: "brunel:ready",
     sendMsg,
     flog,
     assignIdleWorkers: vi.fn().mockResolvedValue(undefined),
-  } as unknown as ReturnType<typeof makeDeps>;
+  });
+  return Object.assign(router, { sendMsg, flog });
+}
+
+function callForwardEvent(router: EventRouter, task: Task, evt: WebhookEvent, ref: string): void {
+  (router as any).forwardEvent(task, evt, ref);
 }
 
 beforeEach(() => { Worker._reset(); });
 
 // ── Core bug fix: worker that has moved on ─────────────────────────────────────
 
-describe("forwardEvent — worker has moved on to a different task", () => {
+describe("EventRouter.forwardEvent — worker has moved on to a different task", () => {
   it("drops the event when the registry shows the worker is now on a different task", () => {
     // Simulates the bug: task T1 completes, worker is assigned T2,
     // but task.workerId for T1 still points to that worker.
@@ -55,12 +59,12 @@ describe("forwardEvent — worker has moved on to a different task", () => {
     });
     const w = Worker.register("worker-1", fakeWs());
     w.assign("other-task-id"); // worker has moved on to a different task
-    const deps = makeDeps();
+    const router = makeRouter();
 
-    forwardEvent(deps, task, makeEvent(), "#42");
+    callForwardEvent(router, task, makeEvent(), "#42");
 
-    expect(deps.sendMsg).not.toHaveBeenCalled();
-    expect(deps.taskManager.queueEvent).not.toHaveBeenCalled();
+    expect(router.sendMsg).not.toHaveBeenCalled();
+    expect((router as any).taskManager.queueEvent).not.toHaveBeenCalled();
   });
 
   it("drops the event when the registry shows the worker is now idle (task completed, no new task yet)", () => {
@@ -71,12 +75,12 @@ describe("forwardEvent — worker has moved on to a different task", () => {
       completed_at: new Date().toISOString(),
     });
     Worker.register("worker-1", fakeWs()); // idle with no currentTaskId
-    const deps = makeDeps();
+    const router = makeRouter();
 
-    forwardEvent(deps, task, makeEvent(), "#42");
+    callForwardEvent(router, task, makeEvent(), "#42");
 
-    expect(deps.sendMsg).not.toHaveBeenCalled();
-    expect(deps.taskManager.queueEvent).not.toHaveBeenCalled();
+    expect(router.sendMsg).not.toHaveBeenCalled();
+    expect((router as any).taskManager.queueEvent).not.toHaveBeenCalled();
   });
 
   it("logs a drop message when the worker has moved on", () => {
@@ -88,18 +92,18 @@ describe("forwardEvent — worker has moved on to a different task", () => {
     });
     const w = Worker.register("worker-1", fakeWs());
     w.assign("other-task-id");
-    const deps = makeDeps();
+    const router = makeRouter();
 
-    forwardEvent(deps, task, makeEvent("issue_comment"), "#42");
+    callForwardEvent(router, task, makeEvent("issue_comment"), "#42");
 
-    expect(deps.flog).toHaveBeenCalledWith(expect.stringContaining("dropped"));
-    expect(deps.flog).toHaveBeenCalledWith(expect.stringContaining("different task"));
+    expect(router.flog).toHaveBeenCalledWith(expect.stringContaining("dropped"));
+    expect(router.flog).toHaveBeenCalledWith(expect.stringContaining("different task"));
   });
 });
 
 // ── Active tasks still receive events (regression guard) ───────────────────────
 
-describe("forwardEvent — active tasks still receive events", () => {
+describe("EventRouter.forwardEvent — active tasks still receive events", () => {
   it("forwards the event when the registry confirms the worker is still on this task", () => {
     const task = Task.fromTest({
       task_id: "42",
@@ -108,12 +112,12 @@ describe("forwardEvent — active tasks still receive events", () => {
     });
     const w = Worker.register("worker-1", fakeWs());
     w.assign("42");
-    const deps = makeDeps();
+    const router = makeRouter();
 
-    forwardEvent(deps, task, makeEvent(), "#42");
+    callForwardEvent(router, task, makeEvent(), "#42");
 
-    expect(deps.sendMsg).toHaveBeenCalledOnce();
-    expect(deps.sendMsg).toHaveBeenCalledWith(
+    expect(router.sendMsg).toHaveBeenCalledOnce();
+    expect(router.sendMsg).toHaveBeenCalledWith(
       "worker-1",
       expect.objectContaining({ type: "event_notification" }),
     );
@@ -129,12 +133,12 @@ describe("forwardEvent — active tasks still receive events", () => {
     });
     const w = Worker.register("worker-1", fakeWs());
     w.assign("42");
-    const deps = makeDeps();
+    const router = makeRouter();
 
-    forwardEvent(deps, task, makeEvent(), "#42");
+    callForwardEvent(router, task, makeEvent(), "#42");
 
-    expect(deps.sendMsg).toHaveBeenCalledOnce();
-    expect(deps.flog).not.toHaveBeenCalledWith(expect.stringContaining("dropped"));
+    expect(router.sendMsg).toHaveBeenCalledOnce();
+    expect(router.flog).not.toHaveBeenCalledWith(expect.stringContaining("dropped"));
   });
 
   it("still forwards events when the task's issue is closed but worker is still on it", () => {
@@ -146,22 +150,22 @@ describe("forwardEvent — active tasks still receive events", () => {
     });
     const w = Worker.register("worker-1", fakeWs());
     w.assign("42");
-    const deps = makeDeps();
+    const router = makeRouter();
 
-    forwardEvent(deps, task, makeEvent(), "#42");
+    callForwardEvent(router, task, makeEvent(), "#42");
 
-    expect(deps.sendMsg).toHaveBeenCalledOnce();
-    expect(deps.flog).not.toHaveBeenCalledWith(expect.stringContaining("dropped"));
+    expect(router.sendMsg).toHaveBeenCalledOnce();
+    expect(router.flog).not.toHaveBeenCalledWith(expect.stringContaining("dropped"));
   });
 
   it("queues event for a pending task with no worker", () => {
     const task = Task.fromTest({ task_id: "42", issue_number: 42 });
     task.blockersLoaded = true; // no open blockers → status is "pending"
-    const deps = makeDeps();
+    const router = makeRouter();
 
-    forwardEvent(deps, task, makeEvent(), "#42");
+    callForwardEvent(router, task, makeEvent(), "#42");
 
-    expect(deps.taskManager.queueEvent).toHaveBeenCalledOnce();
-    expect(deps.sendMsg).not.toHaveBeenCalled();
+    expect((router as any).taskManager.queueEvent).toHaveBeenCalledOnce();
+    expect(router.sendMsg).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Replaces `EventRouterDeps` interface + free functions (`doRouteEvent`, `forwardEvent`, `startDepsLoad`) with an `EventRouter` class whose constructor takes the same fields
- `routeEvent(name, p, evt)` is the public routing method; `forwardEvent` and `startDepsLoad` become private methods
- `extractLinkedIssueNumber`, `summaryEvent`, `isMutedEvent` remain as module-level exports (they don't use deps)
- `wss.ts` instantiates `EventRouter` and calls `router.routeEvent(...)`
- Tests updated to construct `EventRouter` directly instead of using free functions

## Test plan

- [ ] All unit tests pass (`npm test`)
- [ ] TypeScript type check clean (`npx tsc --noEmit`)
- [ ] Existing event-router tests continue to cover the same behavior via `(router as any).forwardEvent()`

Closes #613

🤖 Generated with [Claude Code](https://claude.com/claude-code)