### PR TITLE
refactor: remove re-exports from src/agent/index.ts

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -20,11 +20,6 @@ import { handleEffortCommand } from "./effort.js";
 import type { EffortValue } from "./effort.js";
 import { CommandRegistry } from "./command-registry.js";
 import { QueryStats } from "./query-stats.js";
-export { parseSlashCommand, dispatchInput, matchCommands, ask } from "./input.js";
-export type { SlashCommandResult, DispatchResult } from "./input.js";
-export { handleModelCommand, getCachedModels, _resetCachedModels } from "./model.js";
-export { handleEffortCommand } from "./effort.js";
-
 // ── Log file ──────────────────────────────────────────────────────────────────
 
 const LOG_FILE = "repl.log";

--- a/tests/repl.query.test.ts
+++ b/tests/repl.query.test.ts
@@ -25,7 +25,8 @@ vi.mock("../src/agent/input.js", async (importOriginal) => {
 
 import { PassThrough } from "stream";
 import { query } from "@anthropic-ai/claude-agent-sdk";
-import { runQuery, getCachedModels, _resetCachedModels } from "../src/agent/index.js";
+import { runQuery } from "../src/agent/index.js";
+import { getCachedModels, _resetCachedModels } from "../src/agent/model.js";
 import { ask, pick, pickMultiple, pickQuestion } from "../src/agent/input.js";
 import { toolUseNames, stopStatus, setVerbose } from "../src/agent/display.js";
 


### PR DESCRIPTION
## Summary

- Updated `tests/repl.query.test.ts` to import `getCachedModels` and `_resetCachedModels` directly from `../src/agent/model.js` instead of via the index re-export
- Deleted the 4 re-export lines from `src/agent/index.ts` that served only as pass-throughs for `input.js`, `model.js`, and `effort.js`

## Test plan
- [ ] `npm test` passes (1388 tests, same as before)
- [ ] `npx tsc --noEmit` passes with no errors

Closes #608