### PR TITLE
fix: use id: undefined instead of id: 0 for unsaved WebhookEvent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ MVC structure. Models own state; controllers handle external inputs.
 
 - **Models** (`models/`) — `Task` is the active-record for tasks. `WebhookEvent` is the active-record for incoming GitHub webhook events (`webhook_events` table); `WebhookEvent.fromIncoming()` builds an in-memory instance and `toWorkerPayload()` maps `eventName` → `name` for the wire protocol. `ForemanMessage` is the active-record for foreman↔worker messages (`foreman_messages` table); `ForemanMessage.buildSummary()` is the single source of truth for log entry summaries. `queryActivityLog()` (in `activity-log.ts`) merges both tables by timestamp. `TaskManager` owns ephemeral in-memory state only (event queues, branch mappings, blocker state). `Worker` is the active-record for connected workers (module-level registry, static finders, `Worker._reset()` for test isolation).
 - **Controllers** (`controllers/`) — `http-server.ts` handles webhooks + REST + SPA. `wss.ts` handles the WebSocket lifecycle with workers. `event-router.ts` routes GitHub events to the right worker or queue.
-- **Infrastructure** — `db-client.ts` wires the shared Supabase client. `admin-ws.ts` broadcasts to the admin dashboard. `github.ts` wraps GitHub API calls.
+- **Infrastructure** — `db-client.ts` wires the shared Supabase client and exports `DbRow<T>`, a helper type that makes `id` optional for in-memory (unsaved) model instances. `admin-ws.ts` broadcasts to the admin dashboard. `github.ts` wraps GitHub API calls.
 
 ### Agent/Worker (`src/agent/`)
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -25,7 +25,7 @@ export interface WorkerSnapshot {
 
 export interface LogEntry {
   kind: "webhook" | "message";
-  id: number;
+  id: number | undefined;
   timestamp: string;
   taskId: string | null;
   workerId: string | null;

--- a/src/foreman/admin-ws.ts
+++ b/src/foreman/admin-ws.ts
@@ -5,7 +5,7 @@ import type { TaskStatus } from "../../shared/types.js";
 
 export interface LogEntry {
   kind: string;
-  id: number;
+  id: number | undefined;
   timestamp: string;
   taskId: string | null;
   workerId: string | null;

--- a/src/foreman/db-client.ts
+++ b/src/foreman/db-client.ts
@@ -6,3 +6,7 @@ export let db: SupabaseClient<Database>;
 export function initDb(supabase: SupabaseClient<Database>): void {
   db = supabase;
 }
+
+/** DB row type for a table, with `id` made optional for in-memory (unsaved) instances. */
+export type DbRow<T extends keyof Database["public"]["Tables"]> =
+  Omit<Database["public"]["Tables"][T]["Row"], "id"> & { id?: number };

--- a/src/foreman/models/webhook-event.ts
+++ b/src/foreman/models/webhook-event.ts
@@ -8,7 +8,7 @@ type DbRow = Database["public"]["Tables"]["webhook_events"]["Row"];
 // ── Model ──────────────────────────────────────────────────────────────────────
 
 export class WebhookEvent {
-  readonly id: number;
+  readonly id: number | undefined;
   readonly deliveryId: string | null;
   readonly eventName: string;
   readonly action: string | null;
@@ -22,7 +22,7 @@ export class WebhookEvent {
   readonly payload: Record<string, unknown>;
   readonly receivedAt: string;
 
-  private constructor(row: DbRow) {
+  private constructor(row: Omit<DbRow, "id"> & { id?: number }) {
     this.id = row.id;
     this.deliveryId = row.delivery_id;
     this.eventName = row.event_name;
@@ -53,7 +53,6 @@ export class WebhookEvent {
     const sender = typeof (payload.sender as R | undefined)?.login === "string"
       ? (payload.sender as R).login as string : null;
     return new WebhookEvent({
-      id: 0,
       delivery_id: deliveryId,
       event_name: eventName,
       action,

--- a/src/foreman/models/webhook-event.ts
+++ b/src/foreman/models/webhook-event.ts
@@ -1,9 +1,10 @@
-import type { Database, Json } from "../../database.types.js";
+import type { Json } from "../../database.types.js";
 import { db } from "../db-client.js";
+import type { DbRow } from "../db-client.js";
 import { fmtEvent } from "../event-fmt.js";
 import * as Wire from "../../wire.js";
 
-type DbRow = Database["public"]["Tables"]["webhook_events"]["Row"];
+type Row = DbRow<"webhook_events">;
 
 // ── Model ──────────────────────────────────────────────────────────────────────
 
@@ -22,7 +23,7 @@ export class WebhookEvent {
   readonly payload: Record<string, unknown>;
   readonly receivedAt: string;
 
-  private constructor(row: Omit<DbRow, "id"> & { id?: number }) {
+  private constructor(row: Row) {
     this.id = row.id;
     this.deliveryId = row.delivery_id;
     this.eventName = row.event_name;

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -159,6 +159,13 @@ describe("ForemanMessage.buildSummary richer summaries", () => {
   });
 });
 
+describe("WebhookEvent.fromIncoming", () => {
+  it("produces an in-memory instance with id undefined", () => {
+    const evt = WebhookEvent.fromIncoming("d1", "issues", { action: "labeled" });
+    expect(evt.id).toBeUndefined();
+  });
+});
+
 describe("WebhookEvent.format (richer summaries)", () => {
   function fmt(eventName: string, payload: Record<string, unknown>): string {
     return WebhookEvent.fromIncoming("test", eventName, payload).format();


### PR DESCRIPTION
## Summary

- `WebhookEvent.id` is now `number | undefined` — `undefined` means the record is unsaved (not yet persisted to DB), which is the correct semantic vs. the previous sentinel `0`
- Constructor updated to accept `Omit<DbRow, "id"> & { id?: number }` so `fromIncoming()` can simply omit `id`
- `LogEntry.id` updated to `number | undefined` in both server (`admin-ws.ts`) and frontend (`frontend/src/types.ts`) types
- Added test asserting `WebhookEvent.fromIncoming()` produces `id === undefined`

## Test plan

- [ ] `npm test` passes (all 1313 non-DB tests pass)
- [ ] `npx tsc --noEmit` passes with no errors
- [ ] `npm run lint` passes

Closes #629