### PR TITLE
fix: display general-purpose subagent type as Subagent

### DIFF
--- a/src/agent/views/display.ts
+++ b/src/agent/views/display.ts
@@ -538,6 +538,11 @@ export const USER_BLOCK_FMT: FmtTable = {
   _default: (b) => c.darkGray(`[user/${b.type}]`),
 };
 
+function fmtSubagentType(subagentType: string | null | undefined): string {
+  if (!subagentType || subagentType === "general-purpose") return "Subagent";
+  return subagentType;
+}
+
 export const TOOL_CALL_FMT: FmtTable = {
   Bash:       (b) => fmtToolCall(b, `$ ${b.input?.command ?? ""}`),
   Read:       (b) => fmtToolCall(b, `• Read(${toRelativePath(b.input?.file_path ?? "?")})`),
@@ -546,7 +551,7 @@ export const TOOL_CALL_FMT: FmtTable = {
   Glob:       (b) => fmtToolCall(b, `• Glob(${b.input?.pattern ?? "?"})`),
   Grep:       (b) => fmtToolCall(b, `• grep ${trunc(b.input?.pattern ?? "?", 30)} ${b.input?.path != null ? toRelativePath(b.input.path as string) : "."}`),
   Skill:      (b) => fmtToolCall(b, `• Skill(${b.input?.skill ?? "?"})`),
-  Agent:      (b) => fmtToolCall(b, `• ${b.input?.subagent_type ?? "Agent"}(${trunc(b.input?.prompt ?? "", 80)})`),
+  Agent:      (b) => fmtToolCall(b, `• ${fmtSubagentType(b.input?.subagent_type)}(${trunc(b.input?.prompt ?? "", 80)})`),
   ToolSearch: (b) => fmtToolCall(b, `• ToolSearch(${b.input?.query ?? "?"})`),
   TodoWrite:  (b) => fmtToolCall(b, `• TodoWrite(${fmtTodoWriteInput(b.input?.todos)})`),
   AskUserQuestion: (b) => fmtToolCall(b, `• AskUserQuestion(${fmtAskUserQuestionInput(b.input?.questions)})`),

--- a/tests/repl.formats.test.ts
+++ b/tests/repl.formats.test.ts
@@ -170,6 +170,20 @@ describe("TOOL_CALL_FMT", () => {
     expect(result).toContain("• Explore(find files)");
   });
 
+  it("Agent: shows • Subagent(<prompt>) for general-purpose subagent type", () => {
+    const result = r(TOOL_CALL_FMT, "Agent", {
+      input: { subagent_type: "general-purpose", prompt: "research something" },
+    });
+    expect(result).toContain("• Subagent(research something)");
+  });
+
+  it("Agent: shows • Subagent(<prompt>) when subagent_type is missing", () => {
+    const result = r(TOOL_CALL_FMT, "Agent", {
+      input: { prompt: "research something" },
+    });
+    expect(result).toContain("• Subagent(research something)");
+  });
+
   it("AskUserQuestion: shows question text(s)", () => {
     const result = r(TOOL_CALL_FMT, "AskUserQuestion", {
       input: { questions: [{ question: "Which approach?", header: "Approach", options: [], multiSelect: false }] },


### PR DESCRIPTION
## Summary

- When an `Agent` tool call has `subagent_type: "general-purpose"` (or no subagent type), the TUI was showing `• general-purpose(...)` which looked awkward
- Now renders as `• Subagent(...)` — consistent with named types like `• Explore(...)` or `• Plan(...)`

## Test plan

- [x] Added test for `general-purpose` → `Subagent` rendering
- [x] Added test for missing `subagent_type` → `Subagent` rendering
- [x] All existing tests still pass

Closes #711

🤖 Generated with [Claude Code](https://claude.com/claude-code)