### PR TITLE
cleanup: minor foreman code smells

### DIFF
--- a/src/foreman/controllers/admin-ws.ts
+++ b/src/foreman/controllers/admin-ws.ts
@@ -1,5 +1,5 @@
 import http from "http";
-import { WebSocketServer } from "ws";
+import { WebSocketServer, WebSocket } from "ws";
 import type { WebSocket as WsSocket } from "ws";
 import type { Task, Worker, LogEntry, AdminSnapshot, AdminMessage } from "../../../shared/wire.js";
 
@@ -40,7 +40,7 @@ export function createAdminWss(server: http.Server, getSnapshot?: () => Promise<
   function broadcast(msg: AdminMessage) {
     const json = JSON.stringify(msg);
     for (const ws of clients) {
-      if (ws.readyState === 1 /* OPEN */) ws.send(json);
+      if (ws.readyState === WebSocket.OPEN) ws.send(json);
     }
   }
 

--- a/src/foreman/models/task-manager.ts
+++ b/src/foreman/models/task-manager.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from "events";
+import { EventEmitter } from "node:events";
 import type { WebhookEvent } from "./webhook-event.js";
 import * as Wire from "../../../shared/wire.js";
 import { loadIssuesToQueue, fetchIssueStates } from "../clients/github.js";

--- a/src/foreman/models/task.ts
+++ b/src/foreman/models/task.ts
@@ -148,7 +148,7 @@ export class Task extends ActiveRecord {
     body: string,
   ): Promise<number[]> {
     const [bodyBlockers, nativeBlockers] = await Promise.all([
-      Promise.resolve(Task.parseBodyBlockers(body)),
+      Task.parseBodyBlockers(body),
       fetchNativeBlockers(issueNumber),
     ]);
     return Array.from(new Set([...bodyBlockers, ...nativeBlockers]));

--- a/src/foreman/models/worker.ts
+++ b/src/foreman/models/worker.ts
@@ -1,5 +1,6 @@
-import { EventEmitter } from "events";
+import { EventEmitter } from "node:events";
 import * as Wire from "../../../shared/wire.js";
+import { WebSocket } from "ws";
 import type { WebSocket as WsSocket } from "ws";
 import type { Task } from "./task.js";
 
@@ -84,7 +85,7 @@ export class Worker {
   }
 
   send(msg: Wire.ForemanMessage): boolean {
-    if (this.ws.readyState === 1 /* OPEN */) {
+    if (this.ws.readyState === WebSocket.OPEN) {
       this.ws.send(JSON.stringify(msg));
       return true;
     }


### PR DESCRIPTION
## Summary

- Replace magic number `1` with `WebSocket.OPEN` in `worker.ts` and `admin-ws.ts`
- Remove unnecessary `Promise.resolve()` wrapper around the synchronous `Task.parseBodyBlockers()` call in `task.ts`
- Standardize `EventEmitter` import to `"node:events"` in `task-manager.ts` and `worker.ts` (already correct in `task.ts` and `active-record.ts`)

## Test plan

- [x] `npx tsc --noEmit` — passes with no errors
- [x] `npm test` — all 1341 tests pass (3 DB test failures are pre-existing infrastructure requirement, unrelated to these changes)

Closes #743

🤖 Generated with [Claude Code](https://claude.com/claude-code)