### PR TITLE
refactor: rename Worker.toSnapshot() → toWire() and getTaskSnapshots() → getTasksForBroadcast()

### DIFF
--- a/src/foreman/controllers/wss.ts
+++ b/src/foreman/controllers/wss.ts
@@ -208,8 +208,8 @@ export class ForemanWss {
     async function broadcastSnapshot() {
       if (!adminWss) return;
       adminWss.broadcastSnapshot({
-        tasks: await taskManager.getTaskSnapshots(),
-        workers: Worker.all().map((w) => w.toSnapshot()),
+        tasks: await taskManager.getTasksForBroadcast(),
+        workers: Worker.all().map((w) => w.toWire()),
       });
     }
 

--- a/src/foreman/index.ts
+++ b/src/foreman/index.ts
@@ -47,8 +47,8 @@ if (isMain) {
 
   // Admin WebSocket broadcaster
   const adminWss = createAdminWss(server, async () => ({
-    tasks: await taskManager.getTaskSnapshots(),
-    workers: Worker.all().map((w) => w.toSnapshot()),
+    tasks: await taskManager.getTasksForBroadcast(),
+    workers: Worker.all().map((w) => w.toWire()),
   }));
 
   foremanWss = new ForemanWss({ config, taskManager, server, adminWss });

--- a/src/foreman/models/task-manager.ts
+++ b/src/foreman/models/task-manager.ts
@@ -154,9 +154,9 @@ export class TaskManager extends EventEmitter {
     return blockers.some(b => this._openIssues.has(b));
   }
 
-  /** Task snapshots with open-issue state baked in — for admin broadcasts.
+  /** Active tasks with open-issue state baked in — for admin broadcasts.
    *  Complete tasks are excluded: the dashboard only shows active tasks. */
-  async getTaskSnapshots(): Promise<Wire.Task[]> {
+  async getTasksForBroadcast(): Promise<Wire.Task[]> {
     const tasks = await Task.list();
     return tasks.filter((t) => !t.completedAt).map((t) => {
       this.hydrateBlockers(t);

--- a/src/foreman/models/worker.ts
+++ b/src/foreman/models/worker.ts
@@ -86,7 +86,7 @@ export class Worker {
     return false;
   }
 
-  toSnapshot(): Wire.Worker {
+  toWire(): Wire.Worker {
     return {
       workerId: this.workerId,
       status: this.status,

--- a/tests/browser/server.ts
+++ b/tests/browser/server.ts
@@ -141,8 +141,8 @@ async function handleTestRoute(
 // ── Admin WebSocket ───────────────────────────────────────────────────────────
 
 const adminWss = createAdminWss(server, async () => ({
-  tasks: await taskModel.getTaskSnapshots(),
-  workers: Worker.all().map((w) => w.toSnapshot()),
+  tasks: await taskModel.getTasksForBroadcast(),
+  workers: Worker.all().map((w) => w.toWire()),
 }));
 
 // ── Foreman WebSocket ─────────────────────────────────────────────────────────

--- a/tests/foreman.blockers.test.ts
+++ b/tests/foreman.blockers.test.ts
@@ -36,7 +36,7 @@ describe("foreman — blocker transitions via routeEvent", () => {
     const { wss } = new ForemanWss({ taskManager, server, config: { ...defaultCfg, taskLabel: "brunel:ready", workerReclaimTimeoutMs: 300_000 } });
     wss.close();
 
-    const snapshots = await taskManager.getTaskSnapshots();
+    const snapshots = await taskManager.getTasksForBroadcast();
     expect(snapshots[0].status).toBe("blocked");
   });
 
@@ -53,7 +53,7 @@ describe("foreman — blocker transitions via routeEvent", () => {
     wss.close();
 
     // Initially blocked
-    const snapshots1 = await taskManager.getTaskSnapshots();
+    const snapshots1 = await taskManager.getTasksForBroadcast();
     expect(snapshots1[0].status).toBe("blocked");
 
     // Close the blocker
@@ -63,7 +63,7 @@ describe("foreman — blocker transitions via routeEvent", () => {
     });
 
     // Now pending
-    const snapshots2 = await taskManager.getTaskSnapshots();
+    const snapshots2 = await taskManager.getTasksForBroadcast();
     expect(snapshots2[0].status).toBe("pending");
   });
 
@@ -82,7 +82,7 @@ describe("foreman — blocker transitions via routeEvent", () => {
     wss.close();
 
     // Initially blocked
-    const snapshots1 = await taskManager.getTaskSnapshots();
+    const snapshots1 = await taskManager.getTasksForBroadcast();
     expect(snapshots1[0].status).toBe("blocked");
 
     // Close issue 5 — but 6 is still open
@@ -92,7 +92,7 @@ describe("foreman — blocker transitions via routeEvent", () => {
     });
 
     // Task remains blocked (6 is still open)
-    const snapshots2 = await taskManager.getTaskSnapshots();
+    const snapshots2 = await taskManager.getTasksForBroadcast();
     expect(snapshots2[0].status).toBe("blocked");
   });
 });

--- a/tests/foreman.registry.test.ts
+++ b/tests/foreman.registry.test.ts
@@ -74,10 +74,10 @@ describe("Worker", () => {
     expect(result).toBe(true);
   });
 
-  it("toSnapshot returns WorkerSnapshot", () => {
+  it("toWire returns WorkerSnapshot", () => {
     const w = Worker.register("w1", fakeWs());
     w.assign("42");
-    expect(w.toSnapshot()).toEqual({ workerId: "w1", status: "busy", currentTaskId: "42" });
+    expect(w.toWire()).toEqual({ workerId: "w1", status: "busy", currentTaskId: "42" });
   });
 
   describe("markDisconnected", () => {
@@ -117,7 +117,7 @@ describe("Worker", () => {
       const w = Worker.register("w1", fakeWs());
       w.assign("42");
       w.markDisconnected();
-      const snapshots = Worker.all().map(x => x.toSnapshot());
+      const snapshots = Worker.all().map(x => x.toWire());
       expect(snapshots).toHaveLength(1);
       expect(snapshots[0].status).toBe("disconnected");
       expect(snapshots[0].currentTaskId).toBe("42");

--- a/tests/foreman.startup.test.ts
+++ b/tests/foreman.startup.test.ts
@@ -446,7 +446,7 @@ describe("startup — derived blocked status", () => {
     taskManager.setBlockers(42, [5]);
     taskManager.setIssueOpenState(5, false); // issue 5 is closed
 
-    const snapshots = await taskManager.getTaskSnapshots();
+    const snapshots = await taskManager.getTasksForBroadcast();
     expect(snapshots[0].status).toBe("pending");
   });
 
@@ -462,7 +462,7 @@ describe("startup — derived blocked status", () => {
     taskManager.setBlockers(42, [5]);
     taskManager.setIssueOpenState(5, true); // issue 5 is open
 
-    const snapshots = await taskManager.getTaskSnapshots();
+    const snapshots = await taskManager.getTasksForBroadcast();
     expect(snapshots[0].status).toBe("blocked");
   });
 });

--- a/tests/foreman.taskqueue.test.ts
+++ b/tests/foreman.taskqueue.test.ts
@@ -106,41 +106,41 @@ describe("TaskManager — queue operations", () => {
     expect(await m.getTaskForBranch("unknown-branch")).toBeNull();
   });
 
-  it("getTaskSnapshots includes prUrl when PR is registered", async () => {
+  it("getTasksForBroadcast includes prUrl when PR is registered", async () => {
     await Task.upsert("42", 42, repoSlug, "Fix the bug", "It is broken", ["brunel:ready"]);
     const t = await Task.get("42");
     await t!.registerPr(10, null);
-    const snapshots = await m.getTaskSnapshots();
+    const snapshots = await m.getTasksForBroadcast();
     expect(snapshots[0].prUrl).toBe("https://github.com/test/repo/pull/10");
   });
 
-  it("getTaskSnapshots omits prUrl when no PR registered", async () => {
+  it("getTasksForBroadcast omits prUrl when no PR registered", async () => {
     await registerBase();
-    const snapshots = await m.getTaskSnapshots();
+    const snapshots = await m.getTasksForBroadcast();
     expect(snapshots[0].prUrl).toBeUndefined();
   });
 
-  it("getTaskSnapshots includes empty blockers array when no blockers set", async () => {
+  it("getTasksForBroadcast includes empty blockers array when no blockers set", async () => {
     await registerBase();
-    const snapshots = await m.getTaskSnapshots();
+    const snapshots = await m.getTasksForBroadcast();
     expect(snapshots[0].blockers).toEqual([]);
   });
 
-  it("getTaskSnapshots includes blockers with isOpen status", async () => {
+  it("getTasksForBroadcast includes blockers with isOpen status", async () => {
     await registerBase(); // issueNumber: 42
     m.setBlockers(42, [10, 11]);
     m.setIssueOpenState(10, true);  // 10 is open
     m.setIssueOpenState(11, false); // 11 is closed
-    const snapshots = await m.getTaskSnapshots();
+    const snapshots = await m.getTasksForBroadcast();
     expect(snapshots[0].blockers).toEqual([
       { issueNumber: 10, isOpen: true },
       { issueNumber: 11, isOpen: false },
     ]);
   });
 
-  it("getTaskSnapshots shows empty blockers array when no deps set", async () => {
+  it("getTasksForBroadcast shows empty blockers array when no deps set", async () => {
     await registerBase(); // issueNumber: 42, no blockers set
-    const snapshots = await m.getTaskSnapshots();
+    const snapshots = await m.getTasksForBroadcast();
     expect(snapshots[0].blockers).toEqual([]);
   });
 });
@@ -176,21 +176,21 @@ describe("TaskManager — derived blocked status", () => {
     expect(result.map((t) => t.taskId)).not.toContain("3");
   });
 
-  it("getTaskSnapshots derives blocked status when blocker is open", async () => {
+  it("getTasksForBroadcast derives blocked status when blocker is open", async () => {
     await registerBase(); // issueNumber: 42
     m.trackIssue(42);
     m.setBlockers(42, [100]);
     m.markBlockersLoaded(42);
     m.setIssueOpenState(100, true); // blocker is open (not closed)
 
-    const snapshots = await m.getTaskSnapshots();
+    const snapshots = await m.getTasksForBroadcast();
     expect(snapshots[0].status).toBe("blocked");
   });
 
-  it("getTaskSnapshots derives pending status when no blockers", async () => {
+  it("getTasksForBroadcast derives pending status when no blockers", async () => {
     await registerBase(); // issueNumber: 42, no blockers
 
-    const snapshots = await m.getTaskSnapshots();
+    const snapshots = await m.getTasksForBroadcast();
     expect(snapshots[0].status).toBe("pending");
   });
 });


### PR DESCRIPTION
## Summary

- Renames `Worker.toSnapshot()` → `Worker.toWire()` to match the convention established when `Task.toSnapshot()` became `Task.toWire()` in #631
- Renames `TaskManager.getTaskSnapshots()` → `TaskManager.getTasksForBroadcast()` to better describe what the method does
- Updates all call sites in `src/foreman/index.ts`, `src/foreman/controllers/wss.ts`, and all affected test files

## Test plan

- [x] All 1381 unit tests pass
- [x] TypeScript type check passes with no errors
- [x] No remaining references to old names (`toSnapshot`, `getTaskSnapshots`)

Closes #649

🤖 Generated with [Claude Code](https://claude.com/claude-code)