### PR TITLE
feat: prompt before quit when worker has an active task

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -9,7 +9,7 @@ import * as display from "./display.js";
 import { StatusBar, statusBar, initStatusBar } from "./status-bar.js";
 import { ask, pick, pickMultiple, pickQuestion } from "./input.js";
 import type { PickQuestionResult } from "./input.js";
-import { WorkerSession, registerWorkerCommands, startWorkerMode, generateAgentId } from "./worker.js";
+import { WorkerSession, registerWorkerCommands, startWorkerMode, generateAgentId, confirmTaskQuit } from "./worker.js";
 import type { RunQuery } from "./worker.js";
 import { loadConfig, getConfig } from "../config.js";
 import { Workspace, confirmIfUnsafe, registerWorkspaceCommands } from "./workspace.js";
@@ -288,7 +288,13 @@ export async function main(
   registry.register("exit", {
     description: "Exit",
     handler: async () => {
-      if (!session) await doExit();
+      if (!session) { await doExit(); return "exit"; }
+      const taskInfo = session.getTaskQuitInfo();
+      if (taskInfo) {
+        const choice = await confirmTaskQuit(taskInfo);
+        if (choice === "cancel") return undefined;
+        if (choice === "complete-and-quit") await session.completeCurrentTask();
+      }
       return "exit";
     },
   });
@@ -356,7 +362,13 @@ export async function main(
 
     // ^D / ^C on empty buffer — treat as exit.
     if (input === "__eof__") {
-      if (!session) await doExit();
+      if (!session) { await doExit(); break; }
+      const taskInfo = session.getTaskQuitInfo();
+      if (taskInfo) {
+        const choice = await confirmTaskQuit(taskInfo);
+        if (choice === "cancel") continue;
+        if (choice === "complete-and-quit") await session.completeCurrentTask();
+      }
       break;
     }
 

--- a/src/agent/worker.ts
+++ b/src/agent/worker.ts
@@ -120,6 +120,42 @@ const WS_PROMPT = "__ws_prompt__";
 // Sentinel: a fatal foreman error was received; main() should drop back to interactive REPL
 const WS_FATAL = "__ws_fatal__";
 
+/** Task state needed to decide whether and how to prompt before quitting. */
+export type TaskQuitInfo = {
+  taskNumber: number;
+  workerId: string;
+  issueClosed: boolean;
+};
+
+/**
+ * Prompt the user before quitting with an active task.
+ *
+ * - Issue closed but not complete: asks whether to complete first (default yes).
+ * - Issue still open: warns about unassignment and asks to confirm quit (default no).
+ *
+ * Returns 'quit' to proceed without completing, 'complete-and-quit' to mark
+ * the task complete then quit, or 'cancel' to stay in the worker.
+ *
+ * An injectable pickFn is accepted so callers can supply a mock in tests.
+ */
+export async function confirmTaskQuit(
+  info: TaskQuitInfo,
+  pickFn: (options: string[]) => Promise<number> = pick,
+): Promise<"quit" | "complete-and-quit" | "cancel"> {
+  if (info.issueClosed) {
+    display.print(display.c.amber(`\nTask #${info.taskNumber} is closed but not complete. Complete it before exiting?`));
+    const idx = await pickFn(["Yes, complete before exiting", "No, just exit", "Don't exit"]);
+    if (idx === 0) return "complete-and-quit";
+    if (idx === 1) return "quit";
+    return "cancel";
+  } else {
+    display.print(display.c.amber(`\nTask #${info.taskNumber} is still open. Quitting now will unassign ${info.workerId}. Quit anyway?`));
+    const idx = await pickFn(["No, keep working", "Yes, quit anyway"]);
+    if (idx === 1) return "quit";
+    return "cancel";
+  }
+}
+
 /** A prompt queued by WorkerSession for main() to execute. */
 export type QueuedPrompt = { prompt: string; fresh: boolean };
 
@@ -147,6 +183,7 @@ export class WorkerSession {
   private _queryRunning = false;
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private prIsClosed = false;
+  private issueClosed = false;
   private _resetPromise: Promise<void> | null = null;
   private stopped = false;
   // Handshake lifecycle: "registered" = hello_ack received (or initial state);
@@ -262,6 +299,19 @@ export class WorkerSession {
   /** Returns the workspace for use with registerWorkspaceCommands(). */
   get workspace(): Workspace | undefined {
     return this.options.workspace;
+  }
+
+  /**
+   * Returns task quit info if a task is currently active, undefined otherwise.
+   * Used by the quit/exit handlers to decide whether to prompt the user.
+   */
+  getTaskQuitInfo(): TaskQuitInfo | undefined {
+    if (!this.currentTaskId || !this.currentIssue) return undefined;
+    return {
+      taskNumber: this.currentIssue.number,
+      workerId: this.agentId,
+      issueClosed: this.issueClosed,
+    };
   }
 
   /**
@@ -494,6 +544,7 @@ export class WorkerSession {
       this.currentTaskId = msg.taskId;
       this.currentIssue = msg.issue;
       this.prIsClosed = false;
+      this.issueClosed = false;
       this.statusBar.update({ taskNumber: msg.issue.number, prNumber: undefined });
       void this.refreshBranch();
       const initialPrompt = buildInitialPrompt(msg.issue, !!this.options.workspace);
@@ -525,6 +576,12 @@ export class WorkerSession {
         } else if (pr?.number != null) {
           this.statusBar.update({ prNumber: pr.number });
         }
+      }
+
+      if (event.name === "issues" && action === "closed") {
+        this.issueClosed = true;
+      } else if (event.name === "issues" && action === "reopened") {
+        this.issueClosed = false;
       }
 
       if (event.name === "pull_request" && action === "closed") {
@@ -665,6 +722,12 @@ export async function startWorkerMode(): Promise<{
   const shutdown = async () => {
     if (shuttingDown) return;
     shuttingDown = true;
+    const taskInfo = session.getTaskQuitInfo();
+    if (taskInfo) {
+      const choice = await confirmTaskQuit(taskInfo);
+      if (choice === "cancel") { shuttingDown = false; return; }
+      if (choice === "complete-and-quit") await session.completeCurrentTask();
+    }
     const ok = await confirmIfUnsafe(workspace, workspace.confirm);
     if (ok) await workspace.destroy();
     process.exit(0);

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1361,6 +1361,8 @@ describe("prIsClosed guard", () => {
 
 import { Workspace, registerWorkspaceCommands } from "../src/agent/workspace.js";
 import { CommandRegistry } from "../src/agent/command-registry.js";
+import { confirmTaskQuit } from "../src/agent/worker.js";
+import type { TaskQuitInfo } from "../src/agent/worker.js";
 // ── foreman_error ─────────────────────────────────────────────────────────────
 
 describe("foreman_error", () => {
@@ -1715,5 +1717,154 @@ describe("heartbeat", () => {
     // Even after another interval, no more pings sent on the closed socket
     vi.advanceTimersByTime(100);
     expect(ws.ping).not.toHaveBeenCalled();
+  });
+});
+
+// ── getTaskQuitInfo ───────────────────────────────────────────────────────────
+
+describe("getTaskQuitInfo", () => {
+  it("returns undefined when no task is assigned", () => {
+    expect(session.getTaskQuitInfo()).toBeUndefined();
+  });
+
+  it("returns task info with issueClosed=false when task is assigned", () => {
+    const issue = makeIssue(7);
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "t7", issue });
+    const info = session.getTaskQuitInfo();
+    expect(info).toEqual({ taskNumber: 7, workerId: AGENT_ID, issueClosed: false });
+  });
+
+  it("returns undefined after task is completed", async () => {
+    const issue = makeIssue();
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "t1", issue });
+    session.takeNextPrompt();
+    await session.completeCurrentTask();
+    expect(session.getTaskQuitInfo()).toBeUndefined();
+  });
+
+  it("returns issueClosed=true after issues/closed event is received", () => {
+    const issue = makeIssue(5);
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "t5", issue });
+    session.takeNextPrompt();
+
+    const closedEvt: Wire.WebhookEvent = { id: "e1", name: "issues", payload: { action: "closed" } };
+    sendMsg(fakeWs, { type: "event_notification", taskId: "t5", event: closedEvt });
+
+    expect(session.getTaskQuitInfo()?.issueClosed).toBe(true);
+  });
+
+  it("returns issueClosed=false after issues/reopened follows issues/closed", () => {
+    const issue = makeIssue(5);
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "t5", issue });
+    session.takeNextPrompt();
+
+    sendMsg(fakeWs, { type: "event_notification", taskId: "t5", event: { id: "e1", name: "issues", payload: { action: "closed" } } });
+    expect(session.getTaskQuitInfo()?.issueClosed).toBe(true);
+
+    sendMsg(fakeWs, { type: "event_notification", taskId: "t5", event: { id: "e2", name: "issues", payload: { action: "reopened" } } });
+    expect(session.getTaskQuitInfo()?.issueClosed).toBe(false);
+  });
+
+  it("resets issueClosed to false on new task_assigned", () => {
+    const issue1 = makeIssue(1);
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "t1", issue: issue1 });
+    session.takeNextPrompt();
+
+    sendMsg(fakeWs, { type: "event_notification", taskId: "t1", event: { id: "e1", name: "issues", payload: { action: "closed" } } });
+    expect(session.getTaskQuitInfo()?.issueClosed).toBe(true);
+
+    const issue2 = makeIssue(2);
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "t2", issue: issue2 });
+    expect(session.getTaskQuitInfo()?.issueClosed).toBe(false);
+  });
+
+  it("does not set issueClosed when issues/closed is for a different task", () => {
+    const issue = makeIssue(5);
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "t5", issue });
+    session.takeNextPrompt();
+
+    // Event for a different task — should be ignored entirely
+    sendMsg(fakeWs, { type: "event_notification", taskId: "t99", event: { id: "e1", name: "issues", payload: { action: "closed" } } });
+    expect(session.getTaskQuitInfo()?.issueClosed).toBe(false);
+  });
+});
+
+// ── confirmTaskQuit ───────────────────────────────────────────────────────────
+
+describe("confirmTaskQuit", () => {
+  const openTask: TaskQuitInfo = { taskNumber: 42, workerId: "test-worker", issueClosed: false };
+  const closedTask: TaskQuitInfo = { taskNumber: 42, workerId: "test-worker", issueClosed: true };
+
+  it("open issue: returns 'cancel' when user picks 'No, keep working' (index 0)", async () => {
+    const mockPick = vi.fn().mockResolvedValue(0);
+    const result = await confirmTaskQuit(openTask, mockPick);
+    expect(result).toBe("cancel");
+  });
+
+  it("open issue: returns 'quit' when user picks 'Yes, quit anyway' (index 1)", async () => {
+    const mockPick = vi.fn().mockResolvedValue(1);
+    const result = await confirmTaskQuit(openTask, mockPick);
+    expect(result).toBe("quit");
+  });
+
+  it("open issue: prompt mentions task number and worker id", async () => {
+    const printSpy = vi.spyOn(displayModule, "print").mockImplementation(() => {});
+    try {
+      const mockPick = vi.fn().mockResolvedValue(0);
+      await confirmTaskQuit(openTask, mockPick);
+      const printed = printSpy.mock.calls.map(([s]) => stripAnsi(s as string)).join("\n");
+      expect(printed).toContain("#42");
+      expect(printed).toContain("test-worker");
+    } finally {
+      printSpy.mockRestore();
+    }
+  });
+
+  it("closed issue: returns 'complete-and-quit' when user picks index 0 (yes, complete)", async () => {
+    const mockPick = vi.fn().mockResolvedValue(0);
+    const result = await confirmTaskQuit(closedTask, mockPick);
+    expect(result).toBe("complete-and-quit");
+  });
+
+  it("closed issue: returns 'quit' when user picks index 1 (no, just exit)", async () => {
+    const mockPick = vi.fn().mockResolvedValue(1);
+    const result = await confirmTaskQuit(closedTask, mockPick);
+    expect(result).toBe("quit");
+  });
+
+  it("closed issue: returns 'cancel' when user picks index 2 (don't exit)", async () => {
+    const mockPick = vi.fn().mockResolvedValue(2);
+    const result = await confirmTaskQuit(closedTask, mockPick);
+    expect(result).toBe("cancel");
+  });
+
+  it("closed issue: prompt mentions task number", async () => {
+    const printSpy = vi.spyOn(displayModule, "print").mockImplementation(() => {});
+    try {
+      const mockPick = vi.fn().mockResolvedValue(0);
+      await confirmTaskQuit(closedTask, mockPick);
+      const printed = printSpy.mock.calls.map(([s]) => stripAnsi(s as string)).join("\n");
+      expect(printed).toContain("#42");
+    } finally {
+      printSpy.mockRestore();
+    }
+  });
+
+  it("open issue: pick is called with two options (No first, Yes second)", async () => {
+    const mockPick = vi.fn().mockResolvedValue(0);
+    await confirmTaskQuit(openTask, mockPick);
+    expect(mockPick).toHaveBeenCalledOnce();
+    const options = mockPick.mock.calls[0][0] as string[];
+    expect(options).toHaveLength(2);
+    expect(options[0].toLowerCase()).toContain("no");
+    expect(options[1].toLowerCase()).toContain("yes");
+  });
+
+  it("closed issue: pick is called with three options", async () => {
+    const mockPick = vi.fn().mockResolvedValue(0);
+    await confirmTaskQuit(closedTask, mockPick);
+    expect(mockPick).toHaveBeenCalledOnce();
+    const options = mockPick.mock.calls[0][0] as string[];
+    expect(options).toHaveLength(3);
   });
 });


### PR DESCRIPTION
## Summary

- When `/exit`, `^C` (SIGINT, no running query), or `^D` are used while a task is assigned, the worker now prompts instead of silently quitting
- If the issue is closed (`issues/closed` event received, no `issues/reopened`): asks "Task #N is closed but not complete. Complete it before exiting?" with three options — yes/complete first (default), no/just exit, don't exit
- If the issue is still open: warns "Task #N is still open. Quitting now will unassign <worker-id>. Quit anyway?" with no/keep working (default) and yes/quit anyway

## Implementation

- `WorkerSession` now tracks `issueClosed` state from `issues` webhook events (reset on each `task_assigned`)
- New `getTaskQuitInfo()` public method returns `{ taskNumber, workerId, issueClosed }` or `undefined`
- New exported `confirmTaskQuit(info, pickFn?)` function handles the prompt logic (injectable `pickFn` for testability)
- All three exit paths use the new confirmation: `/exit` command, `__eof__` handler, and `shutdown()` (SIGINT)

## Test plan

- [ ] 16 new unit tests cover `getTaskQuitInfo()` and `confirmTaskQuit()` for all cases (open/closed issue, all option choices, state tracking)
- [ ] All 1471 tests pass (3 failures are pre-existing DB tests requiring Supabase)
- [ ] Type-checks clean, lint clean

Closes #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)