### PR TITLE
docs: update wire type location to shared/wire.ts

### DIFF
--- a/docs/type-system.md
+++ b/docs/type-system.md
@@ -101,6 +101,6 @@ Payload types within the union reference the shared Wire interfaces directly rat
 | What | Where |
 |---|---|
 | Server model classes | `src/foreman/models/*.ts` |
-| Wire interfaces and protocol unions | `src/wire.ts` |
+| Wire interfaces and protocol unions | `shared/wire.ts` |
 | Shared domain types (enums, value objects) | `shared/types.ts` |
 | Frontend-only UI state | `frontend/src/` (local, not in wire.ts) |


### PR DESCRIPTION
Updates the "Where things live" table in `docs/type-system.md` to reflect the agreed location of `shared/wire.ts` (per #630) rather than `src/wire.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)