### PR TITLE
refactor: consolidate TaskRow into Wire.Task

### DIFF
--- a/docs/type-system.md
+++ b/docs/type-system.md
@@ -58,9 +58,10 @@ export interface Task {
   prNumber?: number;
   prUrl?: string;
   blockers?: BlockerInfo[];
-  // detail fields only present in REST responses:
-  body?: string;
+  // Extended fields — present in REST responses, optional in WebSocket snapshots
+  repo?: string;
   branch?: string;
+  createdAt?: string;
   assignedAt?: string;
   completedAt?: string;
 }

--- a/frontend/src/pages/TaskList.tsx
+++ b/frontend/src/pages/TaskList.tsx
@@ -1,20 +1,20 @@
 import { useState, useEffect, useCallback } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import { useAdminWs } from "../hooks/useAdminWs.ts";
-import type { AdminMessage, TaskRow, TaskStatus } from "../types.ts";
+import type { AdminMessage, Task, TaskStatus } from "../types.ts";
 import { shortWorkerId } from "../../../shared/utils.ts";
 
 export default function TaskList() {
   const [searchParams, setSearchParams] = useSearchParams();
   const statusFilter = (searchParams.get("status") ?? "all") as "all" | TaskStatus;
-  const [tasks, setTasks] = useState<TaskRow[]>([]);
+  const [tasks, setTasks] = useState<Task[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const url = statusFilter === "all" ? "/api/tasks" : `/api/tasks?status=${statusFilter}`;
     setLoading(true);
     fetch(url)
-      .then((r) => r.json() as Promise<TaskRow[]>)
+      .then((r) => r.json() as Promise<Task[]>)
       .then((data) => { setTasks(data); setLoading(false); })
       .catch((err) => { console.error(err); setLoading(false); });
   }, [statusFilter]);
@@ -79,13 +79,13 @@ export default function TaskList() {
                 <td style={td}><Link to={`/tasks/${t.taskId}`}>#{t.issueNumber}</Link></td>
                 <td style={td}>{t.title}</td>
                 <td style={td}>{t.status}</td>
-                <td style={td}>{t.workerId
-                  ? <Link to={`/workers/${t.workerId}`}>{shortWorkerId(t.workerId)}</Link>
+                <td style={td}>{t.assignedWorkerId
+                  ? <Link to={`/workers/${t.assignedWorkerId}`}>{shortWorkerId(t.assignedWorkerId)}</Link>
                   : "—"}</td>
-                <td style={td}>{t.prNumber
-                  ? <a href={`https://github.com/${t.repo}/pull/${t.prNumber}`} target="_blank" rel="noreferrer">#{t.prNumber}</a>
+                <td style={td}>{t.prUrl
+                  ? <a href={t.prUrl} target="_blank" rel="noreferrer">#{t.prNumber}</a>
                   : "—"}</td>
-                <td style={td}>{new Date(t.createdAt).toLocaleString()}</td>
+                <td style={td}>{t.createdAt ? new Date(t.createdAt).toLocaleString() : "—"}</td>
                 <td style={td}>{t.completedAt ? new Date(t.completedAt).toLocaleString() : "—"}</td>
               </tr>
             ))}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,17 +1,2 @@
-import type { TaskStatus } from "../../shared/types.ts";
-export type { TaskStatus };
+export type { TaskStatus } from "../../shared/types.ts";
 export type { Task, Worker, LogEntry, AdminMessage, BlockerInfo } from "../../shared/wire.ts";
-
-export interface TaskRow {
-  taskId: string;
-  issueNumber: number;
-  repo: string;
-  title: string;
-  status: TaskStatus;
-  workerId: string | null;
-  prNumber: number | null;
-  branch: string | null;
-  createdAt: string;
-  assignedAt: string | null;
-  completedAt: string | null;
-}

--- a/frontend/tests/TaskList.test.tsx
+++ b/frontend/tests/TaskList.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor, act } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import TaskList from "../src/pages/TaskList.tsx";
-import type { AdminMessage, TaskRow } from "../src/types.ts";
+import type { AdminMessage, Task } from "../src/types.ts";
 
 let capturedHandler: ((msg: AdminMessage) => void) | null = null;
 
@@ -12,18 +12,17 @@ vi.mock("../src/hooks/useAdminWs.ts", () => ({
   },
 }));
 
-const assignedTask: TaskRow = {
+const assignedTask: Task = {
   taskId: "42",
   issueNumber: 42,
-  repo: "owner/repo",
   title: "Fix the bug",
   status: "assigned",
-  workerId: "worker-abc-123",
-  prNumber: null,
-  branch: null,
+  assignedWorkerId: "worker-abc-123",
+  repo: "owner/repo",
+  branch: undefined,
   createdAt: "2026-01-01T00:00:00.000Z",
   assignedAt: "2026-01-01T01:00:00.000Z",
-  completedAt: null,
+  completedAt: undefined,
 };
 
 function renderTaskList() {

--- a/shared/wire.ts
+++ b/shared/wire.ts
@@ -20,6 +20,12 @@ export interface Task {
   prNumber?: number;
   prUrl?: string;
   blockers?: BlockerInfo[];
+  // Extended fields — present in REST responses, optional in WebSocket snapshots
+  repo?: string;
+  branch?: string;
+  createdAt?: string;
+  assignedAt?: string;
+  completedAt?: string;
 }
 
 /** Wire representation of a connected worker — sent over the admin WebSocket. */

--- a/src/foreman/controllers/http-server.ts
+++ b/src/foreman/controllers/http-server.ts
@@ -103,10 +103,10 @@ export function createHttpServer({ webhooks, routeEvent, taskManager }: HttpServ
     try {
       const statusFilter = c.req.query("status") as TaskStatus | undefined;
       const tasks = taskManager ? await Task.list() : [];
-      if (statusFilter) {
-        return c.json(tasks.filter((t) => t.status === statusFilter));
-      }
-      return c.json(tasks.filter((t) => t.status !== "complete"));
+      const filtered = statusFilter
+        ? tasks.filter((t) => t.status === statusFilter)
+        : tasks.filter((t) => t.status !== "complete");
+      return c.json(filtered.map((t) => t.toWire()));
     } catch (err) {
       flog(`ERROR API query failed: ${fmtError(err)}`);
       return c.json({ error: "internal error" }, 500);

--- a/src/foreman/models/task-manager.ts
+++ b/src/foreman/models/task-manager.ts
@@ -160,7 +160,7 @@ export class TaskManager extends EventEmitter {
     const tasks = await Task.list();
     return tasks.filter((t) => !t.completedAt).map((t) => {
       this.hydrateBlockers(t);
-      return t.toSnapshot();
+      return t.toWire();
     });
   }
 

--- a/src/foreman/models/task.ts
+++ b/src/foreman/models/task.ts
@@ -62,27 +62,7 @@ export class Task {
     return `https://github.com/${this.repo}`;
   }
 
-  toJSON() {
-    return {
-      taskId: this.taskId,
-      issueNumber: this.issueNumber,
-      repo: this.repo,
-      title: this.title,
-      body: this.body,
-      labels: this.labels,
-      status: this.status,
-      workerId: this.workerId,
-      prNumber: this.prNumber,
-      branch: this.branch,
-      createdAt: this.createdAt,
-      assignedAt: this.assignedAt,
-      completedAt: this.completedAt,
-      issueClosedAt: this.issueClosedAt,
-      prMergedAt: this.prMergedAt,
-    };
-  }
-
-  toSnapshot(): Wire.Task {
+  toWire(): Wire.Task {
     return {
       taskId: this.taskId,
       issueNumber: this.issueNumber,
@@ -92,6 +72,11 @@ export class Task {
       prNumber: this.prNumber ?? undefined,
       prUrl: this.prNumber != null ? `https://github.com/${this.repo}/pull/${this.prNumber}` : undefined,
       blockers: this.blockers,
+      repo: this.repo,
+      branch: this.branch ?? undefined,
+      createdAt: this.createdAt,
+      assignedAt: this.assignedAt ?? undefined,
+      completedAt: this.completedAt ?? undefined,
     };
   }
 

--- a/tests/foreman.http.test.ts
+++ b/tests/foreman.http.test.ts
@@ -206,9 +206,9 @@ describe("GET /api/tasks", () => {
         taskId: "1",
         repo: "test/repo",
         status: "pending",
-        workerId: null,
-        completedAt: null,
       });
+      expect(body[0].assignedWorkerId).toBeUndefined();
+      expect(body[0].completedAt).toBeUndefined();
     } finally {
       vi.restoreAllMocks();
       await stopServer(s);


### PR DESCRIPTION
## Summary

- Extended `Wire.Task` in `shared/wire.ts` with optional fields (`repo?`, `branch?`, `createdAt?`, `assignedAt?`, `completedAt?`) to cover what `TaskRow` had
- Renamed `Task.toSnapshot()` → `Task.toWire()` and added the new optional fields to its return value; removed the now-redundant `toJSON()` method
- Updated the `/api/tasks` REST endpoint to serialize via `toWire()` so both WebSocket and HTTP responses use the same unified `Wire.Task` type
- Dropped `TaskRow` from `frontend/src/types.ts` and updated `TaskList.tsx` and its test to use `Wire.Task` (`assignedWorkerId` instead of `workerId`, `prUrl` instead of constructing it from `repo`)

## Test plan

- [ ] `npm test` passes (all 1381 non-DB tests green)
- [ ] `npx tsc --noEmit` passes with no errors
- [ ] `npm run lint` passes with no warnings
- [ ] `npm run smoke` — foreman and worker connect successfully
- [ ] Admin dashboard TaskList shows tasks with correct worker links and PR links

Closes #631

🤖 Generated with [Claude Code](https://claude.com/claude-code)