### PR TITLE
feat: add foreman_error message to wire protocol

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,8 @@ Every `worker_hello` gets a `hello_ack` with one of three statuses before any ta
 - `busy` — reconnection accepted, worker may resume
 - `cancelled` — task was taken or completed; worker should reset and become idle
 
+If a catastrophic error occurs during hello handling or message processing, the foreman sends `foreman_error` (`{ type, message, fatal }`) instead of silently dropping the connection. `fatal: true` causes the worker to stop reconnecting and return to interactive REPL mode; `fatal: false` is informational and the worker continues.
+
 ## Dev workflow
 
 Three terminals:

--- a/docs/type-system.md
+++ b/docs/type-system.md
@@ -81,7 +81,8 @@ The foreman↔worker WebSocket protocol is defined as union types in `wire.ts`:
 export type ForemanMessage =
   | { type: "task_assigned"; taskId: string; task: Task }
   | { type: "event_notification"; taskId: string; event: WebhookEvent }
-  | { type: "hello_ack"; workerId: string; status: "idle" | "busy" | "cancelled" };
+  | { type: "hello_ack"; workerId: string; status: "idle" | "busy" | "cancelled" }
+  | { type: "foreman_error"; message: string; fatal: boolean };
 
 export type WorkerMessage =
   | { type: "worker_hello"; workerId: string; claimedTaskId?: string }

--- a/shared/wire.ts
+++ b/shared/wire.ts
@@ -82,4 +82,5 @@ export type WorkerMessage =
 export type ForemanMessage =
   | { type: "task_assigned"; taskId: string; issue: TaskIssue }
   | { type: "event_notification"; taskId: string; event: WebhookEvent }
-  | { type: "hello_ack"; workerId: string; status: "idle" | "busy" | "cancelled" };
+  | { type: "hello_ack"; workerId: string; status: "idle" | "busy" | "cancelled" }
+  | { type: "foreman_error"; message: string; fatal: boolean };

--- a/src/agent/display.ts
+++ b/src/agent/display.ts
@@ -653,6 +653,7 @@ export const FOREMAN_MESSAGE_FMT: FmtTable = {
   task_assigned:      { verbose: (m) => c.darkGray(`Task assigned: #${m.issue.number}, ${m.issue.title}`) },
   event_notification: { verbose: (m) => c.darkGray(`Event received [${fmtTime()}]: ${fmtEvent(m.event as Wire.WebhookEvent)}`) },
   hello_ack:          { verbose: (m) => c.darkGray(`hello_ack: ${m.status}`) },
+  foreman_error:      (m) => c.boldRed(`[foreman error] ${m.message}`),
   _default:           (m) => c.darkGray(`Unknown foreman message: ${m.type}`),
 };
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -10,7 +10,7 @@ import { setThinkOutLoud, setVerbose, verbose } from "./display.js";
 import { StatusBar, statusBar, initStatusBar } from "./status-bar.js";
 import { ask, pick, pickMultiple, pickQuestion } from "./input.js";
 import type { PickQuestionResult } from "./input.js";
-import { WorkerSession, registerWorkerCommands, startWorkerMode, generateAgentId } from "./worker.js";
+import { WorkerSession, registerWorkerCommands, startWorkerMode, generateAgentId, WS_FATAL } from "./worker.js";
 import type { RunQuery, WorkerModeConfig } from "./worker.js";
 import { loadConfig } from "../config.js";
 import { Workspace, confirmIfUnsafe, registerWorkspaceCommands } from "./workspace.js";
@@ -364,6 +364,13 @@ export async function main(
     // Ignore the internal abort sentinel (fired when wsAbort resolves at the
     // same tick as the ask() call; never a user action).
     if (input === "__abort__") continue;
+
+    // WS_FATAL: a fatal foreman_error was received — drop back to interactive REPL.
+    // The session has already stopped reconnecting; just show the prompt and continue.
+    if (input === WS_FATAL) {
+      showPrompt = true;
+      continue;
+    }
 
     // WS_PROMPT: a task prompt or debounced event prompt is ready. Hide the
     // prompt, drain all queued prompts through runQueryFn, then show the prompt

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -10,7 +10,7 @@ import { setThinkOutLoud, setVerbose, verbose } from "./display.js";
 import { StatusBar, statusBar, initStatusBar } from "./status-bar.js";
 import { ask, pick, pickMultiple, pickQuestion } from "./input.js";
 import type { PickQuestionResult } from "./input.js";
-import { WorkerSession, registerWorkerCommands, startWorkerMode, generateAgentId, WS_FATAL } from "./worker.js";
+import { WorkerSession, registerWorkerCommands, startWorkerMode, generateAgentId } from "./worker.js";
 import type { RunQuery, WorkerModeConfig } from "./worker.js";
 import { loadConfig } from "../config.js";
 import { Workspace, confirmIfUnsafe, registerWorkspaceCommands } from "./workspace.js";
@@ -367,7 +367,7 @@ export async function main(
 
     // WS_FATAL: a fatal foreman_error was received — drop back to interactive REPL.
     // The session has already stopped reconnecting; just show the prompt and continue.
-    if (input === WS_FATAL) {
+    if (WorkerSession.isFatalSignal(input)) {
       showPrompt = true;
       continue;
     }

--- a/src/agent/worker.ts
+++ b/src/agent/worker.ts
@@ -131,6 +131,8 @@ export type WorkerModeConfig = {
 
 // Sentinel: a prompt is ready for main() to execute
 export const WS_PROMPT = "__ws_prompt__";
+// Sentinel: a fatal foreman error was received; main() should drop back to interactive REPL
+export const WS_FATAL = "__ws_fatal__";
 
 /** A prompt queued by WorkerSession for main() to execute. */
 export type QueuedPrompt = { prompt: string; fresh: boolean };
@@ -160,6 +162,7 @@ export class WorkerSession {
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private prIsClosed = false;
   private _resetPromise: Promise<void> | null = null;
+  private stopped = false;
   // Handshake lifecycle: "registered" = hello_ack received (or initial state);
   // "hello_sent" = worker_hello was sent but hello_ack not yet received.
   // Initialized to "registered" so sessions that never emit "open" (e.g. tests)
@@ -327,6 +330,15 @@ export class WorkerSession {
     return input === WS_PROMPT;
   }
 
+  /**
+   * Returns true if the input string is the fatal-error sentinel emitted by
+   * WorkerSession when a fatal foreman_error is received. Used by main() to
+   * drop back to interactive REPL mode without exiting the process.
+   */
+  static isFatalSignal(input: string): boolean {
+    return input === WS_FATAL;
+  }
+
   // ── Private ───────────────────────────────────────────────────────────────
 
   /**
@@ -419,6 +431,7 @@ export class WorkerSession {
     ws.on("close", (code: number, _reason: Buffer) => {
       clearPingTimer(); // always clean up the ping timer when this socket closes
       if (ws !== this.ws) return; // stale close from a previous connection
+      if (this.stopped) return; // fatal error received; don't reconnect
       const delay = 2000 + Math.random() * 3000;
       // Setting reconnectAt starts a 1-second countdown timer in the model.
       this.statusBar.update({
@@ -440,6 +453,17 @@ export class WorkerSession {
 
   private handleMessage(msg: Wire.ForemanMessage): void {
     this.display.printForemanMessage(msg);
+
+    if (msg.type === "foreman_error") {
+      if (msg.fatal) {
+        this.stopped = true;
+        this.currentAc?.abort(); // abort any running query immediately
+        this.ws?.close();
+        this.resolveWsInput?.(WS_FATAL);
+        this.resolveWsInput = null;
+      }
+      return;
+    }
 
     if (msg.type === "hello_ack") {
       if (msg.status === "cancelled") {

--- a/src/agent/worker.ts
+++ b/src/agent/worker.ts
@@ -130,9 +130,9 @@ export type WorkerModeConfig = {
 };
 
 // Sentinel: a prompt is ready for main() to execute
-export const WS_PROMPT = "__ws_prompt__";
+const WS_PROMPT = "__ws_prompt__";
 // Sentinel: a fatal foreman error was received; main() should drop back to interactive REPL
-export const WS_FATAL = "__ws_fatal__";
+const WS_FATAL = "__ws_fatal__";
 
 /** A prompt queued by WorkerSession for main() to execute. */
 export type QueuedPrompt = { prompt: string; fresh: boolean };

--- a/src/foreman/controllers/wss.ts
+++ b/src/foreman/controllers/wss.ts
@@ -153,7 +153,10 @@ export class ForemanWss {
           else if (msg.type === "worker_goodbye") await handleWorkerGoodbye(msg);
           else { log(`[worker ${workerId}] unknown message type: ${(msg as R).type}`); return; }
           await this.assignWork();
-        })().catch(err => log(`ERROR handling worker message: ${fmtError(err)}`));
+        })().catch(err => {
+          log(`ERROR handling worker message: ${fmtError(err)}`);
+          this.sendError(ws, `Internal error: ${fmtError(err)}`, false);
+        });
       });
 
       ws.on("close", (code, reason) => {
@@ -289,6 +292,17 @@ export class ForemanWss {
     log(`[worker ${shortWorkerId(wid)}] ${line}`);
   }
 
+  /**
+   * Send a foreman_error message directly to a WebSocket connection.
+   * Used when a catastrophic error occurs during hello handling or message
+   * processing — gives the worker an explanation instead of a silent drop.
+   */
+  private sendError(ws: WebSocket, message: string, fatal: boolean): void {
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: "foreman_error", message, fatal } satisfies Wire.ForemanMessage));
+    }
+  }
+
   // ── Hello handlers ───────────────────────────────────────────────────────────
 
   private flushQueuedEvents(worker: Worker, task: Task): void {
@@ -325,35 +339,40 @@ export class ForemanWss {
    * 6. Otherwise (live task, same or no worker) → reclaim
    */
   async handleBusyHello(workerId: string, claimedTaskId: string, ws: WebSocket): Promise<void> {
-    const existing = await Task.get(claimedTaskId);
-    const worker = Worker.register(workerId, ws);
+    try {
+      const existing = await Task.get(claimedTaskId);
+      const worker = Worker.register(workerId, ws);
 
-    if (!existing) {
-      this.workerLog(workerId, `hello busy task=#${claimedTaskId} — unknown task, respecting busy status`);
-      const issueNumber = parseInt(claimedTaskId, 10);
-      let placeholderTask: Task | null = null;
-      if (!isNaN(issueNumber)) {
-        placeholderTask = await Task.upsert(claimedTaskId, issueNumber, "", "", "", []);
-      }
-      if (placeholderTask) {
-        await this.reclaimWorker(worker, placeholderTask);
-      } else {
-        this.cancelWorker(worker, null);
-      }
-    } else if (existing.status === "complete") {
-      if (existing.workerId && existing.workerId !== workerId) {
-        this.workerLog(workerId, `hello busy task=#${claimedTaskId} — task complete but owned by another worker, cancelling`);
+      if (!existing) {
+        this.workerLog(workerId, `hello busy task=#${claimedTaskId} — unknown task, respecting busy status`);
+        const issueNumber = parseInt(claimedTaskId, 10);
+        let placeholderTask: Task | null = null;
+        if (!isNaN(issueNumber)) {
+          placeholderTask = await Task.upsert(claimedTaskId, issueNumber, "", "", "", []);
+        }
+        if (placeholderTask) {
+          await this.reclaimWorker(worker, placeholderTask);
+        } else {
+          this.cancelWorker(worker, null);
+        }
+      } else if (existing.status === "complete") {
+        if (existing.workerId && existing.workerId !== workerId) {
+          this.workerLog(workerId, `hello busy task=#${claimedTaskId} — task complete but owned by another worker, cancelling`);
+          this.cancelWorker(worker, existing);
+        } else {
+          this.workerLog(workerId, `hello busy task=#${claimedTaskId} — task already complete, reclaiming for finalization`);
+          await this.reclaimWorker(worker, existing);
+        }
+      } else if (existing.workerId && existing.workerId !== workerId) {
+        this.workerLog(workerId, `hello busy task=#${claimedTaskId} — task taken by another worker`);
         this.cancelWorker(worker, existing);
       } else {
-        this.workerLog(workerId, `hello busy task=#${claimedTaskId} — task already complete, reclaiming for finalization`);
+        this.workerLog(workerId, `hello busy task=#${claimedTaskId} — reclaimed`);
         await this.reclaimWorker(worker, existing);
       }
-    } else if (existing.workerId && existing.workerId !== workerId) {
-      this.workerLog(workerId, `hello busy task=#${claimedTaskId} — task taken by another worker`);
-      this.cancelWorker(worker, existing);
-    } else {
-      this.workerLog(workerId, `hello busy task=#${claimedTaskId} — reclaimed`);
-      await this.reclaimWorker(worker, existing);
+    } catch (err) {
+      log(`ERROR handleBusyHello ${workerId}: ${fmtError(err)}`);
+      this.sendError(ws, `Internal error during reconnection: ${fmtError(err)}`, false);
     }
   }
 
@@ -370,6 +389,7 @@ export class ForemanWss {
         this.workerLog(workerId, `hello idle (had task #${priorTask.taskId}) — reverting task to pending`);
       } catch (err) {
         log(`ERROR Failed to revert task #${priorTask.taskId} to pending: ${fmtError(err)}`);
+        this.sendError(ws, `Failed to revert prior task to pending: ${fmtError(err)}`, false);
         return; // don't register as idle — task stays assigned, worker retries on reconnect
       }
     } else {

--- a/tests/foreman.hello-handlers.test.ts
+++ b/tests/foreman.hello-handlers.test.ts
@@ -225,4 +225,56 @@ describe("handleIdleHello", () => {
     const ackCall = sendMsg.mock.calls.find(([, msg]) => (msg as { type: string }).type === "hello_ack");
     expect(ackCall).toBeUndefined();
   });
+
+  it("revert failure sends foreman_error (non-fatal) to the worker ws", async () => {
+    const task = addTask({
+      task_id: "10",
+      issue_number: 10,
+      worker_id: "w1",
+      assigned_at: new Date().toISOString(),
+    });
+    vi.mocked(task.revert).mockRejectedValueOnce(new Error("DB down"));
+
+    const { wss } = makeWss(taskManager);
+    vi.spyOn(utils, "log").mockImplementation(() => {});
+    const ws = fakeWs();
+    await wss.handleIdleHello("w1", ws);
+
+    const errorCall = ws.send.mock.calls.find(([data]: [string]) => {
+      const msg = JSON.parse(data);
+      return msg.type === "foreman_error";
+    });
+    expect(errorCall).toBeDefined();
+    const parsed = JSON.parse(errorCall![0]);
+    expect(parsed.fatal).toBe(false);
+    expect(parsed.message).toContain("DB down");
+  });
+});
+
+// ── handleBusyHello error handling ─────────────────────────────────────────────
+
+describe("handleBusyHello — error handling", () => {
+  it("sends foreman_error (non-fatal) when task.assign throws during reclaim", async () => {
+    const task = addTask({
+      task_id: "10",
+      issue_number: 10,
+      worker_id: "w1",
+      assigned_at: new Date().toISOString(),
+    });
+    vi.mocked(task.assign).mockRejectedValueOnce(new Error("DB write failed"));
+
+    const { wss } = makeWss(taskManager);
+    vi.spyOn(utils, "log").mockImplementation(() => {});
+    const ws = fakeWs();
+    await wss.handleBusyHello("w1", "10", ws);
+
+    const errorCall = ws.send.mock.calls.find(([data]: [string]) => {
+      const msg = JSON.parse(data);
+      return msg.type === "foreman_error";
+    });
+    expect(errorCall).toBeDefined();
+    const parsed = JSON.parse(errorCall![0]);
+    expect(parsed.fatal).toBe(false);
+    expect(parsed.message).toContain("DB write failed");
+  });
 });

--- a/tests/repl.foreman-message.test.ts
+++ b/tests/repl.foreman-message.test.ts
@@ -167,6 +167,34 @@ describe("printForemanMessage - hello_ack", () => {
   });
 });
 
+describe("printForemanMessage - foreman_error", () => {
+  it("foreman_error always prints the message (not verbose-only)", () => {
+    const msg: Wire.ForemanMessage = { type: "foreman_error", message: "DB connection lost", fatal: false };
+    const output = captureOutput(() => printForemanMessage(msg));
+    expect(stripAnsi(output)).toContain("DB connection lost");
+  });
+
+  it("foreman_error fatal=true also prints the message", () => {
+    const msg: Wire.ForemanMessage = { type: "foreman_error", message: "Catastrophic failure", fatal: true };
+    const output = captureOutput(() => printForemanMessage(msg));
+    expect(stripAnsi(output)).toContain("Catastrophic failure");
+  });
+
+  it("foreman_error prints even when verbose=false", () => {
+    setVerbose(false);
+    const msg: Wire.ForemanMessage = { type: "foreman_error", message: "Visible error", fatal: false };
+    const output = captureOutput(() => printForemanMessage(msg));
+    expect(stripAnsi(output.trim())).not.toBe("");
+    expect(stripAnsi(output)).toContain("Visible error");
+  });
+
+  it("foreman_error output contains error prefix", () => {
+    const msg: Wire.ForemanMessage = { type: "foreman_error", message: "Something broke", fatal: false };
+    const output = captureOutput(() => printForemanMessage(msg));
+    expect(stripAnsi(output)).toContain("[foreman error]");
+  });
+});
+
 describe("printForemanMessage - _default", () => {
   it("unknown type prints <type>", () => {
     const output = captureOutput(() => printForemanMessage({ type: "unknown_future_type" } as any));

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -12,6 +12,10 @@ class FakeWs extends EventEmitter {
   readyState = 1; // OPEN
   send = vi.fn();
   ping = vi.fn();
+  close = vi.fn().mockImplementation(() => {
+    this.readyState = 3; // CLOSED
+    this.emit("close", 1000, Buffer.from(""));
+  });
   terminate = vi.fn().mockImplementation(() => {
     this.readyState = 3; // CLOSED
     this.emit("close", 1006, Buffer.from(""));
@@ -1357,6 +1361,74 @@ describe("prIsClosed guard", () => {
 
 import { Workspace, registerWorkspaceCommands } from "../src/agent/workspace.js";
 import { CommandRegistry } from "../src/agent/command-registry.js";
+import { WS_FATAL } from "../src/agent/worker.js";
+
+// ── foreman_error ─────────────────────────────────────────────────────────────
+
+describe("foreman_error", () => {
+  it("non-fatal: calls printForemanMessage and does not queue a prompt", () => {
+    sendMsg(fakeWs, { type: "foreman_error", message: "Something went wrong", fatal: false });
+    expect(display.printForemanMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "foreman_error", message: "Something went wrong", fatal: false })
+    );
+    expect(session.hasPendingPrompts()).toBe(false);
+  });
+
+  it("non-fatal: does not stop reconnecting (close still triggers reconnect)", async () => {
+    vi.useFakeTimers();
+    try {
+      sendMsg(fakeWs, { type: "foreman_error", message: "Transient error", fatal: false });
+      fakeWs.emit("close", 1006, Buffer.from(""));
+      vi.advanceTimersByTime(6000);
+      // A new connection should have been made
+      expect(wsFactory).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("fatal: resolves WS input promise with WS_FATAL sentinel", async () => {
+    const wsInput = session.createWsInputPromise();
+    sendMsg(fakeWs, { type: "foreman_error", message: "Catastrophic failure", fatal: true });
+    const result = await wsInput;
+    expect(result).toBe(WS_FATAL);
+  });
+
+  it("fatal: does not reconnect after ws closes", async () => {
+    vi.useFakeTimers();
+    try {
+      sendMsg(fakeWs, { type: "foreman_error", message: "Fatal error", fatal: true });
+      // The fatal handler closes the ws, which triggers close event
+      // Advance past any reconnect delay
+      vi.advanceTimersByTime(10000);
+      // Should NOT have created a second connection
+      expect(wsFactory).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("fatal: aborts any running query", () => {
+    const ac = new AbortController();
+    session.notifyQueryStart(ac);
+    sendMsg(fakeWs, { type: "foreman_error", message: "Fatal error", fatal: true });
+    expect(ac.signal.aborted).toBe(true);
+    session.notifyQueryEnd(true);
+  });
+
+  it("fatal: calls printForemanMessage so the error is displayed", () => {
+    sendMsg(fakeWs, { type: "foreman_error", message: "Critical failure", fatal: true });
+    expect(display.printForemanMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "foreman_error", fatal: true })
+    );
+  });
+
+  it("isFatalSignal returns true only for WS_FATAL sentinel", () => {
+    expect(WorkerSession.isFatalSignal(WS_FATAL)).toBe(true);
+    expect(WorkerSession.isFatalSignal("__ws_prompt__")).toBe(false);
+    expect(WorkerSession.isFatalSignal("")).toBe(false);
+  });
+});
 
 // ── workspace slash commands via WorkerSession.workspace ──────────────────────
 

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1361,8 +1361,6 @@ describe("prIsClosed guard", () => {
 
 import { Workspace, registerWorkspaceCommands } from "../src/agent/workspace.js";
 import { CommandRegistry } from "../src/agent/command-registry.js";
-import { WS_FATAL } from "../src/agent/worker.js";
-
 // ── foreman_error ─────────────────────────────────────────────────────────────
 
 describe("foreman_error", () => {
@@ -1387,11 +1385,11 @@ describe("foreman_error", () => {
     }
   });
 
-  it("fatal: resolves WS input promise with WS_FATAL sentinel", async () => {
+  it("fatal: resolves WS input promise with the fatal sentinel", async () => {
     const wsInput = session.createWsInputPromise();
     sendMsg(fakeWs, { type: "foreman_error", message: "Catastrophic failure", fatal: true });
     const result = await wsInput;
-    expect(result).toBe(WS_FATAL);
+    expect(WorkerSession.isFatalSignal(result)).toBe(true);
   });
 
   it("fatal: does not reconnect after ws closes", async () => {
@@ -1423,10 +1421,13 @@ describe("foreman_error", () => {
     );
   });
 
-  it("isFatalSignal returns true only for WS_FATAL sentinel", () => {
-    expect(WorkerSession.isFatalSignal(WS_FATAL)).toBe(true);
-    expect(WorkerSession.isFatalSignal("__ws_prompt__")).toBe(false);
+  it("isFatalSignal returns true for the fatal sentinel and false for others", async () => {
+    const wsInput = session.createWsInputPromise();
+    sendMsg(fakeWs, { type: "foreman_error", message: "Fatal", fatal: true });
+    const sentinel = await wsInput;
+    expect(WorkerSession.isFatalSignal(sentinel)).toBe(true);
     expect(WorkerSession.isFatalSignal("")).toBe(false);
+    expect(WorkerSession.isWsSignal(sentinel)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `{ type: "foreman_error", message: string, fatal: boolean }` to the `ForemanMessage` wire type in `shared/wire.ts`
- Foreman sends this instead of silently dropping the connection when catastrophic errors occur during hello handling or message processing
- Worker displays it in bold red; if `fatal`, stops reconnecting and returns to interactive REPL mode (no process exit)

## Changes

**Wire protocol** (`shared/wire.ts`): New `foreman_error` variant on `ForemanMessage`.

**Foreman** (`src/foreman/controllers/wss.ts`):
- `sendError(ws, message, fatal)` — sends `foreman_error` directly to a socket
- `handleIdleHello`: sends non-fatal error when task revert fails (previously just logged and returned)
- `handleBusyHello`: wrapped in try/catch; sends non-fatal error on unexpected exceptions
- Outer message handler catch: sends non-fatal error so workers know something went wrong

**Worker** (`src/agent/worker.ts`, `src/agent/index.ts`):
- Non-fatal: prints and continues (handles display via `FOREMAN_MESSAGE_FMT`)
- Fatal: aborts running query, stops reconnecting (`stopped` flag), signals `main()` via new `WS_FATAL` sentinel → drops to interactive REPL prompt

**Display** (`src/agent/display.ts`): `foreman_error` always prints (not verbose-only) in bold red with `[foreman error]` prefix.

**Docs** (`docs/type-system.md`): Updated `ForemanMessage` example.

## Test plan

- [x] `tests/repl.foreman-message.test.ts` — foreman_error always prints, not verbose-gated, includes error prefix
- [x] `tests/worker.test.ts` — non-fatal continues, fatal stops reconnecting + resolves WS_FATAL + aborts query
- [x] `tests/foreman.hello-handlers.test.ts` — idle hello revert failure sends foreman_error; busy hello assign failure sends foreman_error
- [x] All 1445 unit tests passing; type check clean; lint clean

Closes #694

🤖 Generated with [Claude Code](https://claude.com/claude-code)