### PR TITLE
fix: classify hello handler errors as non-fatal (recoverable DB errors)

### DIFF
--- a/src/foreman/controllers/wss.ts
+++ b/src/foreman/controllers/wss.ts
@@ -366,6 +366,8 @@ export class ForemanWss {
       }
     } catch (err) {
       log(`ERROR handleBusyHello ${workerId}: ${fmtError(err)}`);
+      // DB error during task lookup or reclaim — recoverable: DB may be temporarily down.
+      // Worker retries on reconnect and the operation succeeds once the DB recovers.
       this.sendError(ws, `Internal error during reconnection: ${fmtError(err)}`, false);
     }
   }
@@ -376,21 +378,32 @@ export class ForemanWss {
    * registers the worker, and sends an idle hello_ack.
    */
   async handleIdleHello(workerId: string, ws: WebSocket): Promise<void> {
-    const priorTask = await Task.getByWorker(workerId);
-    if (priorTask) {
-      try {
-        await priorTask.revert();
-        this.workerLog(workerId, `hello idle (had task #${priorTask.taskId}) — reverting task to pending`);
-      } catch (err) {
-        log(`ERROR Failed to revert task #${priorTask.taskId} to pending: ${fmtError(err)}`);
-        this.sendError(ws, `Failed to revert prior task to pending: ${fmtError(err)}`, false);
-        return; // don't register as idle — task stays assigned, worker retries on reconnect
+    try {
+      // DB error here is transient — recoverable: worker retries on reconnect.
+      const priorTask = await Task.getByWorker(workerId);
+      if (priorTask) {
+        try {
+          await priorTask.revert();
+          this.workerLog(workerId, `hello idle (had task #${priorTask.taskId}) — reverting task to pending`);
+        } catch (err) {
+          log(`ERROR Failed to revert task #${priorTask.taskId} to pending: ${fmtError(err)}`);
+          // DB error reverting prior task — recoverable: task stays assigned so the
+          // failure is visible; a new idle assignment would create a double assignment.
+          // Worker retries on reconnect and the revert succeeds once the DB recovers.
+          this.sendError(ws, `Failed to revert prior task to pending: ${fmtError(err)}`, false);
+          return; // don't register as idle — task stays assigned, worker retries on reconnect
+        }
+      } else {
+        this.workerLog(workerId, "hello idle");
       }
-    } else {
-      this.workerLog(workerId, "hello idle");
+      const w = Worker.register(workerId, ws);
+      this.sendMsg(w, { type: "hello_ack", workerId: w.workerId, status: "idle" });
+    } catch (err) {
+      log(`ERROR handleIdleHello ${workerId}: ${fmtError(err)}`);
+      // DB error during worker lookup — recoverable: DB may be temporarily down.
+      // Worker retries on reconnect and the operation succeeds once the DB recovers.
+      this.sendError(ws, `Internal error during idle hello: ${fmtError(err)}`, false);
     }
-    const w = Worker.register(workerId, ws);
-    this.sendMsg(w, { type: "hello_ack", workerId: w.workerId, status: "idle" });
   }
 
   // ── Routing ─────────────────────────────────────────────────────────────────

--- a/tests/foreman.hello-handlers.test.ts
+++ b/tests/foreman.hello-handlers.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import http from "http";
 import { ForemanWss } from "../src/foreman/controllers/wss.js";
 import { Worker } from "../src/foreman/models/worker.js";
+import { Task } from "../src/foreman/models/task.js";
 import { TaskManager } from "../src/foreman/models/task-manager.js";
 import { setupInMemoryTasks } from "./helpers/task.js";
 import * as utils from "../src/utils.js";
@@ -252,8 +253,50 @@ describe("handleIdleHello", () => {
 });
 
 // ── handleBusyHello error handling ─────────────────────────────────────────────
+//
+// All errors in handleBusyHello are transient DB errors (Task.get failing,
+// Task.upsert failing, or task.assign failing during reclaim). These are
+// recoverable — the DB may be temporarily down — so fatal: false is correct.
+// The worker retries on reconnect and the operation succeeds once the DB recovers.
 
 describe("handleBusyHello — error handling", () => {
+  it("sends foreman_error (non-fatal) when Task.get throws (DB read failure)", async () => {
+    vi.mocked(Task.get).mockRejectedValueOnce(new Error("DB connection lost"));
+
+    const { wss } = makeWss(taskManager);
+    vi.spyOn(utils, "log").mockImplementation(() => {});
+    const ws = fakeWs();
+    await wss.handleBusyHello("w1", "10", ws);
+
+    const errorCall = ws.send.mock.calls.find(([data]: [string]) => {
+      const msg = JSON.parse(data);
+      return msg.type === "foreman_error";
+    });
+    expect(errorCall).toBeDefined();
+    const parsed = JSON.parse(errorCall![0]);
+    expect(parsed.fatal).toBe(false);
+    expect(parsed.message).toContain("DB connection lost");
+  });
+
+  it("sends foreman_error (non-fatal) when Task.upsert throws during placeholder creation", async () => {
+    // Task.get returns null (unknown task), numeric taskId, upsert fails
+    vi.mocked(Task.upsert).mockRejectedValueOnce(new Error("DB write failed"));
+
+    const { wss } = makeWss(taskManager);
+    vi.spyOn(utils, "log").mockImplementation(() => {});
+    const ws = fakeWs();
+    await wss.handleBusyHello("w1", "42", ws);
+
+    const errorCall = ws.send.mock.calls.find(([data]: [string]) => {
+      const msg = JSON.parse(data);
+      return msg.type === "foreman_error";
+    });
+    expect(errorCall).toBeDefined();
+    const parsed = JSON.parse(errorCall![0]);
+    expect(parsed.fatal).toBe(false);
+    expect(parsed.message).toContain("DB write failed");
+  });
+
   it("sends foreman_error (non-fatal) when task.assign throws during reclaim", async () => {
     const task = addTask({
       task_id: "10",
@@ -276,5 +319,44 @@ describe("handleBusyHello — error handling", () => {
     const parsed = JSON.parse(errorCall![0]);
     expect(parsed.fatal).toBe(false);
     expect(parsed.message).toContain("DB write failed");
+  });
+});
+
+// ── handleIdleHello error handling ─────────────────────────────────────────────
+//
+// All errors in handleIdleHello are transient DB errors (Task.getByWorker
+// failing, or priorTask.revert failing). These are recoverable — the DB may be
+// temporarily down — so fatal: false is correct in both cases. The worker
+// retries on reconnect and the operation succeeds once the DB recovers.
+
+describe("handleIdleHello — error handling", () => {
+  it("sends foreman_error (non-fatal) when Task.getByWorker throws (DB read failure)", async () => {
+    vi.mocked(Task.getByWorker).mockRejectedValueOnce(new Error("DB connection lost"));
+
+    const { wss } = makeWss(taskManager);
+    vi.spyOn(utils, "log").mockImplementation(() => {});
+    const ws = fakeWs();
+    await wss.handleIdleHello("w1", ws);
+
+    const errorCall = ws.send.mock.calls.find(([data]: [string]) => {
+      const msg = JSON.parse(data);
+      return msg.type === "foreman_error";
+    });
+    expect(errorCall).toBeDefined();
+    const parsed = JSON.parse(errorCall![0]);
+    expect(parsed.fatal).toBe(false);
+    expect(parsed.message).toContain("DB connection lost");
+  });
+
+  it("does not register worker when Task.getByWorker throws", async () => {
+    vi.mocked(Task.getByWorker).mockRejectedValueOnce(new Error("DB connection lost"));
+
+    const { wss, sendMsg } = makeWss(taskManager);
+    vi.spyOn(utils, "log").mockImplementation(() => {});
+    await wss.handleIdleHello("w1", fakeWs());
+
+    expect(Worker.get("w1")).toBeUndefined();
+    const ackCall = sendMsg.mock.calls.find(([, msg]) => (msg as { type: string }).type === "hello_ack");
+    expect(ackCall).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- Audited all error paths in `handleBusyHello` and `handleIdleHello` for fatality classification
- All errors are transient DB failures (Task.get, Task.upsert, task.assign, priorTask.revert, Task.getByWorker) — recoverable with retry → `fatal: false` throughout
- Fixed `handleIdleHello` to explicitly catch `Task.getByWorker` errors (previously uncaught, falling to generic outer handler) — now wraps the full body in a try/catch matching the pattern of `handleBusyHello`
- Added tests for all error paths documenting the `fatal: false` classification with rationale

## Audit findings

**`handleBusyHello` catch** — covers Task.get failure, Task.upsert failure (placeholder creation), and task.assign failure during reclaim. All are transient DB errors; the DB may be temporarily down and the operation will succeed on the next reconnect attempt.

**`handleIdleHello` — `priorTask.revert()` failure** — task stays assigned in DB so the failure is visible; registering the worker as idle would create a double assignment. Worker retries on reconnect. Correct as `fatal: false`.

**`handleIdleHello` — `Task.getByWorker()` failure** (previously uncaught) — DB error looking up prior task. Now caught explicitly with `fatal: false` and a specific error message.

The "unrecoverable" cases from the issue description (task taken by another worker, task with non-numeric ID) are already handled via `hello_ack: cancelled` (not via `sendError`), so the worker correctly resets to idle without a retry loop.

Closes #698

🤖 Generated with [Claude Code](https://claude.com/claude-code)