### PR TITLE
refactor: consolidate createHttpServer args to a single options object

### DIFF
--- a/src/foreman/controllers/http-server.ts
+++ b/src/foreman/controllers/http-server.ts
@@ -18,11 +18,13 @@ function printEvent(id: string, name: string, payload: unknown) {
   flog(summaryEvent(id, name, payload));
 }
 
-export function createHttpServer(
-  webhooks: InstanceType<typeof Webhooks> | null,
-  routeEvent: (id: string, name: string, payload: unknown) => void | Promise<void>,
-  taskManager?: TaskManager,
-): http.Server {
+export interface HttpServerOptions {
+  webhooks: InstanceType<typeof Webhooks> | null;
+  routeEvent: (id: string, name: string, payload: unknown) => void | Promise<void>;
+  taskManager?: TaskManager;
+}
+
+export function createHttpServer({ webhooks, routeEvent, taskManager }: HttpServerOptions): http.Server {
   const app = new Hono();
 
   // ── Webhook ────────────────────────────────────────────────────────────────

--- a/src/foreman/index.ts
+++ b/src/foreman/index.ts
@@ -44,7 +44,7 @@ if (isMain) {
   initDb(supabase);
 
   let foremanWss: ForemanWss;
-  const server = createHttpServer(webhooks, (id, name, payload) => foremanWss.routeEvent(id, name, payload), taskManager);
+  const server = createHttpServer({ webhooks, routeEvent: (id, name, payload) => foremanWss.routeEvent(id, name, payload), taskManager });
 
   // Admin WebSocket broadcaster
   const adminWss = createAdminWss(server, async () => ({

--- a/tests/browser/server.ts
+++ b/tests/browser/server.ts
@@ -64,10 +64,10 @@ const mockWorkers = new Map<string, WebSocket>();
 let foremanWss: ReturnType<typeof createForemanWss>;
 
 // Build the foreman HTTP server (handles /webhook, /health, /api/*, static dist/)
-const server = createHttpServer(
-  null,
-  (id, name, payload) => foremanWss.routeEvent(id, name, payload),
-);
+const server = createHttpServer({
+  webhooks: null,
+  routeEvent: (id, name, payload) => foremanWss.routeEvent(id, name, payload),
+});
 
 // Intercept the request event so we can add /test/* routes without touching
 // the production createHttpServer factory.

--- a/tests/foreman.http.test.ts
+++ b/tests/foreman.http.test.ts
@@ -75,7 +75,7 @@ let routeEvent: ReturnType<typeof vi.fn>;
 beforeEach(async () => {
   routeEvent = vi.fn();
   vi.mocked(queryActivityLog).mockResolvedValue([]);
-  server = createHttpServer(null, routeEvent);
+  server = createHttpServer({ webhooks: null, routeEvent });
   port = await startServer(server);
 });
 
@@ -194,7 +194,7 @@ describe("GET /api/tasks", () => {
     const t2 = await Task.upsert("2", 2, "test/repo", "Done bug", "Description", []);
     await t2.complete();
 
-    const s = createHttpServer(null, vi.fn(), tm);
+    const s = createHttpServer({ webhooks: null, routeEvent: vi.fn(), taskManager: tm });
     const p = await startServer(s);
     try {
       const res = await request(p, "GET", "/api/tasks");
@@ -222,7 +222,7 @@ describe("GET /api/tasks", () => {
     const t = await Task.upsert("42", 42, "test/repo", "Fix bug", "Description", []);
     await t.complete();
 
-    const s = createHttpServer(null, vi.fn(), tm);
+    const s = createHttpServer({ webhooks: null, routeEvent: vi.fn(), taskManager: tm });
     const p = await startServer(s);
     try {
       const res = await request(p, "GET", "/api/tasks?status=complete");
@@ -244,7 +244,7 @@ describe("GET /api/tasks", () => {
     await t1.complete();
     await Task.upsert("2", 2, "test/repo", "T2", "b", []);
 
-    const s = createHttpServer(null, vi.fn(), tm);
+    const s = createHttpServer({ webhooks: null, routeEvent: vi.fn(), taskManager: tm });
     const p = await startServer(s);
     try {
       const res = await request(p, "GET", "/api/tasks?status=complete");


### PR DESCRIPTION
## Summary

- Changes `createHttpServer` to accept a single `{ webhooks, routeEvent, taskManager }` options object instead of 4 positional args
- Exports a new `HttpServerOptions` interface from `http-server.ts`
- Updates all call sites: `src/foreman/index.ts`, `tests/foreman.http.test.ts`, `tests/browser/server.ts`

Closes #615