### PR TITLE
feat: extract QueryStats class for per-query stat accumulation

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -113,9 +113,6 @@ export async function runQuery(
     process.stdout.write("\r\n\x1b[J");
   }
 
-  // Accumulate stats from stream_event messages to show in the status line.
-  // message_delta.usage.output_tokens is cumulative per message, so we sum
-  // completed messages and track the current one separately.
   const stats = new QueryStats();
   const getStatusText = () => display.c.darkGray(stats.getStatusText());
   display.startStatus(getStatusText);

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -118,7 +118,7 @@ export async function runQuery(
   // completed messages and track the current one separately.
   const stats = new QueryStats();
   const workingVerb = display.pickWorkingVerb();
-  const getStatusText = () => stats.getStatusText(workingVerb);
+  const getStatusText = () => display.c.darkGray(stats.getStatusText(workingVerb));
   display.startStatus(getStatusText);
 
   const canUseTool: CanUseTool = async (toolName, input) => {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -19,6 +19,7 @@ import type { ModelInfo, FetchModelsFn } from "./model.js";
 import { handleEffortCommand } from "./effort.js";
 import type { EffortValue } from "./effort.js";
 import { CommandRegistry } from "./command-registry.js";
+import { QueryStats } from "./query-stats.js";
 export { parseSlashCommand, dispatchInput, matchCommands, ask } from "./input.js";
 export type { SlashCommandResult, DispatchResult } from "./input.js";
 export { handleModelCommand, getCachedModels, _resetCachedModels } from "./model.js";
@@ -112,17 +113,12 @@ export async function runQuery(
     process.stdout.write("\r\n\x1b[J");
   }
 
-  const startTime = Date.now();
   // Accumulate stats from stream_event messages to show in the status line.
   // message_delta.usage.output_tokens is cumulative per message, so we sum
   // completed messages and track the current one separately.
-  const stats = { turns: 0, inputTokens: 0, completedOutputTokens: 0, currentOutputTokens: 0 };
+  const stats = new QueryStats();
   const workingVerb = display.pickWorkingVerb();
-  const getStatusText = () => {
-    const secs = Math.floor((Date.now() - startTime) / 1000);
-    const outTokens = stats.completedOutputTokens + stats.currentOutputTokens;
-    return display.c.darkGray(`${workingVerb}… ${display.fmtStats(secs, stats.turns || undefined, outTokens || undefined, stats.inputTokens || undefined)}`);
-  };
+  const getStatusText = () => stats.getStatusText(workingVerb);
   display.startStatus(getStatusText);
 
   const canUseTool: CanUseTool = async (toolName, input) => {
@@ -188,12 +184,7 @@ export async function runQuery(
       // Extract turn count and token totals from streaming events.
       if (message.type === "stream_event") {
         if (message.parent_tool_use_id == null) {
-          // BetaRawMessageStreamEvent is a discriminated union; use a structural type for field access
-          type StreamEvent = { type: string; message?: { usage?: { input_tokens?: number } }; usage?: { output_tokens?: number } };
-          const ev = message.event as StreamEvent;
-          if (ev.type === "message_start")       { stats.turns++; stats.inputTokens += ev.message?.usage?.input_tokens ?? 0; }
-          if (ev.type === "message_delta")       stats.currentOutputTokens = ev.usage?.output_tokens ?? stats.currentOutputTokens;
-          if (ev.type === "message_stop")        { stats.completedOutputTokens += stats.currentOutputTokens; stats.currentOutputTokens = 0; }
+          stats.update(message.event as Parameters<typeof stats.update>[0]);
         }
         continue; // stream events are display-only; don't pass to printMessage
       }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -117,8 +117,7 @@ export async function runQuery(
   // message_delta.usage.output_tokens is cumulative per message, so we sum
   // completed messages and track the current one separately.
   const stats = new QueryStats();
-  const workingVerb = display.pickWorkingVerb();
-  const getStatusText = () => display.c.darkGray(stats.getStatusText(workingVerb));
+  const getStatusText = () => display.c.darkGray(stats.getStatusText());
   display.startStatus(getStatusText);
 
   const canUseTool: CanUseTool = async (toolName, input) => {

--- a/src/agent/query-stats.ts
+++ b/src/agent/query-stats.ts
@@ -1,0 +1,66 @@
+import { EventEmitter } from "node:events";
+import * as display from "./display.js";
+
+// Structural type for stream events carrying token usage data.
+// BetaRawMessageStreamEvent is a discriminated union; we access fields structurally.
+export type QueryStreamEvent = {
+  type: string;
+  message?: { usage?: { input_tokens?: number } };
+  usage?: { output_tokens?: number };
+};
+
+/**
+ * Accumulates per-query token/turn statistics from stream events.
+ * Emits "change" whenever a stat-bearing event is processed, so subscribers
+ * can react without polling.
+ *
+ * Usage:
+ *   const stats = new QueryStats();
+ *   stats.update(ev); // call for each message_start/message_delta/message_stop
+ *   stats.getStatusText("Working"); // formatted status bar text
+ */
+export class QueryStats extends EventEmitter {
+  private _turns = 0;
+  private _inputTokens = 0;
+  private _completedOutputTokens = 0;
+  private _currentOutputTokens = 0;
+  private readonly _startTime: number;
+
+  constructor(startTime = Date.now()) {
+    super();
+    this._startTime = startTime;
+  }
+
+  get turns(): number { return this._turns; }
+  get inputTokens(): number { return this._inputTokens; }
+  get outputTokens(): number { return this._completedOutputTokens + this._currentOutputTokens; }
+  get elapsedSecs(): number { return Math.floor((Date.now() - this._startTime) / 1000); }
+
+  /**
+   * Process a single top-level stream event. Emits "change" for stat-bearing
+   * events (message_start, message_delta, message_stop); silently ignores others.
+   */
+  update(event: QueryStreamEvent): void {
+    if (event.type === "message_start") {
+      this._turns++;
+      this._inputTokens += event.message?.usage?.input_tokens ?? 0;
+    } else if (event.type === "message_delta") {
+      this._currentOutputTokens = event.usage?.output_tokens ?? this._currentOutputTokens;
+    } else if (event.type === "message_stop") {
+      this._completedOutputTokens += this._currentOutputTokens;
+      this._currentOutputTokens = 0;
+    } else {
+      return; // unrecognized event — no state change, no emission
+    }
+    this.emit("change");
+  }
+
+  /** Formatted status bar text for use with display.startStatus(). */
+  getStatusText(workingVerb: string): string {
+    const secs = this.elapsedSecs;
+    const outTokens = this.outputTokens;
+    return display.c.darkGray(
+      `${workingVerb}… ${display.fmtStats(secs, this._turns || undefined, outTokens || undefined, this._inputTokens || undefined)}`,
+    );
+  }
+}

--- a/src/agent/query-stats.ts
+++ b/src/agent/query-stats.ts
@@ -11,13 +11,13 @@ export type QueryStreamEvent = {
 
 /**
  * Accumulates per-query token/turn statistics from stream events.
- * Emits "change" whenever a stat-bearing event is processed, so subscribers
- * can react without polling.
+ * Picks its own working verb at construction and emits "change" whenever a
+ * stat-bearing event is processed, so subscribers can react without polling.
  *
  * Usage:
  *   const stats = new QueryStats();
  *   stats.update(ev); // call for each message_start/message_delta/message_stop
- *   stats.getStatusText("Working"); // formatted status bar text
+ *   stats.getStatusText(); // formatted status bar text
  */
 export class QueryStats extends EventEmitter {
   private _turns = 0;
@@ -25,10 +25,12 @@ export class QueryStats extends EventEmitter {
   private _completedOutputTokens = 0;
   private _currentOutputTokens = 0;
   private readonly _startTime: number;
+  private readonly _workingVerb: string;
 
   constructor(startTime = Date.now()) {
     super();
     this._startTime = startTime;
+    this._workingVerb = display.pickWorkingVerb();
   }
 
   get turns(): number { return this._turns; }
@@ -56,9 +58,9 @@ export class QueryStats extends EventEmitter {
   }
 
   /** Formatted status bar text for use with display.startStatus(). Styling is the caller's responsibility. */
-  getStatusText(workingVerb: string): string {
+  getStatusText(): string {
     const secs = this.elapsedSecs;
     const outTokens = this.outputTokens;
-    return `${workingVerb}… ${display.fmtStats(secs, this._turns || undefined, outTokens || undefined, this._inputTokens || undefined)}`;
+    return `${this._workingVerb}… ${display.fmtStats(secs, this._turns || undefined, outTokens || undefined, this._inputTokens || undefined)}`;
   }
 }

--- a/src/agent/query-stats.ts
+++ b/src/agent/query-stats.ts
@@ -55,12 +55,10 @@ export class QueryStats extends EventEmitter {
     this.emit("change");
   }
 
-  /** Formatted status bar text for use with display.startStatus(). */
+  /** Formatted status bar text for use with display.startStatus(). Styling is the caller's responsibility. */
   getStatusText(workingVerb: string): string {
     const secs = this.elapsedSecs;
     const outTokens = this.outputTokens;
-    return display.c.darkGray(
-      `${workingVerb}… ${display.fmtStats(secs, this._turns || undefined, outTokens || undefined, this._inputTokens || undefined)}`,
-    );
+    return `${workingVerb}… ${display.fmtStats(secs, this._turns || undefined, outTokens || undefined, this._inputTokens || undefined)}`;
   }
 }

--- a/tests/repl.query-stats.test.ts
+++ b/tests/repl.query-stats.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { QueryStats } from "../src/agent/query-stats.js";
+import * as display from "../src/agent/display.js";
 import { stripAnsi } from "./helpers.js";
 
 afterEach(() => {
@@ -184,10 +185,11 @@ describe("QueryStats - elapsedSecs", () => {
 });
 
 describe("QueryStats - getStatusText", () => {
-  it("returns a string containing the working verb", () => {
+  it("uses a verb from pickWorkingVerb", () => {
+    const verb = "Welding";
+    vi.spyOn(display, "pickWorkingVerb").mockReturnValueOnce(verb);
     const stats = new QueryStats();
-    const text = stripAnsi(stats.getStatusText("Thinking"));
-    expect(text).toContain("Thinking");
+    expect(stripAnsi(stats.getStatusText())).toContain(verb);
   });
 
   it("includes elapsed time", () => {
@@ -195,27 +197,23 @@ describe("QueryStats - getStatusText", () => {
     const start = Date.now();
     const stats = new QueryStats(start);
     vi.advanceTimersByTime(5000);
-    const text = stripAnsi(stats.getStatusText("Working"));
-    expect(text).toContain("5s");
+    expect(stripAnsi(stats.getStatusText())).toContain("5s");
   });
 
   it("includes turn count after message_start", () => {
     const stats = new QueryStats();
     stats.update({ type: "message_start", message: { usage: { input_tokens: 10 } } });
-    const text = stripAnsi(stats.getStatusText("Working"));
-    expect(text).toContain("1 turn");
+    expect(stripAnsi(stats.getStatusText())).toContain("1 turn");
   });
 
   it("includes output token count after message_delta", () => {
     const stats = new QueryStats();
     stats.update({ type: "message_delta", usage: { output_tokens: 500 } });
-    const text = stripAnsi(stats.getStatusText("Working"));
-    expect(text).toContain("500");
+    expect(stripAnsi(stats.getStatusText())).toContain("500");
   });
 
   it("omits turn count before first message_start (turns=0)", () => {
     const stats = new QueryStats();
-    const text = stripAnsi(stats.getStatusText("Working"));
-    expect(text).not.toContain("turn");
+    expect(stripAnsi(stats.getStatusText())).not.toContain("turn");
   });
 });

--- a/tests/repl.query-stats.test.ts
+++ b/tests/repl.query-stats.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { QueryStats } from "../src/agent/query-stats.js";
+import { stripAnsi } from "./helpers.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("QueryStats - initial state", () => {
+  it("starts with zero turns", () => {
+    const stats = new QueryStats();
+    expect(stats.turns).toBe(0);
+  });
+
+  it("starts with zero inputTokens", () => {
+    const stats = new QueryStats();
+    expect(stats.inputTokens).toBe(0);
+  });
+
+  it("starts with zero outputTokens", () => {
+    const stats = new QueryStats();
+    expect(stats.outputTokens).toBe(0);
+  });
+
+  it("elapsedSecs is 0 at creation (using fixed startTime)", () => {
+    vi.useFakeTimers();
+    const now = Date.now();
+    const stats = new QueryStats(now);
+    expect(stats.elapsedSecs).toBe(0);
+  });
+});
+
+describe("QueryStats - message_start", () => {
+  it("increments turns on message_start", () => {
+    const stats = new QueryStats();
+    stats.update({ type: "message_start", message: { usage: { input_tokens: 50 } } });
+    expect(stats.turns).toBe(1);
+  });
+
+  it("accumulates inputTokens across multiple message_start events", () => {
+    const stats = new QueryStats();
+    stats.update({ type: "message_start", message: { usage: { input_tokens: 100 } } });
+    stats.update({ type: "message_start", message: { usage: { input_tokens: 200 } } });
+    expect(stats.inputTokens).toBe(300);
+  });
+
+  it("treats missing input_tokens as 0", () => {
+    const stats = new QueryStats();
+    stats.update({ type: "message_start" });
+    expect(stats.inputTokens).toBe(0);
+    expect(stats.turns).toBe(1);
+  });
+
+  it("emits change on message_start", () => {
+    const stats = new QueryStats();
+    const onChange = vi.fn();
+    stats.on("change", onChange);
+    stats.update({ type: "message_start", message: { usage: { input_tokens: 10 } } });
+    expect(onChange).toHaveBeenCalledOnce();
+  });
+});
+
+describe("QueryStats - message_delta", () => {
+  it("tracks current output tokens on message_delta", () => {
+    const stats = new QueryStats();
+    stats.update({ type: "message_delta", usage: { output_tokens: 30 } });
+    expect(stats.outputTokens).toBe(30);
+  });
+
+  it("replaces (not adds) current output tokens on successive deltas", () => {
+    const stats = new QueryStats();
+    stats.update({ type: "message_delta", usage: { output_tokens: 20 } });
+    stats.update({ type: "message_delta", usage: { output_tokens: 45 } });
+    expect(stats.outputTokens).toBe(45);
+  });
+
+  it("retains previous value when output_tokens is missing", () => {
+    const stats = new QueryStats();
+    stats.update({ type: "message_delta", usage: { output_tokens: 30 } });
+    stats.update({ type: "message_delta" });
+    expect(stats.outputTokens).toBe(30);
+  });
+
+  it("emits change on message_delta", () => {
+    const stats = new QueryStats();
+    const onChange = vi.fn();
+    stats.on("change", onChange);
+    stats.update({ type: "message_delta", usage: { output_tokens: 10 } });
+    expect(onChange).toHaveBeenCalledOnce();
+  });
+});
+
+describe("QueryStats - message_stop", () => {
+  it("commits current output tokens to completed on message_stop", () => {
+    const stats = new QueryStats();
+    stats.update({ type: "message_delta", usage: { output_tokens: 50 } });
+    stats.update({ type: "message_stop" });
+    expect(stats.outputTokens).toBe(50);
+  });
+
+  it("resets current output tokens to 0 after message_stop", () => {
+    const stats = new QueryStats();
+    stats.update({ type: "message_delta", usage: { output_tokens: 50 } });
+    stats.update({ type: "message_stop" });
+    // Start a new delta — it should add on top of committed 50
+    stats.update({ type: "message_delta", usage: { output_tokens: 20 } });
+    expect(stats.outputTokens).toBe(70);
+  });
+
+  it("accumulates completed output tokens across multiple messages", () => {
+    const stats = new QueryStats();
+    // First message
+    stats.update({ type: "message_delta", usage: { output_tokens: 50 } });
+    stats.update({ type: "message_stop" });
+    // Second message
+    stats.update({ type: "message_delta", usage: { output_tokens: 30 } });
+    stats.update({ type: "message_stop" });
+    expect(stats.outputTokens).toBe(80);
+  });
+
+  it("emits change on message_stop", () => {
+    const stats = new QueryStats();
+    const onChange = vi.fn();
+    stats.on("change", onChange);
+    stats.update({ type: "message_stop" });
+    expect(onChange).toHaveBeenCalledOnce();
+  });
+});
+
+describe("QueryStats - unrecognized events", () => {
+  it("does not emit change for unknown event types", () => {
+    const stats = new QueryStats();
+    const onChange = vi.fn();
+    stats.on("change", onChange);
+    stats.update({ type: "content_block_delta" });
+    stats.update({ type: "content_block_start" });
+    stats.update({ type: "ping" });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("does not change any stats for unknown event types", () => {
+    const stats = new QueryStats();
+    stats.update({ type: "unknown_event" });
+    expect(stats.turns).toBe(0);
+    expect(stats.inputTokens).toBe(0);
+    expect(stats.outputTokens).toBe(0);
+  });
+});
+
+describe("QueryStats - multi-turn accumulation", () => {
+  it("correctly accumulates stats across two full message cycles", () => {
+    const stats = new QueryStats();
+    // Turn 1
+    stats.update({ type: "message_start", message: { usage: { input_tokens: 100 } } });
+    stats.update({ type: "message_delta", usage: { output_tokens: 50 } });
+    stats.update({ type: "message_stop" });
+    // Turn 2
+    stats.update({ type: "message_start", message: { usage: { input_tokens: 200 } } });
+    stats.update({ type: "message_delta", usage: { output_tokens: 30 } });
+    stats.update({ type: "message_stop" });
+
+    expect(stats.turns).toBe(2);
+    expect(stats.inputTokens).toBe(300);
+    expect(stats.outputTokens).toBe(80);
+  });
+});
+
+describe("QueryStats - elapsedSecs", () => {
+  it("reports elapsed seconds relative to startTime", () => {
+    vi.useFakeTimers();
+    const start = Date.now();
+    const stats = new QueryStats(start);
+    vi.advanceTimersByTime(3000);
+    expect(stats.elapsedSecs).toBe(3);
+  });
+
+  it("floors elapsed time (does not round up)", () => {
+    vi.useFakeTimers();
+    const start = Date.now();
+    const stats = new QueryStats(start);
+    vi.advanceTimersByTime(2900);
+    expect(stats.elapsedSecs).toBe(2);
+  });
+});
+
+describe("QueryStats - getStatusText", () => {
+  it("returns a string containing the working verb", () => {
+    const stats = new QueryStats();
+    const text = stripAnsi(stats.getStatusText("Thinking"));
+    expect(text).toContain("Thinking");
+  });
+
+  it("includes elapsed time", () => {
+    vi.useFakeTimers();
+    const start = Date.now();
+    const stats = new QueryStats(start);
+    vi.advanceTimersByTime(5000);
+    const text = stripAnsi(stats.getStatusText("Working"));
+    expect(text).toContain("5s");
+  });
+
+  it("includes turn count after message_start", () => {
+    const stats = new QueryStats();
+    stats.update({ type: "message_start", message: { usage: { input_tokens: 10 } } });
+    const text = stripAnsi(stats.getStatusText("Working"));
+    expect(text).toContain("1 turn");
+  });
+
+  it("includes output token count after message_delta", () => {
+    const stats = new QueryStats();
+    stats.update({ type: "message_delta", usage: { output_tokens: 500 } });
+    const text = stripAnsi(stats.getStatusText("Working"));
+    expect(text).toContain("500");
+  });
+
+  it("omits turn count before first message_start (turns=0)", () => {
+    const stats = new QueryStats();
+    const text = stripAnsi(stats.getStatusText("Working"));
+    expect(text).not.toContain("turn");
+  });
+});


### PR DESCRIPTION
## Summary

- Extracts a `QueryStats` class (`src/agent/query-stats.ts`) from the inline stat-tracking logic in `runQuery`
- The class owns `turns`, `inputTokens`, `completedOutputTokens`, and `currentOutputTokens`, plus `startTime`
- Exposes an `update(event)` method that processes `message_start`, `message_delta`, and `message_stop` stream events and emits `"change"` on each stat-bearing event — consistent with the `AgentStatus` reactive model pattern
- Exposes `getStatusText(workingVerb)` for status bar rendering, replacing the `getStatusText` closure in `runQuery`
- 26 new unit tests covering initial state, per-event-type behavior, multi-turn accumulation, elapsed time, and status text formatting

## Test plan

- [ ] `npm test` passes (all non-DB tests)
- [ ] `npx tsc --noEmit` clean
- [ ] Existing `repl.query.test.ts` tests still pass (stat accumulation behavior unchanged)

Closes #624

🤖 Generated with [Claude Code](https://claude.com/claude-code)