### PR TITLE
refactor: fold WorkspaceCommandDeps and WorkspaceCtx into Workspace class

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -255,7 +255,6 @@ export async function main(
 
   let sessionId: string | undefined;
   const originalCwd = process.cwd();
-  const workspaceRef: { current: Workspace | undefined } = { current: undefined };
 
   const confirm = async (msg: string): Promise<boolean> => {
     display.stopStatus();
@@ -264,12 +263,20 @@ export async function main(
     return idx === 0;
   };
 
+  // In REPL mode, create a Workspace (without cloning) if GitHub is configured.
+  // In worker mode, the workspace is owned by the session (already created).
+  const workspace: Workspace | undefined = session
+    ? session.workspace
+    : workspaceCfg
+      ? new Workspace(workspaceCfg.workspaceDir, agentId, workspaceCfg.repoUrl, originalCwd, confirm)
+      : undefined;
+
   // doExit handles REPL workspace cleanup and stdin/stdout teardown.
   // Only called in REPL mode (worker mode cleanup goes through workerCtx.cleanup()).
   const doExit = async () => {
-    if (workspaceRef.current) {
-      const ok = await confirmIfUnsafe(workspaceRef.current, confirm);
-      if (ok) await workspaceRef.current.destroy();
+    if (workspace?.isCreated) {
+      const ok = await confirmIfUnsafe(workspace, workspace.confirm);
+      if (ok) await workspace.destroy();
     }
     process.stdout.write("\x1b[?2004l\r\n");
     if (process.stdin.isTTY) process.stdin.setRawMode(false);
@@ -279,12 +286,7 @@ export async function main(
   // Register all commands. All commands are present in both REPL and worker
   // modes; commands that require a foreman connection degrade gracefully.
   const registry = new CommandRegistry();
-  registerWorkspaceCommands(
-    session
-      ? session.workspaceCommandDeps
-      : { workspace: workspaceRef, config: workspaceCfg ? { ...workspaceCfg, sessionId: agentId } : undefined, originalCwd, confirm },
-    registry.scoped("workspace"),
-  );
+  registerWorkspaceCommands(workspace, registry.scoped("workspace"));
   registerWorkerCommands(session, registry.scoped("worker"));
   registry.register("exit", {
     description: "Exit",

--- a/src/agent/worker.ts
+++ b/src/agent/worker.ts
@@ -9,7 +9,6 @@ import { buildInitialPrompt, buildEventPrompt } from "./templates.js";
 import type { EffortValue } from "./effort.js";
 import * as Wire from "../../shared/wire.js";
 import { Workspace, confirmIfUnsafe } from "./workspace.js";
-import type { WorkspaceCommandDeps } from "./workspace.js";
 import { fmtError } from "../utils.js";
 import type { CommandRegistry } from "./command-registry.js";
 import { pick } from "./input.js";
@@ -183,17 +182,9 @@ export type WorkerDisplay = {
   setOnToolResultCallback?: (fn: ((toolName: string) => void) | null) => void;
 };
 
-export type WorkspaceCtx = {
-  workspace: Workspace;
-  originalCwd: string;
-  workspaceDir: string;
-  repoUrl: string;
-  confirm: (msg: string) => Promise<boolean>;
-};
-
 export type WorkerSessionOptions = {
   afterTask?: () => Promise<void>;
-  workspaceCtx?: WorkspaceCtx;
+  workspace?: Workspace;
   /** Interval in ms between worker-sent pings. Dead connections are detected after
    * one interval with no pong. Default is set in the config schema (pingIntervalMs). */
   pingIntervalMs?: number;
@@ -352,30 +343,9 @@ export class WorkerSession {
     return "task-complete";
   }
 
-  /**
-   * Returns the workspace command deps for use with registerWorkspaceCommands().
-   * Exposes a proxy so workspace mutations from commands update the session state.
-   */
-  get workspaceCommandDeps(): WorkspaceCommandDeps {
-    const self = this;
-    return {
-      workspace: {
-        get current() { return self.options.workspaceCtx?.workspace; },
-        set current(ws: Workspace | undefined) {
-          if (self.options.workspaceCtx) {
-            if (ws) { self.options.workspaceCtx.workspace = ws; }
-            else { self.options.workspaceCtx = undefined; }
-          }
-        },
-      },
-      config: this.options.workspaceCtx ? {
-        workspaceDir: this.options.workspaceCtx.workspaceDir,
-        repoUrl: this.options.workspaceCtx.repoUrl,
-        sessionId: this.agentStatus.agentId,
-      } : undefined,
-      originalCwd: this.options.workspaceCtx?.originalCwd ?? process.cwd(),
-      confirm: this.options.workspaceCtx?.confirm ?? (() => Promise.resolve(false)),
-    };
+  /** Returns the workspace for use with registerWorkspaceCommands(). */
+  get workspace(): Workspace | undefined {
+    return this.options.workspace;
   }
 
   /**
@@ -562,9 +532,9 @@ export class WorkerSession {
           branch: "",
         });
         this.display.print(display.c.amber("Task cancelled (reassigned to another worker)."));
-        const ctx = this.options.workspaceCtx;
-        if (ctx) {
-          void ctx.workspace.reset().then(() => {
+        const workspace = this.options.workspace;
+        if (workspace?.isCreated) {
+          void workspace.reset().then(() => {
             this.display.print(display.c.amber("Workspace reset."));
           }).catch((err: unknown) => {
             this.display.print(display.c.boldRed(`Workspace reset failed: ${err instanceof Error ? err.message : String(err)}`));
@@ -585,7 +555,7 @@ export class WorkerSession {
       this.prIsClosed = false;
       this.agentStatus.update({ taskNumber: msg.issue.number, prNumber: undefined });
       void this.refreshBranch();
-      const initialPrompt = buildInitialPrompt(msg.issue, !!this.options.workspaceCtx);
+      const initialPrompt = buildInitialPrompt(msg.issue, !!this.options.workspace);
       this.display.print(display.c.sageGreen(initialPrompt));
       this.enqueuePrompt(initialPrompt, true); // fresh=true: new task, reset session
     } else if (msg.type === "event_notification") {
@@ -693,17 +663,18 @@ export async function startWorkerMode(config: WorkerModeConfig, agentStatus: Age
   const workspaceDir = config.workspaceDir ?? path.join(os.homedir(), ".brunel", "workers");
   const repoUrl = config.repoUrl ?? `https://${config.githubToken}@github.com/${config.githubRepo}.git`;
 
-  const workspace = await Workspace.create(workspaceDir, agentStatus.agentId, repoUrl);
-  process.chdir(workspace.dir);
-
   const confirm = async (msg: string): Promise<boolean> => {
     display.print(display.c.amber(`\n⚠ Potential data loss:\n${msg}`));
     const idx = await pick(["Yes, proceed", "No, cancel"]);
     return idx === 0;
   };
 
+  const workspace = new Workspace(workspaceDir, agentStatus.agentId, repoUrl, originalCwd, confirm);
+  await workspace.create();
+  process.chdir(workspace.dir);
+
   const afterTask = async () => {
-    const ok = await confirmIfUnsafe(workspace, confirm);
+    const ok = await confirmIfUnsafe(workspace, workspace.confirm);
     if (!ok) {
       display.print(display.c.amber("Workspace reset cancelled. Task not marked complete."));
       throw new Error("cancelled");
@@ -744,14 +715,14 @@ export async function startWorkerMode(config: WorkerModeConfig, agentStatus: Age
 
   const session = new WorkerSession(agentStatus, wsFactory, workerDisplay, {
     afterTask,
-    workspaceCtx: { workspace, originalCwd, workspaceDir, repoUrl, confirm },
+    workspace,
     pingIntervalMs: config.pingIntervalMs,
   });
 
   const shutdown = async () => {
     if (shuttingDown) return;
     shuttingDown = true;
-    const ok = await confirmIfUnsafe(workspace, confirm);
+    const ok = await confirmIfUnsafe(workspace, workspace.confirm);
     if (ok) await workspace.destroy();
     process.exit(0);
   };
@@ -775,7 +746,7 @@ export async function startWorkerMode(config: WorkerModeConfig, agentStatus: Age
   const cleanup = async () => {
     session.sendGoodbye();
     shuttingDown = true;
-    const ok = await confirmIfUnsafe(workspace, confirm);
+    const ok = await confirmIfUnsafe(workspace, workspace.confirm);
     if (ok) await workspace.destroy();
     process.stdout.write("\x1b[?2004l\r\n");
     if (process.stdin.isTTY) process.stdin.setRawMode(false);

--- a/src/agent/workspace.ts
+++ b/src/agent/workspace.ts
@@ -32,32 +32,24 @@ function isProcessAlive(pid: number): boolean {
 
 export class Workspace {
   readonly dir: string;
+  readonly workspaceDir: string;
+  isCreated = false;
 
   constructor(
-    baseDir: string,
-    workerId: string,
+    workspaceDir: string,
+    readonly sessionId: string,
     private readonly repoUrl: string,
+    readonly originalCwd: string,
+    readonly confirm: (msg: string) => Promise<boolean>,
     private readonly exec: GitExec = defaultGitExec,
     private readonly npm: NpmExec = defaultNpmExec,
   ) {
-    this.dir = path.join(baseDir, workerId);
-  }
-
-  /** Convenience factory: constructs a Workspace and calls create(). */
-  static async create(
-    baseDir: string,
-    workerId: string,
-    repoUrl: string,
-    exec: GitExec = defaultGitExec,
-    npm: NpmExec = defaultNpmExec,
-  ): Promise<Workspace> {
-    const ws = new Workspace(baseDir, workerId, repoUrl, exec, npm);
-    await ws.create();
-    return ws;
+    this.workspaceDir = workspaceDir;
+    this.dir = path.join(workspaceDir, sessionId);
   }
 
   /**
-   * Clone the repo into baseDir/workerId if not already present.
+   * Clone the repo into workspaceDir/sessionId if not already present.
    * Runs npm install after a fresh clone.
    * Writes a PID lockfile on every call.
    */
@@ -70,6 +62,7 @@ export class Workspace {
       await this._npmInstall();
     }
     fs.writeFileSync(path.join(this.dir, ".brunel.lock"), String(process.pid));
+    this.isCreated = true;
   }
 
   /**
@@ -145,19 +138,19 @@ export class Workspace {
   }
 
   /**
-   * Remove orphaned workspace directories under baseDir.
+   * Remove orphaned workspace directories under workspaceDir.
    * A directory is orphaned if it has no .brunel.lock, or its lock PID is dead.
    * Active workers (live PID) are skipped.
    * Returns the list of directories removed.
    */
-  static async prune(baseDir: string): Promise<string[]> {
-    if (!fs.existsSync(baseDir)) return [];
-    display.print(display.c.sageGreen(`[workspace] Pruning orphaned workspaces in ${baseDir}`));
-    const entries = fs.readdirSync(baseDir, { withFileTypes: true });
+  static async prune(workspaceDir: string): Promise<string[]> {
+    if (!fs.existsSync(workspaceDir)) return [];
+    display.print(display.c.sageGreen(`[workspace] Pruning orphaned workspaces in ${workspaceDir}`));
+    const entries = fs.readdirSync(workspaceDir, { withFileTypes: true });
     const removed: string[] = [];
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
-      const dir = path.join(baseDir, entry.name);
+      const dir = path.join(workspaceDir, entry.name);
       const lockPath = path.join(dir, ".brunel.lock");
       if (fs.existsSync(lockPath)) {
         const pid = parseInt(fs.readFileSync(lockPath, "utf8").trim(), 10);
@@ -177,52 +170,47 @@ export class Workspace {
   async destroy(): Promise<void> {
     display.print(display.c.sageGreen(`[workspace] Destroying ${this.dir}`));
     fs.rmSync(this.dir, { recursive: true, force: true });
+    this.isCreated = false;
   }
 }
 
 // ── Workspace command registration ────────────────────────────────────────────
 
-export interface WorkspaceCommandDeps {
-  workspace: { current: Workspace | undefined };
-  config: { workspaceDir: string; repoUrl: string; sessionId: string } | undefined;
-  originalCwd: string;
-  confirm: (msg: string) => Promise<boolean>;
-}
-
 /**
  * Register workspace commands into the given registry (which should already be
  * scoped, e.g. registry.scoped("workspace")). Call this once at startup.
+ *
+ * Pass `undefined` when no GitHub repo is configured — commands that require
+ * a workspace will print an appropriate error message.
  */
-export function registerWorkspaceCommands(deps: WorkspaceCommandDeps, registry: CommandRegistry): void {
+export function registerWorkspaceCommands(workspace: Workspace | undefined, registry: CommandRegistry): void {
   registry.register("create", {
     description: "Create an isolated git checkout for this session",
     handler: async () => {
-      if (!deps.config) {
+      if (!workspace) {
         display.print(display.c.boldRed("Cannot create workspace: no GitHub repo configured."));
         return;
       }
-      if (deps.workspace.current) {
-        display.print(display.c.amber(`Workspace already exists: ${deps.workspace.current.dir}`));
+      if (workspace.isCreated) {
+        display.print(display.c.amber(`Workspace already exists: ${workspace.dir}`));
         return;
       }
-      const ws = await Workspace.create(deps.config.workspaceDir, deps.config.sessionId, deps.config.repoUrl);
-      deps.workspace.current = ws;
-      process.chdir(ws.dir);
-      display.print(display.c.sageGreen(`Workspace created: ${ws.dir}`));
+      await workspace.create();
+      process.chdir(workspace.dir);
+      display.print(display.c.sageGreen(`Workspace created: ${workspace.dir}`));
     },
   });
 
   registry.register("reset", {
     description: "Reset workspace to clean main branch",
     handler: async () => {
-      const ws = deps.workspace.current;
-      if (!ws) {
+      if (!workspace?.isCreated) {
         display.print(display.c.boldRed("No workspace. Use /workspace:create first."));
         return;
       }
-      const ok = await confirmIfUnsafe(ws, deps.confirm);
+      const ok = await confirmIfUnsafe(workspace, workspace.confirm);
       if (!ok) return;
-      await ws.reset();
+      await workspace.reset();
       display.print(display.c.sageGreen("Workspace reset to main."));
     },
   });
@@ -230,28 +218,26 @@ export function registerWorkspaceCommands(deps: WorkspaceCommandDeps, registry: 
   registry.register("remove", {
     description: "Remove the workspace checkout for this session",
     handler: async () => {
-      const ws = deps.workspace.current;
-      if (!ws) {
+      if (!workspace?.isCreated) {
         display.print(display.c.boldRed("No workspace in this session."));
         return;
       }
-      const ok = await confirmIfUnsafe(ws, deps.confirm);
+      const ok = await confirmIfUnsafe(workspace, workspace.confirm);
       if (!ok) return;
-      await ws.destroy();
-      process.chdir(deps.originalCwd);
-      deps.workspace.current = undefined;
-      display.print(display.c.sageGreen(`Workspace removed. Now in: ${deps.originalCwd}`));
+      await workspace.destroy();
+      process.chdir(workspace.originalCwd);
+      display.print(display.c.sageGreen(`Workspace removed. Now in: ${workspace.originalCwd}`));
     },
   });
 
   registry.register("prune", {
     description: "Remove orphaned worker workspace directories",
     handler: async () => {
-      if (!deps.config) {
+      if (!workspace) {
         display.print(display.c.boldRed("Cannot prune: no workspace directory configured."));
         return;
       }
-      const removed = await Workspace.prune(deps.config.workspaceDir);
+      const removed = await Workspace.prune(workspace.workspaceDir);
       if (removed.length === 0) {
         display.print(display.c.sageGreen("Nothing to prune."));
       } else {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -21,12 +21,7 @@ export async function registerTestCommands(): Promise<CommandRegistry> {
   const { CommandRegistry } = await import("../src/agent/command-registry.js");
   const { registerWorkspaceCommands } = await import("../src/agent/workspace.js");
   const registry = new CommandRegistry();
-  registerWorkspaceCommands({
-    workspace: { current: undefined },
-    config: undefined,
-    originalCwd: process.cwd(),
-    confirm: async () => true,
-  }, registry.scoped("workspace"));
+  registerWorkspaceCommands(undefined, registry.scoped("workspace"));
   const noop = async () => {};
   registry.register("exit",   { description: "Exit", handler: noop });
   registry.register("clear",  { description: "Clear the conversation", handler: noop });

--- a/tests/repl.workspace.test.ts
+++ b/tests/repl.workspace.test.ts
@@ -10,23 +10,17 @@ vi.mock("../src/agent/display.js", async (importOriginal) => {
   return { ...actual, print: vi.fn() };
 });
 
-import { Workspace, registerWorkspaceCommands, type WorkspaceCommandDeps } from "../src/agent/workspace.js";
+import { Workspace, registerWorkspaceCommands } from "../src/agent/workspace.js";
 import * as display from "../src/agent/display.js";
 import { CommandRegistry } from "../src/agent/command-registry.js";
 import { stripAnsi } from "./helpers.js";
 
-const cfg = { workspaceDir: "/base", repoUrl: "https://x@github.com/owner/repo.git", sessionId: "test-session-uuid" };
+const WORKSPACE_DIR = "/base";
+const SESSION_ID = "test-session-uuid";
+const REPO_URL = "https://x@github.com/owner/repo.git";
 const ORIGINAL_CWD = "/original";
 
-const mockInstance = {
-  dir: "/fake/workspace",
-  reset: vi.fn().mockResolvedValue(undefined),
-  destroy: vi.fn().mockResolvedValue(undefined),
-  checkSafety: vi.fn().mockResolvedValue({ uncommittedFiles: [], unpushedCommits: [], noUpstream: false }),
-} as unknown as Workspace;
-
 beforeEach(() => {
-  vi.spyOn(Workspace, "create").mockResolvedValue(mockInstance);
   vi.spyOn(Workspace, "prune").mockResolvedValue([]);
   vi.spyOn(process, "chdir").mockImplementation(() => undefined);
   vi.mocked(display.print).mockClear();
@@ -38,47 +32,47 @@ afterEach(() => {
 
 let registry: CommandRegistry;
 
-function makeAndRegister(overrides: Partial<WorkspaceCommandDeps> = {}) {
+/** Create a Workspace instance for testing (not yet cloned). */
+function makeWorkspace(confirm = vi.fn().mockResolvedValue(true)): Workspace {
+  const ws = new Workspace(WORKSPACE_DIR, SESSION_ID, REPO_URL, ORIGINAL_CWD, confirm);
+  vi.spyOn(ws, "create").mockImplementation(async () => { ws.isCreated = true; });
+  vi.spyOn(ws, "reset").mockResolvedValue(undefined);
+  vi.spyOn(ws, "destroy").mockImplementation(async () => { ws.isCreated = false; });
+  vi.spyOn(ws, "checkSafety").mockResolvedValue({ uncommittedFiles: [], unpushedCommits: [], noUpstream: false });
+  return ws;
+}
+
+function makeAndRegister(workspace: Workspace | undefined): void {
   registry = new CommandRegistry();
-  const workspaceRef: { current: Workspace | undefined } = { current: undefined };
-  const deps: WorkspaceCommandDeps = {
-    workspace: workspaceRef,
-    config: cfg,
-    originalCwd: ORIGINAL_CWD,
-    confirm: vi.fn().mockResolvedValue(true),
-    ...overrides,
-  };
-  registerWorkspaceCommands(deps, registry.scoped("workspace"));
-  return deps;
+  registerWorkspaceCommands(workspace, registry.scoped("workspace"));
 }
 
 // ── workspace:create ──────────────────────────────────────────────────────────
 
 describe("workspace:create", () => {
-  it("prints error if no config", async () => {
-    makeAndRegister({ config: undefined });
+  it("prints error if no workspace (no config)", async () => {
+    makeAndRegister(undefined);
     await registry.execute("workspace:create", "");
     expect(stripAnsi(vi.mocked(display.print).mock.calls[0][0])).toContain("no GitHub repo configured");
-    expect(Workspace.create).not.toHaveBeenCalled();
   });
 
   it("prints error if workspace already exists", async () => {
-    const existing = { dir: "/existing" } as any;
-    const deps = makeAndRegister();
-    deps.workspace.current = existing;
+    const ws = makeWorkspace();
+    ws.isCreated = true;
+    makeAndRegister(ws);
     await registry.execute("workspace:create", "");
     expect(stripAnsi(vi.mocked(display.print).mock.calls[0][0])).toContain("Workspace already exists");
-    expect(Workspace.create).not.toHaveBeenCalled();
+    expect(ws.create).not.toHaveBeenCalled();
   });
 
-  it("creates workspace, chdirs to it, and sets workspace.current", async () => {
-    const deps = makeAndRegister();
+  it("creates workspace, chdirs to it, and sets isCreated", async () => {
+    const ws = makeWorkspace();
+    makeAndRegister(ws);
     await registry.execute("workspace:create", "");
-    expect(Workspace.create).toHaveBeenCalledWith(cfg.workspaceDir, cfg.sessionId, cfg.repoUrl);
-    expect(process.chdir).toHaveBeenCalledWith("/fake/workspace");
+    expect(ws.create).toHaveBeenCalledOnce();
+    expect(process.chdir).toHaveBeenCalledWith(ws.dir);
     expect(stripAnsi(vi.mocked(display.print).mock.calls[0][0])).toContain("Workspace created");
-    expect(deps.workspace.current).toBeTruthy();
-    expect(deps.workspace.current!.dir).toBe("/fake/workspace");
+    expect(ws.isCreated).toBe(true);
   });
 });
 
@@ -86,29 +80,35 @@ describe("workspace:create", () => {
 
 describe("workspace:reset", () => {
   it("prints error if no workspace exists", async () => {
-    makeAndRegister();
+    makeAndRegister(undefined);
     await registry.execute("workspace:reset", "");
     expect(stripAnsi(vi.mocked(display.print).mock.calls[0][0])).toContain("No workspace");
   });
 
+  it("prints error if workspace not yet created", async () => {
+    const ws = makeWorkspace();
+    makeAndRegister(ws);
+    await registry.execute("workspace:reset", "");
+    expect(stripAnsi(vi.mocked(display.print).mock.calls[0][0])).toContain("No workspace");
+    expect(ws.reset).not.toHaveBeenCalled();
+  });
+
   it("resets workspace when clean", async () => {
-    const ws = { dir: "/ws", reset: vi.fn().mockResolvedValue(undefined), destroy: vi.fn(),
-      checkSafety: vi.fn().mockResolvedValue({ uncommittedFiles: [], unpushedCommits: [], noUpstream: false }) } as any;
-    const deps = makeAndRegister();
-    deps.workspace.current = ws;
+    const ws = makeWorkspace();
+    ws.isCreated = true;
+    makeAndRegister(ws);
     await registry.execute("workspace:reset", "");
     expect(ws.reset).toHaveBeenCalled();
     expect(stripAnsi(vi.mocked(display.print).mock.calls[0][0])).toContain("Workspace reset to main");
   });
 
   it("skips reset if user declines confirmation", async () => {
-    const ws = { dir: "/ws", reset: vi.fn(), destroy: vi.fn(),
-      checkSafety: vi.fn().mockResolvedValue({ uncommittedFiles: ["M foo.ts"], unpushedCommits: [], noUpstream: false }) } as any;
-    const deps = makeAndRegister({ confirm: vi.fn().mockResolvedValue(false) });
-    deps.workspace.current = ws;
+    const ws = makeWorkspace(vi.fn().mockResolvedValue(false));
+    ws.isCreated = true;
+    vi.mocked(ws.checkSafety).mockResolvedValue({ uncommittedFiles: ["M foo.ts"], unpushedCommits: [], noUpstream: false });
+    makeAndRegister(ws);
     await registry.execute("workspace:reset", "");
     expect(ws.reset).not.toHaveBeenCalled();
-    expect(deps.workspace.current).toBe(ws);
   });
 });
 
@@ -116,55 +116,64 @@ describe("workspace:reset", () => {
 
 describe("workspace:remove", () => {
   it("prints error if no workspace exists", async () => {
-    makeAndRegister();
+    makeAndRegister(undefined);
     await registry.execute("workspace:remove", "");
     expect(stripAnsi(vi.mocked(display.print).mock.calls[0][0])).toContain("No workspace in this session");
   });
 
-  it("destroys workspace, chdirs to originalCwd, clears workspace.current", async () => {
-    const ws = { dir: "/ws", reset: vi.fn(), destroy: vi.fn().mockResolvedValue(undefined),
-      checkSafety: vi.fn().mockResolvedValue({ uncommittedFiles: [], unpushedCommits: [], noUpstream: false }) } as any;
-    const deps = makeAndRegister();
-    deps.workspace.current = ws;
+  it("prints error if workspace not yet created", async () => {
+    const ws = makeWorkspace();
+    makeAndRegister(ws);
+    await registry.execute("workspace:remove", "");
+    expect(stripAnsi(vi.mocked(display.print).mock.calls[0][0])).toContain("No workspace in this session");
+    expect(ws.destroy).not.toHaveBeenCalled();
+  });
+
+  it("destroys workspace, chdirs to originalCwd, sets isCreated to false", async () => {
+    const ws = makeWorkspace();
+    ws.isCreated = true;
+    makeAndRegister(ws);
     await registry.execute("workspace:remove", "");
     expect(ws.destroy).toHaveBeenCalled();
     expect(process.chdir).toHaveBeenCalledWith(ORIGINAL_CWD);
     expect(stripAnsi(vi.mocked(display.print).mock.calls[0][0])).toContain("Workspace removed");
-    expect(deps.workspace.current).toBeUndefined();
+    expect(ws.isCreated).toBe(false);
   });
 
   it("skips removal if user declines confirmation", async () => {
-    const ws = { dir: "/ws", reset: vi.fn(), destroy: vi.fn(),
-      checkSafety: vi.fn().mockResolvedValue({ uncommittedFiles: ["M foo.ts"], unpushedCommits: [], noUpstream: false }) } as any;
-    const deps = makeAndRegister({ confirm: vi.fn().mockResolvedValue(false) });
-    deps.workspace.current = ws;
+    const ws = makeWorkspace(vi.fn().mockResolvedValue(false));
+    ws.isCreated = true;
+    vi.mocked(ws.checkSafety).mockResolvedValue({ uncommittedFiles: ["M foo.ts"], unpushedCommits: [], noUpstream: false });
+    makeAndRegister(ws);
     await registry.execute("workspace:remove", "");
     expect(ws.destroy).not.toHaveBeenCalled();
     expect(process.chdir).not.toHaveBeenCalled();
-    expect(deps.workspace.current).toBe(ws);
+    expect(ws.isCreated).toBe(true);
   });
 });
 
 // ── workspace:prune ───────────────────────────────────────────────────────────
 
 describe("workspace:prune", () => {
-  it("prints error if no config", async () => {
-    makeAndRegister({ config: undefined });
+  it("prints error if no workspace (no config)", async () => {
+    makeAndRegister(undefined);
     await registry.execute("workspace:prune", "");
     expect(stripAnsi(vi.mocked(display.print).mock.calls[0][0])).toContain("no workspace directory configured");
   });
 
   it("prints 'Nothing to prune' when no orphans found", async () => {
     vi.mocked(Workspace.prune).mockResolvedValue([]);
-    makeAndRegister();
+    const ws = makeWorkspace();
+    makeAndRegister(ws);
     await registry.execute("workspace:prune", "");
-    expect(Workspace.prune).toHaveBeenCalledWith(cfg.workspaceDir);
+    expect(Workspace.prune).toHaveBeenCalledWith(WORKSPACE_DIR);
     expect(stripAnsi(vi.mocked(display.print).mock.calls[0][0])).toContain("Nothing to prune");
   });
 
   it("lists removed dirs and prints summary when orphans are pruned", async () => {
     vi.mocked(Workspace.prune).mockResolvedValue(["/base/abc", "/base/def"]);
-    makeAndRegister();
+    const ws = makeWorkspace();
+    makeAndRegister(ws);
     await registry.execute("workspace:prune", "");
     const allOutput = vi.mocked(display.print).mock.calls.map(c => stripAnsi(c[0])).join("\n");
     expect(allOutput).toContain("/base/abc");

--- a/tests/worker.main.test.ts
+++ b/tests/worker.main.test.ts
@@ -14,22 +14,50 @@ vi.mock("ws", async () => {
   };
 });
 
+// Singleton fake workspace returned by the mocked Workspace constructor.
+// vi.hoisted() is required so it is defined before vi.mock() factories run.
+const fakeWorkspace = vi.hoisted(() => {
+  const ws: {
+    dir: string;
+    workspaceDir: string;
+    sessionId: string;
+    originalCwd: string;
+    isCreated: boolean;
+    confirm: ReturnType<typeof vi.fn>;
+    destroy: ReturnType<typeof vi.fn>;
+    checkSafety: ReturnType<typeof vi.fn>;
+    reset: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  } = {
+    dir: "/fake/workers/test-worker",
+    workspaceDir: "/fake/workers",
+    sessionId: "test-worker",
+    originalCwd: "/fake/original",
+    isCreated: false,
+    confirm: vi.fn().mockResolvedValue(true),
+    destroy: vi.fn().mockResolvedValue(undefined),
+    checkSafety: vi.fn().mockResolvedValue({
+      uncommittedFiles: [],
+      unpushedCommits: [],
+      noUpstream: false,
+    }),
+    reset: vi.fn().mockResolvedValue(undefined),
+    create: vi.fn().mockImplementation(async () => { ws.isCreated = true; }),
+  };
+  return ws;
+});
+
 vi.mock("../src/agent/workspace.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../src/agent/workspace.js")>();
+  // Use a regular function (not arrow) so it can be called with `new`.
+  // A constructor that returns an object explicitly uses that object (JS spec).
+  // eslint-disable-next-line prefer-arrow-callback
+  const MockWorkspace = vi.fn().mockImplementation(function() { return fakeWorkspace; });
+  // Keep the static prune method
+  (MockWorkspace as any).prune = vi.fn().mockResolvedValue([]);
   return {
     ...actual,
-    Workspace: {
-      create: vi.fn().mockResolvedValue({
-        dir: "/fake/workers/test-worker",
-        destroy: vi.fn().mockResolvedValue(undefined),
-        checkSafety: vi.fn().mockResolvedValue({
-          uncommittedFiles: [],
-          unpushedCommits: [],
-          noUpstream: false,
-        }),
-        reset: vi.fn().mockResolvedValue(undefined),
-      }),
-    },
+    Workspace: MockWorkspace,
     confirmIfUnsafe: vi.fn().mockResolvedValue(true),
   };
 });
@@ -45,7 +73,7 @@ vi.mock("../src/agent/input.js", async (importOriginal) => {
 
 import { main } from "../src/agent/index.js";
 import type { WorkerModeConfig } from "../src/agent/worker.js";
-import { Workspace, confirmIfUnsafe } from "../src/agent/workspace.js";
+import { confirmIfUnsafe } from "../src/agent/workspace.js";
 import * as inputModule from "../src/agent/input.js";
 import * as displayModule from "../src/agent/display.js";
 import { stripAnsi } from "./helpers.js";
@@ -124,6 +152,11 @@ describe("workerMain exit behavior", () => {
     // Default: ask returns __eof__ immediately (^D pressed)
     vi.mocked(inputModule.ask).mockResolvedValue("__eof__");
     vi.mocked(confirmIfUnsafe).mockResolvedValue(true);
+    // Reset fake workspace mocks between tests
+    fakeWorkspace.isCreated = false;
+    vi.mocked(fakeWorkspace.destroy).mockResolvedValue(undefined);
+    vi.mocked(fakeWorkspace.checkSafety).mockResolvedValue({ uncommittedFiles: [], unpushedCommits: [], noUpstream: false });
+    vi.mocked(fakeWorkspace.create).mockImplementation(async () => { fakeWorkspace.isCreated = true; });
   });
 
   afterEach(() => {
@@ -146,28 +179,11 @@ describe("workerMain exit behavior", () => {
   });
 
   it("destroys workspace before exiting when workspace is safe", async () => {
-    const fakeWorkspace = {
-      dir: "/fake/workers/test-worker",
-      destroy: vi.fn().mockResolvedValue(undefined),
-      checkSafety: vi.fn().mockResolvedValue({ uncommittedFiles: [], unpushedCommits: [], noUpstream: false }),
-      reset: vi.fn().mockResolvedValue(undefined),
-    };
-    vi.mocked(Workspace.create).mockResolvedValue(fakeWorkspace as any);
-
     await runWorkerMain();
-
     expect(fakeWorkspace.destroy).toHaveBeenCalledOnce();
   });
 
   it("does not call workspace.destroy when SIGINT fires while a query is running", async () => {
-    const fakeWorkspace = {
-      dir: "/fake/workers/test-worker",
-      destroy: vi.fn().mockResolvedValue(undefined),
-      checkSafety: vi.fn().mockResolvedValue({ uncommittedFiles: [], unpushedCommits: [], noUpstream: false }),
-      reset: vi.fn().mockResolvedValue(undefined),
-    };
-    vi.mocked(Workspace.create).mockResolvedValue(fakeWorkspace as any);
-
     // runQuery blocks until resolved — simulates a running query
     let resolveQuery!: (value: string | undefined) => void;
     const runQueryFn = vi.fn().mockImplementation(
@@ -186,8 +202,6 @@ describe("workerMain exit behavior", () => {
     const exitSpy = vi.spyOn(process, "exit").mockImplementation((code?: number | string) => {
       throw new Error("__process_exit__");
     }) as unknown as ReturnType<typeof vi.spyOn>;
-
-    const chdirSpy = vi.spyOn(process, "chdir").mockImplementation(() => {});
 
     let workerDone = false;
     const workerPromise = main(runQueryFn, permConfig, WORKER_CONFIG).then(
@@ -212,18 +226,9 @@ describe("workerMain exit behavior", () => {
     expect(workerDone).toBe(true);
 
     exitSpy.mockRestore();
-    chdirSpy.mockRestore();
   });
 
   it("does not call workspace.destroy a second time if SIGINT fires after loop exits", async () => {
-    const fakeWorkspace = {
-      dir: "/fake/workers/test-worker",
-      destroy: vi.fn().mockResolvedValue(undefined),
-      checkSafety: vi.fn().mockResolvedValue({ uncommittedFiles: [], unpushedCommits: [], noUpstream: false }),
-      reset: vi.fn().mockResolvedValue(undefined),
-    };
-    vi.mocked(Workspace.create).mockResolvedValue(fakeWorkspace as any);
-
     // Simulate: user types /exit, cleanup runs, process tries to exit.
     // Before process.exit completes (in our mock it throws), emit SIGINT.
     const exitSpy = vi.spyOn(process, "exit").mockImplementation((code?: number | string) => {

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -706,11 +706,16 @@ describe("hello_ack handshake — buffering", () => {
     }
   });
 
-  it("calls workspace.reset() on hello_ack cancelled when workspaceCtx is set", async () => {
+  it("calls workspace.reset() on hello_ack cancelled when workspace is set", async () => {
     vi.useFakeTimers();
     try {
       const workspace = {
         dir: "/tmp/test-workspace",
+        workspaceDir: "/tmp/workers",
+        sessionId: "test-agent",
+        originalCwd: "/original",
+        isCreated: true,
+        confirm: vi.fn(),
         reset: vi.fn().mockResolvedValue(undefined),
         destroy: vi.fn().mockResolvedValue(undefined),
         checkSafety: vi.fn().mockResolvedValue({ uncommittedFiles: [], unpushedCommits: [], noUpstream: false }),
@@ -721,9 +726,7 @@ describe("hello_ack handshake — buffering", () => {
       let callCount = 0;
       const wsFactoryWs = vi.fn().mockImplementation(() => callCount++ === 0 ? wsA : wsB);
 
-      const sessionWithWs = new WorkerSession(new AgentStatus(AGENT_ID), wsFactoryWs, display, {
-        workspaceCtx: { workspace, originalCwd: "/original", workspaceDir: "/tmp/workers", repoUrl: "https://github.com/owner/repo", confirm: vi.fn() },
-      });
+      const sessionWithWs = new WorkerSession(new AgentStatus(AGENT_ID), wsFactoryWs, display, { workspace });
       sessionWithWs.start(); // uses wsA
 
       const issue = makeIssue();
@@ -1310,12 +1313,17 @@ describe("prIsClosed guard", () => {
 import { Workspace, registerWorkspaceCommands } from "../src/agent/workspace.js";
 import { CommandRegistry } from "../src/agent/command-registry.js";
 
-// ── workspace slash commands via workspaceCommandDeps ─────────────────────────
+// ── workspace slash commands via WorkerSession.workspace ──────────────────────
 
 describe("workspace slash commands in WorkerSession", () => {
   function makeWorkspace(): Workspace {
     return {
       dir: "/tmp/test-workspace",
+      workspaceDir: "/tmp/workers",
+      sessionId: "test-agent-id",
+      originalCwd: "/original",
+      isCreated: true,
+      confirm: vi.fn().mockResolvedValue(true),
       reset: vi.fn().mockResolvedValue(undefined),
       destroy: vi.fn().mockResolvedValue(undefined),
       checkSafety: vi.fn().mockResolvedValue({
@@ -1326,19 +1334,10 @@ describe("workspace slash commands in WorkerSession", () => {
 
   it("/workspace:reset calls workspace.reset() when clean", async () => {
     const workspace = makeWorkspace();
-    const confirm = vi.fn().mockResolvedValue(true);
-    const sessionWs = new WorkerSession(new AgentStatus(AGENT_ID), wsFactory, display, {
-      workspaceCtx: {
-        workspace,
-        originalCwd: "/original",
-        workspaceDir: "/tmp/workers",
-        repoUrl: "https://token@github.com/owner/repo.git",
-        confirm,
-      },
-    });
+    const sessionWs = new WorkerSession(new AgentStatus(AGENT_ID), wsFactory, display, { workspace });
     sessionWs.start();
     const wsReg1 = new CommandRegistry();
-    registerWorkspaceCommands(sessionWs.workspaceCommandDeps, wsReg1.scoped("workspace"));
+    registerWorkspaceCommands(sessionWs.workspace, wsReg1.scoped("workspace"));
     await wsReg1.execute("workspace:reset", "");
     expect(workspace.reset).toHaveBeenCalledOnce();
   });
@@ -1348,59 +1347,38 @@ describe("workspace slash commands in WorkerSession", () => {
     (workspace.checkSafety as ReturnType<typeof vi.fn>).mockResolvedValue({
       uncommittedFiles: ["M foo.ts"], unpushedCommits: [], noUpstream: false,
     });
-    const confirm = vi.fn().mockResolvedValue(false);
-    const sessionWs = new WorkerSession(new AgentStatus(AGENT_ID), wsFactory, display, {
-      workspaceCtx: {
-        workspace,
-        originalCwd: "/original",
-        workspaceDir: "/tmp/workers",
-        repoUrl: "https://token@github.com/owner/repo.git",
-        confirm,
-      },
-    });
+    (workspace.confirm as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+    const sessionWs = new WorkerSession(new AgentStatus(AGENT_ID), wsFactory, display, { workspace });
     sessionWs.start();
     const wsReg2 = new CommandRegistry();
-    registerWorkspaceCommands(sessionWs.workspaceCommandDeps, wsReg2.scoped("workspace"), true);
+    registerWorkspaceCommands(sessionWs.workspace, wsReg2.scoped("workspace"));
     await wsReg2.execute("workspace:reset", "");
     expect(workspace.reset).not.toHaveBeenCalled();
   });
 
   it("/workspace:remove calls destroy() when approved", async () => {
-    const workspace = makeWorkspace();
-    const confirm = vi.fn().mockResolvedValue(true);
-    const originalCwd = process.cwd();
-    const sessionWs = new WorkerSession(new AgentStatus(AGENT_ID), wsFactory, display, {
-      workspaceCtx: {
-        workspace,
-        originalCwd,
-        workspaceDir: "/tmp/workers",
-        repoUrl: "https://token@github.com/owner/repo.git",
-        confirm,
-      },
-    });
-    sessionWs.start();
-    const wsReg3 = new CommandRegistry();
-    registerWorkspaceCommands(sessionWs.workspaceCommandDeps, wsReg3.scoped("workspace"), true);
-    await wsReg3.execute("workspace:remove", "");
-    expect(workspace.destroy).toHaveBeenCalledOnce();
+    const chdirSpy = vi.spyOn(process, "chdir").mockImplementation(() => {});
+    try {
+      const workspace = makeWorkspace();
+      const sessionWs = new WorkerSession(new AgentStatus(AGENT_ID), wsFactory, display, { workspace });
+      sessionWs.start();
+      const wsReg3 = new CommandRegistry();
+      registerWorkspaceCommands(sessionWs.workspace, wsReg3.scoped("workspace"));
+      await wsReg3.execute("workspace:remove", "");
+      expect(workspace.destroy).toHaveBeenCalledOnce();
+    } finally {
+      chdirSpy.mockRestore();
+    }
   });
 
   it("/workspace:create prints 'already exists' when workspace is pre-created", async () => {
     const printSpy = vi.spyOn(displayModule, "print").mockImplementation(() => {});
     try {
       const workspace = makeWorkspace();
-      const sessionWs = new WorkerSession(new AgentStatus(AGENT_ID), wsFactory, display, {
-        workspaceCtx: {
-          workspace,
-          originalCwd: "/original",
-          workspaceDir: "/tmp/workers",
-          repoUrl: "https://token@github.com/owner/repo.git",
-          confirm: vi.fn(),
-        },
-      });
+      const sessionWs = new WorkerSession(new AgentStatus(AGENT_ID), wsFactory, display, { workspace });
       sessionWs.start();
       const wsReg4 = new CommandRegistry();
-      registerWorkspaceCommands(sessionWs.workspaceCommandDeps, wsReg4.scoped("workspace"));
+      registerWorkspaceCommands(sessionWs.workspace, wsReg4.scoped("workspace"));
       await wsReg4.execute("workspace:create", "");
       const printed = printSpy.mock.calls.map(([s]) => stripAnsi(s as string)).join("\n");
       expect(printed).toContain("Workspace already exists");

--- a/tests/workspace.test.ts
+++ b/tests/workspace.test.ts
@@ -30,7 +30,7 @@ async function makeWorkspace(
   exec = makeExec(),
   npm = makeNpmExec(),
 ): Promise<Workspace> {
-  const ws = new Workspace(BASE_DIR, WORKER_ID, REPO_URL, exec, npm);
+  const ws = new Workspace(BASE_DIR, WORKER_ID, REPO_URL, "/original-cwd", async () => true, exec, npm);
   await ws.create();
   return ws;
 }


### PR DESCRIPTION
## Summary

- Eliminates `WorkspaceCommandDeps` and `WorkspaceCtx` — both types represented workspace context but existed as separate bags because the checkout lifecycle wasn't owned by the class
- `Workspace` constructor now takes `originalCwd`, `confirm`, and `workspaceDir`/`sessionId`/`repoUrl` so it owns all its own state
- Added `workspace.isCreated` to track whether `create()` has been called (replacing the `{ current: Workspace | undefined }` ref pattern)
- `registerWorkspaceCommands(workspace: Workspace | undefined, registry)` — takes the instance directly; `undefined` means no GitHub repo configured
- `WorkerSession.workspaceCommandDeps` getter replaced by simple `workspace` getter; `WorkerSessionOptions.workspaceCtx` replaced by `workspace`
- Removed static `Workspace.create` factory — callers construct then call `workspace.create()`

## Test plan

- [ ] `npm test` — all non-DB tests pass (1390/1390)
- [ ] `npx tsc --noEmit` — no type errors
- [ ] CI passes

Closes #641