### PR TITLE
refactor: consolidate pull_request handling in event_notification handler

### DIFF
--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -535,8 +535,8 @@ export class WorkerSession extends EventEmitter {
       const { event } = msg;
       const action = event.payload["action"] as string | undefined;
 
-      // Track PR number from any pull_request event for the status bar.
       if (event.name === "pull_request") {
+        // Track PR number for the status bar.
         const pr = event.payload["pull_request"] as { number?: number; merged?: boolean } | undefined;
         if (action === "closed" && !pr?.merged) {
           // PR was closed without merging — clear the PR from the status bar.
@@ -544,20 +544,20 @@ export class WorkerSession extends EventEmitter {
         } else if (pr?.number != null) {
           this.statusBar.update({ prNumber: pr.number });
         }
-      }
-
-      if (event.name === "issues" && action === "closed") {
-        this.issueClosed = true;
-      } else if (event.name === "issues" && action === "reopened") {
-        this.issueClosed = false;
-      }
-
-      if (event.name === "pull_request" && action === "closed") {
-        this.prIsClosed = true;
-        // process normally (cleanup prompt still fires)
-      } else if (event.name === "pull_request" && action === "reopened") {
-        this.prIsClosed = false;
-        // process normally
+        // Track prIsClosed flag.
+        if (action === "closed") {
+          this.prIsClosed = true;
+          // process normally (cleanup prompt still fires)
+        } else if (action === "reopened") {
+          this.prIsClosed = false;
+          // process normally
+        }
+      } else if (event.name === "issues") {
+        if (action === "closed") {
+          this.issueClosed = true;
+        } else if (action === "reopened") {
+          this.issueClosed = false;
+        }
       } else if (this.prIsClosed && event.name === "check_suite") {
         // Post-merge check suite: already logged via printForemanMessage; silently drop.
         return;


### PR DESCRIPTION
## Summary

- Merges the two separate `pull_request` event blocks in `WorkerSession.handleMessage()` into a single `if/else if` chain
- Status bar update and `prIsClosed` tracking are now co-located inside one `pull_request` branch
- `issues` handling and the `check_suite` drop are now proper `else if` siblings — no longer interspersed between the PR blocks
- Pure reordering: no logic changes

## Test plan

- [x] All existing unit tests pass (`npm test` — 1343 tests)
- [x] TypeScript type check clean (`npx tsc --noEmit`)

Closes #753

🤖 Generated with [Claude Code](https://claude.com/claude-code)