### PR TITLE
fix: address error handling gaps across foreman and worker

### DIFF
--- a/src/agent/worker.ts
+++ b/src/agent/worker.ts
@@ -159,6 +159,7 @@ export class WorkerSession {
   private _queryRunning = false;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private prIsClosed = false;
+  private _resetPromise: Promise<void> | null = null;
   // Handshake lifecycle: "registered" = hello_ack received (or initial state);
   // "hello_sent" = worker_hello was sent but hello_ack not yet received.
   // Initialized to "registered" so sessions that never emit "open" (e.g. tests)
@@ -251,7 +252,11 @@ export class WorkerSession {
   async completeCurrentTask(): Promise<"task-complete" | undefined> {
     if (!this.currentTaskId) return undefined;
     if (this.options.afterTask) {
-      try { await this.options.afterTask(); } catch { return undefined; }
+      try { await this.options.afterTask(); } catch (err) {
+        // Log but don't abort — the task IS complete even if workspace cleanup fails.
+        // Returning early here would leave the task stuck on the foreman forever.
+        this.display.print(display.c.amber(`afterTask failed: ${fmtError(err)}`));
+      }
     }
     this.sendTaskMessage({
       type: "task_complete",
@@ -456,10 +461,14 @@ export class WorkerSession {
         this.display.print(display.c.amber("Task cancelled (reassigned to another worker)."));
         const workspace = this.options.workspace;
         if (workspace?.isCreated) {
-          void workspace.reset().then(() => {
+          // Track the reset promise so that task_assigned prompts are deferred until
+          // the workspace is clean — preventing a new task from running in a dirty state.
+          this._resetPromise = workspace.reset().then(() => {
             this.display.print(display.c.amber("Workspace reset."));
           }).catch((err: unknown) => {
             this.display.print(display.c.boldRed(`Workspace reset failed: ${err instanceof Error ? err.message : String(err)}`));
+          }).finally(() => {
+            this._resetPromise = null;
           });
         }
       } else {
@@ -479,7 +488,14 @@ export class WorkerSession {
       void this.refreshBranch();
       const initialPrompt = buildInitialPrompt(msg.issue, !!this.options.workspace);
       this.display.print(display.c.sageGreen(initialPrompt));
-      this.enqueuePrompt(initialPrompt, true); // fresh=true: new task, reset session
+      // If a workspace reset is in progress (from a cancelled hello_ack), defer the
+      // prompt until the reset finishes — otherwise the task could run in a dirty workspace.
+      const enqueue = () => this.enqueuePrompt(initialPrompt, true);
+      if (this._resetPromise) {
+        void this._resetPromise.then(enqueue, enqueue);
+      } else {
+        enqueue(); // fresh=true: new task, reset session
+      }
     } else if (msg.type === "event_notification") {
       // Ignore stale events forwarded for tasks we're no longer working on.
       if (msg.taskId !== this.currentTaskId) {

--- a/src/agent/workspace.ts
+++ b/src/agent/workspace.ts
@@ -131,6 +131,8 @@ export class Workspace {
       const msg = String(err);
       if (msg.includes("no upstream") || msg.includes("no tracking information")) {
         noUpstream = true;
+      } else {
+        throw err;
       }
     }
 

--- a/src/foreman/controllers/wss.ts
+++ b/src/foreman/controllers/wss.ts
@@ -107,9 +107,12 @@ export class ForemanWss {
           return;
         }
         if (task) {
-          await task.complete().catch((err: unknown) =>
-            log(`ERROR Failed to mark task #${msg.taskId} complete: ${fmtError(err)}`)
-          );
+          try {
+            await task.complete();
+          } catch (err) {
+            log(`ERROR Failed to mark task #${msg.taskId} complete: ${fmtError(err)}`);
+            return; // don't release — keeps task assigned so the failure is visible
+          }
         }
         Worker.get(workerId)?.release();
       };
@@ -362,10 +365,13 @@ export class ForemanWss {
   async handleIdleHello(workerId: string, ws: WebSocket): Promise<void> {
     const priorTask = await Task.getByWorker(workerId);
     if (priorTask) {
-      await priorTask.revert().catch((err: unknown) =>
-        log(`ERROR Failed to revert task #${priorTask.taskId} to pending: ${fmtError(err)}`)
-      );
-      this.workerLog(workerId, `hello idle (had task #${priorTask.taskId}) — reverting task to pending`);
+      try {
+        await priorTask.revert();
+        this.workerLog(workerId, `hello idle (had task #${priorTask.taskId}) — reverting task to pending`);
+      } catch (err) {
+        log(`ERROR Failed to revert task #${priorTask.taskId} to pending: ${fmtError(err)}`);
+        return; // don't register as idle — task stays assigned, worker retries on reconnect
+      }
     } else {
       this.workerLog(workerId, "hello idle");
     }
@@ -522,25 +528,35 @@ export class ForemanWss {
       action === "unlabeled" &&
       (p.label as R | undefined)?.name === this.taskLabel
     ) {
-      await this.taskManager.dequeueIssue(issueNumber)
-        .catch((err: unknown) => log(`ERROR Failed to dequeue task #${issueNumber}: ${fmtError(err)}`));
-      log(`[task #${issueNumber}] dequeued (label removed)`);
+      try {
+        await this.taskManager.dequeueIssue(issueNumber);
+        log(`[task #${issueNumber}] dequeued (label removed)`);
+      } catch (err) {
+        log(`ERROR Failed to dequeue task #${issueNumber}: ${fmtError(err)}`);
+        return result(task);
+      }
       await this.assignWork();
       return result(task);
     }
 
     if (action === "closed") {
-      await this.taskManager.closeIssue(issueNumber).catch((err: unknown) =>
-        log(`ERROR Failed to close issue #${issueNumber}: ${fmtError(err)}`)
-      );
+      try {
+        await this.taskManager.closeIssue(issueNumber);
+      } catch (err) {
+        log(`ERROR Failed to close issue #${issueNumber}: ${fmtError(err)}`);
+        return result(task);
+      }
       await this.assignWork();
       return result(task);
     }
 
     if (action === "reopened") {
-      await this.taskManager.reopenIssue(issueNumber).catch((err: unknown) =>
-        log(`ERROR Failed to reopen issue #${issueNumber}: ${fmtError(err)}`)
-      );
+      try {
+        await this.taskManager.reopenIssue(issueNumber);
+      } catch (err) {
+        log(`ERROR Failed to reopen issue #${issueNumber}: ${fmtError(err)}`);
+        return result(task);
+      }
       await this.assignWork();
       return result(task);
     }

--- a/src/foreman/models/foreman-message.ts
+++ b/src/foreman/models/foreman-message.ts
@@ -1,5 +1,6 @@
 import type { Database, Json } from "../../database.types.js";
 import { ActiveRecord } from "./active-record.js";
+import { log, fmtError } from "../../utils.js";
 
 type DbRow = Database["public"]["Tables"]["foreman_messages"]["Row"];
 
@@ -44,7 +45,7 @@ export class ForemanMessage extends ActiveRecord {
       task_id: data.taskId,
       msg_type: data.msgType,
       payload: data.payload as Json,
-    }).then(() => undefined).catch((err: unknown) => console.error("[db] foreman_messages insert error:", err));
+    }).then(() => undefined).catch((err: unknown) => log(`[db] foreman_messages insert error: ${fmtError(err)}`));
   }
 
   // ── Queries ──────────────────────────────────────────────────────────────────

--- a/src/foreman/models/webhook-event.ts
+++ b/src/foreman/models/webhook-event.ts
@@ -2,6 +2,7 @@ import type { Json } from "../../database.types.js";
 import type { DbRow } from "../clients/db-client.js";
 import * as Wire from "../../../shared/wire.js";
 import { ActiveRecord } from "./active-record.js";
+import { log, fmtError } from "../../utils.js";
 
 type Row = DbRow<"webhook_events">;
 
@@ -100,7 +101,7 @@ export class WebhookEvent extends ActiveRecord {
       task_id: data.taskId,
       worker_id: data.workerId,
       payload: data.payload as Json,
-    }).then(() => undefined).catch((err: unknown) => console.error("[db] webhook_events insert error:", err));
+    }).then(() => undefined).catch((err: unknown) => log(`[db] webhook_events insert error: ${fmtError(err)}`));
   }
 
   // ── Queries ──────────────────────────────────────────────────────────────────

--- a/tests/foreman.hello-handlers.test.ts
+++ b/tests/foreman.hello-handlers.test.ts
@@ -205,7 +205,7 @@ describe("handleIdleHello", () => {
     expect(Worker.get("w1")?.status).toBe("idle");
   });
 
-  it("revert failure is logged but does not throw", async () => {
+  it("revert failure is logged and worker is NOT registered (task stays assigned, worker retries)", async () => {
     const task = addTask({
       task_id: "10",
       issue_number: 10,
@@ -214,9 +214,15 @@ describe("handleIdleHello", () => {
     });
     vi.mocked(task.revert).mockRejectedValueOnce(new Error("DB down"));
 
-    const { wss } = makeWss(taskManager);
+    const { wss, sendMsg } = makeWss(taskManager);
     const logSpy = vi.spyOn(utils, "log").mockImplementation(() => {});
     await expect(wss.handleIdleHello("w1", fakeWs())).resolves.toBeUndefined();
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("ERROR"));
+    // Worker must NOT be registered — allowing a new assignment would leave two tasks
+    // pointing at this worker in the DB.
+    expect(Worker.get("w1")).toBeUndefined();
+    // No hello_ack should have been sent either
+    const ackCall = sendMsg.mock.calls.find(([, msg]) => (msg as { type: string }).type === "hello_ack");
+    expect(ackCall).toBeUndefined();
   });
 });

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -747,6 +747,53 @@ describe("hello_ack handshake — buffering", () => {
     }
   });
 
+  it("defers task_assigned prompt until workspace reset completes on hello_ack cancelled", async () => {
+    vi.useFakeTimers();
+    try {
+      let resolveReset!: () => void;
+      const resetPromise = new Promise<void>((resolve) => { resolveReset = resolve; });
+      const workspace = {
+        dir: "/tmp/test-workspace",
+        workspaceDir: "/tmp/workers",
+        sessionId: "test-agent",
+        originalCwd: "/original",
+        isCreated: true,
+        confirm: vi.fn(),
+        reset: vi.fn().mockReturnValue(resetPromise),
+        destroy: vi.fn().mockResolvedValue(undefined),
+        checkSafety: vi.fn().mockResolvedValue({ uncommittedFiles: [], unpushedCommits: [], noUpstream: false }),
+      } as unknown as import("../src/agent/workspace.js").Workspace;
+
+      const wsA = new FakeWs();
+      const wsB = new FakeWs();
+      let callCount = 0;
+      const wsFactoryWs = vi.fn().mockImplementation(() => callCount++ === 0 ? wsA : wsB);
+
+      const sessionWithWs = new WorkerSession(new AgentStatus({ agentId: AGENT_ID }), wsFactoryWs, display, { workspace });
+      sessionWithWs.start();
+
+      sendMsg(wsA, { type: "task_assigned", taskId: "42", issue: makeIssue() });
+      sessionWithWs.takeNextPrompt();
+
+      vi.spyOn(Math, "random").mockReturnValue(0);
+      wsA.emit("close", 1006, Buffer.from(""));
+      vi.advanceTimersByTime(2001);
+      wsB.emit("open");
+      sendMsg(wsB, { type: "hello_ack", workerId: AGENT_ID, status: "cancelled" });
+
+      // Prompt for next task arrives while reset is still running
+      sendMsg(wsB, { type: "task_assigned", taskId: "99", issue: makeIssue(2) });
+      expect(sessionWithWs.hasPendingPrompts()).toBe(false); // deferred
+
+      // Reset completes → prompt is now enqueued
+      resolveReset();
+      await vi.waitFor(() => expect(sessionWithWs.hasPendingPrompts()).toBe(true));
+    } finally {
+      vi.restoreAllMocks();
+      vi.useRealTimers();
+    }
+  });
+
   it("aborts running query when hello_ack cancelled is received", () => {
     vi.useFakeTimers();
     try {
@@ -1406,7 +1453,7 @@ describe("afterTask callback on /worker:complete", () => {
     expect(sentMsg.type).toBe("task_complete");
   });
 
-  it("does not send task_complete if afterTask throws", async () => {
+  it("sends task_complete even if afterTask throws (task must not get stuck on foreman)", async () => {
     const afterTask = vi.fn().mockRejectedValue(new Error("reset failed"));
     const sessionWithAfterTask = new WorkerSession(
       new StatusBar({ agentId: AGENT_ID }), wsFactory, display, { afterTask }
@@ -1422,7 +1469,7 @@ describe("afterTask callback on /worker:complete", () => {
     const taskCompleteSent = fakeWs.send.mock.calls
       .slice(sendCountBefore)
       .some(([data]: [string]) => JSON.parse(data).type === "task_complete");
-    expect(taskCompleteSent).toBe(false);
+    expect(taskCompleteSent).toBe(true);
   });
 
   it("sends task_complete normally with no afterTask", async () => {

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -769,7 +769,7 @@ describe("hello_ack handshake — buffering", () => {
       let callCount = 0;
       const wsFactoryWs = vi.fn().mockImplementation(() => callCount++ === 0 ? wsA : wsB);
 
-      const sessionWithWs = new WorkerSession(new AgentStatus({ agentId: AGENT_ID }), wsFactoryWs, display, { workspace });
+      const sessionWithWs = new WorkerSession(new StatusBar({ agentId: AGENT_ID }), wsFactoryWs, display, { workspace });
       sessionWithWs.start();
 
       sendMsg(wsA, { type: "task_assigned", taskId: "42", issue: makeIssue() });

--- a/tests/workspace.test.ts
+++ b/tests/workspace.test.ts
@@ -249,6 +249,17 @@ describe("Workspace.checkSafety", () => {
     const result = await ws.checkSafety();
     expect(result.noUpstream).toBe(true);
   });
+
+  it("re-throws unexpected git errors (not 'no upstream')", async () => {
+    const exec = vi.fn().mockImplementation(async (args: string[]) => {
+      if (args[0] === "clone") { fs.mkdirSync(path.join(args[2], ".git"), { recursive: true }); return ""; }
+      if (args[0] === "status") return "";
+      if (args[0] === "log") throw new Error("fatal: corrupt object store");
+      return "";
+    });
+    const ws = await makeWorkspace(exec);
+    await expect(ws.checkSafety()).rejects.toThrow("corrupt object store");
+  });
 });
 
 // ── confirmIfUnsafe ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Addresses all five error-handling categories identified in the audit:

1. **Log-and-swallow on critical DB writes** (`wss.ts`): `task.complete()` failures now abort before releasing the worker; `revert()` failures in `handleIdleHello` abort registration (task stays assigned, worker retries on reconnect); `routeIssueEvent` dequeue/close/reopen failures abort without calling `assignWork()`.

2. **`afterTask` failure silently aborting task completion** (`worker.ts`): `completeCurrentTask()` now logs `afterTask` errors and always sends `task_complete` — tasks no longer get stuck on the foreman when workspace reset fails.

3. **Fire-and-forget workspace reset** (`worker.ts`): the `hello_ack cancelled` handler tracks the reset promise; `task_assigned` prompt enqueue is deferred until reset completes so new tasks don't run in a dirty workspace.

4. **`checkSafety()` swallows all git errors** (`workspace.ts`): unexpected errors (not "no upstream") are re-thrown instead of returning a false "safe to reset" signal.

5. **`console.error` in model log methods** (`webhook-event.ts`, `foreman-message.ts`): DB insert failures now use the structured `log()` function so they appear in the admin dashboard audit trail.

## Test plan

- [ ] All existing tests pass (`npm test`)
- [ ] New test: `checkSafety()` re-throws unexpected git errors
- [ ] New test: `completeCurrentTask()` sends `task_complete` even when `afterTask` throws
- [ ] New test: `task_assigned` prompt is deferred until workspace reset completes
- [ ] Updated test: `handleIdleHello` with `revert()` failure does NOT register the worker

Closes #670