### PR TITLE
fix: code review cleanup — bugs, dead code, duplication, re-exports

### DIFF
--- a/src/agent/controllers/agent-controller.ts
+++ b/src/agent/controllers/agent-controller.ts
@@ -35,6 +35,9 @@ export type AgentPermConfig = {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
+/** The SDK query object exposes supportedModels() as an undocumented extension. */
+type QueryWithModels = { supportedModels?: () => Promise<ModelInfo[]> };
+
 /**
  * Returns a function that fetches available Claude models from the SDK.
  * Used by the /model command to populate the model picker.
@@ -42,7 +45,6 @@ export type AgentPermConfig = {
 export function createFetchModelsFn(permConfig: AgentPermConfig): FetchModelsFn {
   return async () => {
     const q = query({ prompt: "", options: { cwd: process.cwd(), systemPrompt: { type: "preset", preset: "claude_code" }, permissionMode: permConfig.permissionMode } });
-    type QueryWithModels = { supportedModels?: () => Promise<ModelInfo[]> };
     const qm = q as unknown as QueryWithModels;
     if (typeof qm.supportedModels === "function") return qm.supportedModels();
     return [];
@@ -134,7 +136,6 @@ export class AgentController {
     });
 
     // Cache the available models list from the SDK (fire-and-forget).
-    type QueryWithModels = { supportedModels?: () => Promise<ModelInfo[]> };
     const qm = iterable as unknown as QueryWithModels;
     if (typeof qm.supportedModels === "function") {
       qm.supportedModels().then(models => { Settings.setCachedModels(models); }).catch(() => {});

--- a/src/agent/controllers/command-controller.ts
+++ b/src/agent/controllers/command-controller.ts
@@ -43,7 +43,7 @@ export type DispatchResult =
  * Sort order: prefix matches of name, then non-prefix name substring matches,
  * then description-only matches.
  */
-function filterCommands(query: string, commands: CommandSuggestion[]): CommandSuggestion[] {
+export function filterCommands(query: string, commands: CommandSuggestion[]): CommandSuggestion[] {
   if (query === "") return commands;
   const q = query.toLowerCase();
   const prefixName = commands.filter(c => c.name.toLowerCase().startsWith(q));

--- a/src/agent/views/display.ts
+++ b/src/agent/views/display.ts
@@ -16,8 +16,6 @@ import {
   formatForemanMessage,
 } from "./renderer.js";
 
-export type { ToolUseBlock, ToolResultBlock, ContentBlock } from "./renderer.js";
-
 // ── Display class ──────────────────────────────────────────────────────────
 
 /**

--- a/src/agent/views/input.ts
+++ b/src/agent/views/input.ts
@@ -1,19 +1,6 @@
 import { c } from "./style.js";
 import type { Display } from "./display.js";
-import type { CommandSuggestion } from "../controllers/command-controller.js";
-
-function filterCommands(query: string, commands: CommandSuggestion[]): CommandSuggestion[] {
-  if (query === "") return commands;
-  const q = query.toLowerCase();
-  const prefixName = commands.filter(c => c.name.toLowerCase().startsWith(q));
-  const substringName = commands.filter(
-    c => !c.name.toLowerCase().startsWith(q) && c.name.toLowerCase().includes(q),
-  );
-  const descOnly = commands.filter(
-    c => !c.name.toLowerCase().includes(q) && c.description.toLowerCase().includes(q),
-  );
-  return [...prefixName, ...substringName, ...descOnly];
-}
+import { type CommandSuggestion, filterCommands } from "../controllers/command-controller.js";
 
 // ── Stash ─────────────────────────────────────────────────────────────────────
 

--- a/src/agent/views/renderer.ts
+++ b/src/agent/views/renderer.ts
@@ -120,9 +120,9 @@ export function toolResultText(b: { content: unknown }): string {
 
 // ── Diff rendering ─────────────────────────────────────────────────────────
 
-export function fmtHunk(hunk: Hunk): string {
+export function fmtHunk(hunk: Hunk, verbose = false): string {
   const header = c.darkGray(`@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@`);
-  const width = effectiveWidth(80);
+  const width = effectiveWidth(80, verbose);
   const lines = hunk.lines.map(line => {
     if (line.startsWith("+")) return c.bgGreen(line.padEnd(width));
     if (line.startsWith("-")) return c.bgRed(line.padEnd(width));
@@ -136,9 +136,10 @@ export function fmtHunk(hunk: Hunk): string {
 export function fmtEditResult(b: {
   content: unknown;
   _msg?: { tool_use_result?: { structuredPatch?: Hunk[] } };
+  _verbose?: boolean;
 }): string {
   const patch = b._msg?.tool_use_result?.structuredPatch;
-  if (patch && patch.length > 0) return patch.map(fmtHunk).join("\n");
+  if (patch && patch.length > 0) return patch.map(h => fmtHunk(h, b._verbose)).join("\n");
   return c.darkGray(`→ ${trunc(toolResultText(b), 100)}`);
 }
 
@@ -207,37 +208,6 @@ function mdInline(text: string): string {
   return text;
 }
 
-function wrapText(text: string, width: number): string[] {
-  if (width <= 0 || text.length <= width) return [text];
-  const words = text.split(" ");
-  const lines: string[] = [];
-  let current = "";
-  for (const word of words) {
-    if (current === "") {
-      if (word.length > width) {
-        let rest = word;
-        while (rest.length > width) { lines.push(rest.slice(0, width)); rest = rest.slice(width); }
-        current = rest;
-      } else {
-        current = word;
-      }
-    } else if (current.length + 1 + word.length <= width) {
-      current += " " + word;
-    } else {
-      lines.push(current);
-      if (word.length > width) {
-        let rest = word;
-        while (rest.length > width) { lines.push(rest.slice(0, width)); rest = rest.slice(width); }
-        current = rest;
-      } else {
-        current = word;
-      }
-    }
-  }
-  if (current) lines.push(current);
-  return lines.length > 0 ? lines : [""];
-}
-
 // Strips ANSI escape sequences to measure the visible length of a string.
 function visLen(str: string): number {
   return str.replace(/\x1b\[[0-9;]*m/g, "").length;
@@ -248,8 +218,8 @@ function ansiPadEnd(str: string, width: number): string {
   return str + " ".repeat(Math.max(0, width - visLen(str)));
 }
 
-// Like wrapText but measures word lengths by visible characters, so ANSI
-// escape sequences in pre-formatted strings don't distort line breaks.
+// Wraps text at visible-character boundaries, ignoring ANSI escape sequences,
+// so pre-formatted strings don't have line breaks distorted by color codes.
 function wrapTextAnsi(text: string, width: number): string[] {
   if (width <= 0 || visLen(text) <= width) return [text];
   const words = text.split(" ");
@@ -573,7 +543,7 @@ export function formatToolResult(
   return _resolve(
     b.is_error ? TOOL_ERROR_FMT : TOOL_RESULT_FMT,
     toolName,
-    { ...b, _msg: msg },
+    { ...b, _msg: msg, _verbose: verbose },
     verbose,
   );
 }

--- a/src/agent/views/status-bar.ts
+++ b/src/agent/views/status-bar.ts
@@ -3,6 +3,7 @@ import { shortWorkerId } from "../../../shared/utils.js";
 import { getConfig } from "../../config.js";
 import type { Settings } from "../models/settings.js";
 import type { EffortValue } from "../models/settings.js";
+import { W } from "./style.js";
 
 // ── Worker status types ────────────────────────────────────────────────────────
 
@@ -18,10 +19,6 @@ export type WorkerStatusPatch = {
   model?: string | undefined;
   effort?: EffortValue | undefined;
 };
-
-// ── Worker status bar formatting ──────────────────────────────────────────────
-
-const W = 70;
 
 // ── StatusBar class ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes from a systematic code review. No behavior changes.

- **Bug**: `fmtHunk` was ignoring the `verbose` flag when computing terminal width (`effectiveWidth(80)` → `effectiveWidth(80, verbose)`). In verbose mode, diffs were 9 chars too wide because the timestamp prefix wasn't accounted for.
- **Dead code**: Remove `wrapText` function in `renderer.ts` — defined but never called (only referenced in a now-updated comment).
- **Duplication**: `filterCommands` was defined identically in both `input.ts` and `command-controller.ts`. Export it from command-controller and import in input.
- **Duplication**: `QueryWithModels` type defined twice in `agent-controller.ts`. Hoisted to module level.
- **Duplication**: `W = 70` in `status-bar.ts` — import from `style.ts` instead.
- **Re-export**: Remove `export type { ToolUseBlock, ToolResultBlock, ContentBlock }` from `display.ts` — no external callers, violates the no-re-export convention.

## Issues filed for follow-up

- #730 Move `stash` state into `Input` class instance
- #731 Move model cache into `Settings` class instance
- #732 Move `WorkerDisplay` interface to views layer
- #733 Replace sentinel string signals with typed worker signals
- #734 Extract `drainPendingPrompts` helper in `index.ts`

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm test` — same failures as `main` (DB tests need Supabase; one pre-existing HTTP test failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)