### PR TITLE
refactor: remove workerMode parameter from registerWorkspaceCommands

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -289,7 +289,6 @@ export async function main(
       ? session.workspaceCommandDeps
       : { workspace: workspaceRef, config: workspaceCfg ? { ...workspaceCfg, sessionId: agentId } : undefined, originalCwd, confirm },
     registry.scoped("workspace"),
-    !!session,
   );
   registerWorkerCommands(session, registry.scoped("worker"));
   registry.register("exit", {

--- a/src/agent/workspace.ts
+++ b/src/agent/workspace.ts
@@ -192,17 +192,11 @@ export interface WorkspaceCommandDeps {
 /**
  * Register workspace commands into the given registry (which should already be
  * scoped, e.g. registry.scoped("workspace")). Call this once at startup.
- * If workerMode is true, the create command prints "managed automatically"
- * instead of creating a workspace (workers have their workspace managed by the foreman).
  */
-export function registerWorkspaceCommands(deps: WorkspaceCommandDeps, registry: CommandRegistry, workerMode = false): void {
+export function registerWorkspaceCommands(deps: WorkspaceCommandDeps, registry: CommandRegistry): void {
   registry.register("create", {
     description: "Create an isolated git checkout for this session",
     handler: async () => {
-      if (workerMode) {
-        display.print(display.c.amber("Workspace is managed automatically in worker mode."));
-        return;
-      }
       if (!deps.config) {
         display.print(display.c.boldRed("Cannot create workspace: no GitHub repo configured."));
         return;

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1338,7 +1338,7 @@ describe("workspace slash commands in WorkerSession", () => {
     });
     sessionWs.start();
     const wsReg1 = new CommandRegistry();
-    registerWorkspaceCommands(sessionWs.workspaceCommandDeps, wsReg1.scoped("workspace"), true);
+    registerWorkspaceCommands(sessionWs.workspaceCommandDeps, wsReg1.scoped("workspace"));
     await wsReg1.execute("workspace:reset", "");
     expect(workspace.reset).toHaveBeenCalledOnce();
   });
@@ -1385,16 +1385,25 @@ describe("workspace slash commands in WorkerSession", () => {
     expect(workspace.destroy).toHaveBeenCalledOnce();
   });
 
-  it("/workspace:create prints 'managed automatically' in worker mode", async () => {
+  it("/workspace:create prints 'already exists' when workspace is pre-created", async () => {
     const printSpy = vi.spyOn(displayModule, "print").mockImplementation(() => {});
     try {
-      const sessionWs = new WorkerSession(new AgentStatus(AGENT_ID), wsFactory, display, {});
+      const workspace = makeWorkspace();
+      const sessionWs = new WorkerSession(new AgentStatus(AGENT_ID), wsFactory, display, {
+        workspaceCtx: {
+          workspace,
+          originalCwd: "/original",
+          workspaceDir: "/tmp/workers",
+          repoUrl: "https://token@github.com/owner/repo.git",
+          confirm: vi.fn(),
+        },
+      });
       sessionWs.start();
       const wsReg4 = new CommandRegistry();
-      registerWorkspaceCommands(sessionWs.workspaceCommandDeps, wsReg4.scoped("workspace"), true);
+      registerWorkspaceCommands(sessionWs.workspaceCommandDeps, wsReg4.scoped("workspace"));
       await wsReg4.execute("workspace:create", "");
       const printed = printSpy.mock.calls.map(([s]) => stripAnsi(s as string)).join("\n");
-      expect(printed).toContain("managed automatically");
+      expect(printed).toContain("Workspace already exists");
     } finally {
       printSpy.mockRestore();
     }


### PR DESCRIPTION
## Summary

- Removes the `workerMode` parameter from `registerWorkspaceCommands` in `workspace.ts`
- Drops the `if (workerMode)` guard in the `workspace:create` handler — in worker mode the workspace is always pre-created by `startWorkerMode()`, so `deps.workspace.current` is already set and the existing "Workspace already exists" check handles it
- Drops the `!!session` third argument at the call site in `index.ts`
- Updates tests in `worker.test.ts` to remove the `true` argument and replaces the "managed automatically" test with one that verifies the "Workspace already exists" path

## Test plan

- [ ] `npm test` passes (all 1381 tests)
- [ ] `npx tsc --noEmit` passes

Closes #622