### PR TITLE
refactor: merge shared/types.ts into shared/wire.ts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ Most tests run without Supabase. DB tests (`db.*.test.ts`, `pipeline.test.ts`) r
 
 ## Type system
 
-See **`docs/type-system.md`** for the full design. In brief: one server model class per concept, one `Wire.*` interface per concept in `shared/wire.ts` (imported as `import * as Wire from "../../shared/wire.js"`), shared domain types in `shared/types.ts`. Prefer a single wire type with optional fields over multiple types for the same concept. Name things after the concept, not the form — `Wire.Task` not `Wire.TaskSnapshot`.
+See **`docs/type-system.md`** for the full design. In brief: one server model class per concept, one `Wire.*` interface per concept in `shared/wire.ts` (imported as `import * as Wire from "../../shared/wire.js"`), shared domain types in `shared/wire.ts`. Prefer a single wire type with optional fields over multiple types for the same concept. Name things after the concept, not the form — `Wire.Task` not `Wire.TaskSnapshot`.
 
 ## Key conventions
 

--- a/docs/type-system.md
+++ b/docs/type-system.md
@@ -11,7 +11,7 @@ Every domain concept has at most two types:
 1. **A server model class** — rich, may persist to the DB, owns behavior
 2. **A `Wire.*` interface** — the shape of data as it crosses any wire boundary (WebSocket, HTTP)
 
-Shared domain types (enums, value objects used on both sides) live in `shared/types.ts`.
+Shared domain types (enums, value objects used on both sides) live in `shared/wire.ts` alongside the Wire interfaces.
 
 ## The Wire namespace
 
@@ -103,5 +103,5 @@ Payload types within the union reference the shared Wire interfaces directly rat
 |---|---|
 | Server model classes | `src/foreman/models/*.ts` |
 | Wire interfaces and protocol unions | `shared/wire.ts` |
-| Shared domain types (enums, value objects) | `shared/types.ts` |
+| Shared domain types (enums, value objects) | `shared/wire.ts` |
 | Frontend-only UI state | `frontend/src/` (local, not in wire.ts) |

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,2 +1,1 @@
-export type { TaskStatus } from "../../shared/types.ts";
-export type { Task, Worker, LogEntry, AdminMessage, BlockerInfo } from "../../shared/wire.ts";
+export type { TaskStatus, Task, Worker, LogEntry, AdminMessage, BlockerInfo } from "../../shared/wire.ts";

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1,3 +1,0 @@
-// Types shared between the backend (src/) and frontend (frontend/src/).
-
-export type TaskStatus = "pending" | "assigned" | "pushed" | "merged" | "closed" | "complete" | "blocked";

--- a/shared/wire.ts
+++ b/shared/wire.ts
@@ -1,7 +1,7 @@
 // ── Wire types shared between the backend (src/) and frontend (frontend/src/)
 // Import with a namespace alias for clarity: import * as Wire from "../../shared/wire.js"
 
-import type { TaskStatus } from "./types.js";
+export type TaskStatus = "pending" | "assigned" | "pushed" | "merged" | "closed" | "complete" | "blocked";
 
 // ── Admin WebSocket wire types (admin dashboard ↔ server) ────────────────────
 

--- a/src/foreman/controllers/http-server.ts
+++ b/src/foreman/controllers/http-server.ts
@@ -5,7 +5,7 @@ import { getRequestListener } from "@hono/node-server";
 import type { TaskManager } from "../models/task-manager.js";
 import { Task } from "../models/task.js";
 import { queryActivityLog } from "../models/activity-log.js";
-import type { TaskStatus } from "../../../shared/types.js";
+import type { TaskStatus } from "../../../shared/wire.js";
 import { fmtError, log } from "../../utils.js";
 
 export interface HttpServerOptions {

--- a/src/foreman/models/task.ts
+++ b/src/foreman/models/task.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "node:events";
-import type { TaskStatus } from "../../../shared/types.js";
+import type { TaskStatus } from "../../../shared/wire.js";
 import type { Worker } from "./worker.js";
 import type { Database } from "../../database.types.js";
 import * as Wire from "../../../shared/wire.js";


### PR DESCRIPTION
## Summary

- Moves `TaskStatus` from `shared/types.ts` into `shared/wire.ts`, where the other shared domain types live
- Deletes the now-empty `shared/types.ts`
- Updates imports in `src/foreman/models/task.ts`, `src/foreman/controllers/http-server.ts`, and `frontend/src/types.ts`
- Updates `docs/type-system.md` and `CLAUDE.md` to reflect the new location

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — all 1408 tests pass

Closes #683