### PR TITLE
fix: forward issues/closed and issues/reopened events to worker; restructure routeIssueEvent()

### DIFF
--- a/src/foreman/controllers/wss.ts
+++ b/src/foreman/controllers/wss.ts
@@ -526,8 +526,12 @@ export class ForemanWss {
 
     const action = p.action as string | undefined;
 
-    // If the issue isn't queued yet, check if this webhook should enqueue it.
+    // Phase 1: foreman-side effects.
+    // Return early only when there is genuinely nothing to forward: no task tracked,
+    // or "unlabeled" (worker doesn't need to know the label was removed).
+
     if (!task) {
+      // Check if this webhook should enqueue a new task.
       const labeledNow =
         action === "labeled" &&
         (p.label as R | undefined)?.name === this.config.taskLabel;
@@ -551,12 +555,15 @@ export class ForemanWss {
         log(`[task #${issueNumber}] enqueued via issues/${action}`);
         return routeResult(enqueued);
       }
+      // No task found and not an enqueue event — still fall through so closed/reopened
+      // can update blocker state (issue may be a dependency, not a task itself).
     }
 
     if (
       action === "unlabeled" &&
       (p.label as R | undefined)?.name === this.config.taskLabel
     ) {
+      // Explicit early return: worker doesn't need to know the label was removed.
       try {
         await this.taskManager.dequeueIssue(issueNumber);
         log(`[task #${issueNumber}] dequeued (label removed)`);
@@ -576,7 +583,6 @@ export class ForemanWss {
         return routeResult(task);
       }
       await this.assignWork();
-      return routeResult(task);
     }
 
     if (action === "reopened") {
@@ -587,7 +593,6 @@ export class ForemanWss {
         return routeResult(task);
       }
       await this.assignWork();
-      return routeResult(task);
     }
 
     if (action === "edited") {
@@ -600,6 +605,8 @@ export class ForemanWss {
       }
     }
 
+    // Phase 2: forward to worker. Forwarding is the default; skipping requires an explicit return above.
+    // No task means there is no worker to notify (e.g., event was for a dependency issue).
     if (!task) return routeResult(null);
     this.forwardEvent(task, evt, `#${issueNumber}`);
     return routeResult(task);

--- a/src/foreman/controllers/wss.ts
+++ b/src/foreman/controllers/wss.ts
@@ -519,16 +519,19 @@ export class ForemanWss {
     return routeResult(null);
   }
 
-  async routeIssueEvent(p: R, evt: WebhookEvent, issue: R, issueNumber: number): Promise<RouteResult> {
+  /**
+   * Phase 1: apply foreman-side effects for an issue event.
+   * Returns the task to forward to the worker, or null to skip notification.
+   * Returning null is an explicit signal: newly-enqueued tasks have no worker yet,
+   * unlabeled doesn't need worker notification, and errors skip forwarding to avoid
+   * notifying the worker of state the foreman failed to record.
+   */
+  private async applyIssueEffects(p: R, issue: R, issueNumber: number): Promise<Task | null> {
     let task = await Task.getByIssue(issueNumber);
     // GitHub issue_comment events on PRs have the PR number in issue.number.
     if (!task) task = await Task.getByPr(issueNumber);
 
     const action = p.action as string | undefined;
-
-    // Phase 1: foreman-side effects.
-    // Return early only when there is genuinely nothing to forward: no task tracked,
-    // or "unlabeled" (worker doesn't need to know the label was removed).
 
     if (!task) {
       // Check if this webhook should enqueue a new task.
@@ -551,9 +554,9 @@ export class ForemanWss {
           log(`ERROR Failed to persist task #${issueNumber}: ${fmtError(err)}`);
           return null;
         });
-        if (!enqueued) return routeResult(null);
+        if (!enqueued) return null;
         log(`[task #${issueNumber}] enqueued via issues/${action}`);
-        return routeResult(enqueued);
+        return enqueued; // returned for routeResult; forwardEvent will queue it (no worker yet)
       }
       // No task found and not an enqueue event — still fall through so closed/reopened
       // can update blocker state (issue may be a dependency, not a task itself).
@@ -563,16 +566,15 @@ export class ForemanWss {
       action === "unlabeled" &&
       (p.label as R | undefined)?.name === this.config.taskLabel
     ) {
-      // Explicit early return: worker doesn't need to know the label was removed.
       try {
         await this.taskManager.dequeueIssue(issueNumber);
         log(`[task #${issueNumber}] dequeued (label removed)`);
       } catch (err) {
         log(`ERROR Failed to dequeue task #${issueNumber}: ${fmtError(err)}`);
-        return routeResult(task);
+        return null; // error: skip notification
       }
       await this.assignWork();
-      return routeResult(task);
+      return null; // worker doesn't need to know the label was removed
     }
 
     if (action === "closed") {
@@ -580,7 +582,7 @@ export class ForemanWss {
         await this.taskManager.closeIssue(issueNumber);
       } catch (err) {
         log(`ERROR Failed to close issue #${issueNumber}: ${fmtError(err)}`);
-        return routeResult(task);
+        return null; // error: skip notification to avoid inconsistency
       }
       await this.assignWork();
     }
@@ -590,7 +592,7 @@ export class ForemanWss {
         await this.taskManager.reopenIssue(issueNumber);
       } catch (err) {
         log(`ERROR Failed to reopen issue #${issueNumber}: ${fmtError(err)}`);
-        return routeResult(task);
+        return null; // error: skip notification to avoid inconsistency
       }
       await this.assignWork();
     }
@@ -605,10 +607,13 @@ export class ForemanWss {
       }
     }
 
-    // Phase 2: forward to worker. Forwarding is the default; skipping requires an explicit return above.
-    // No task means there is no worker to notify (e.g., event was for a dependency issue).
-    if (!task) return routeResult(null);
-    this.forwardEvent(task, evt, `#${issueNumber}`);
+    return task; // null if no task (e.g., dependency issue — nothing to forward)
+  }
+
+  /** Phase 2: always invoked; forwards to the worker iff phase 1 found a task to notify. */
+  async routeIssueEvent(p: R, evt: WebhookEvent, issue: R, issueNumber: number): Promise<RouteResult> {
+    const task = await this.applyIssueEffects(p, issue, issueNumber);
+    if (task) this.forwardEvent(task, evt, `#${issueNumber}`);
     return routeResult(task);
   }
 

--- a/src/foreman/controllers/wss.ts
+++ b/src/foreman/controllers/wss.ts
@@ -610,7 +610,6 @@ export class ForemanWss {
     return task; // null if no task (e.g., dependency issue — nothing to forward)
   }
 
-  /** Phase 2: always invoked; forwards to the worker iff phase 1 found a task to notify. */
   async routeIssueEvent(p: R, evt: WebhookEvent, issue: R, issueNumber: number): Promise<RouteResult> {
     const task = await this.applyIssueEffects(p, issue, issueNumber);
     if (task) this.forwardEvent(task, evt, `#${issueNumber}`);

--- a/src/foreman/controllers/wss.ts
+++ b/src/foreman/controllers/wss.ts
@@ -556,7 +556,7 @@ export class ForemanWss {
         });
         if (!enqueued) return null;
         log(`[task #${issueNumber}] enqueued via issues/${action}`);
-        return enqueued; // returned for routeResult; forwardEvent will queue it (no worker yet)
+        return null; // task just enqueued; no worker assigned yet, nothing to forward
       }
       // No task found and not an enqueue event — still fall through so closed/reopened
       // can update blocker state (issue may be a dependency, not a task itself).

--- a/tests/foreman.event-router.handlers.test.ts
+++ b/tests/foreman.event-router.handlers.test.ts
@@ -334,7 +334,7 @@ describe("routeCheckEvent — via branch name", () => {
 // ── routeIssueEvent ───────────────────────────────────────────────────────────
 
 describe("routeIssueEvent — enqueue on labeled", () => {
-  it("calls handleIssueLabeledEvent and returns the enqueued task", async () => {
+  it("calls handleIssueLabeledEvent and logs enqueue; returns null (no worker assigned yet)", async () => {
     const task = Task.fromTest({ task_id: "42", issue_number: 42 });
     const { wss, taskManager } = makeDeps();
     taskManager.handleIssueLabeledEvent.mockResolvedValue(task);
@@ -348,7 +348,7 @@ describe("routeIssueEvent — enqueue on labeled", () => {
     expect(taskManager.handleIssueLabeledEvent).toHaveBeenCalledWith(
       42, "Do something", "details", ["brunel:ready"], "open",
     );
-    expect(result).toEqual({ taskId: "42", workerId: null });
+    expect(result).toEqual({ taskId: null, workerId: null });
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("enqueued via issues/labeled"));
   });
 
@@ -381,7 +381,7 @@ describe("routeIssueEvent — enqueue on labeled", () => {
 });
 
 describe("routeIssueEvent — enqueue on opened", () => {
-  it("calls handleIssueLabeledEvent when opened with the task label already attached", async () => {
+  it("calls handleIssueLabeledEvent when opened with the task label already attached; returns null (no worker yet)", async () => {
     const task = Task.fromTest({ task_id: "42", issue_number: 42 });
     const { wss, taskManager } = makeDeps();
     taskManager.handleIssueLabeledEvent.mockResolvedValue(task);
@@ -393,7 +393,7 @@ describe("routeIssueEvent — enqueue on opened", () => {
       42,
     );
     expect(taskManager.handleIssueLabeledEvent).toHaveBeenCalled();
-    expect(result).toEqual({ taskId: "42", workerId: null });
+    expect(result).toEqual({ taskId: null, workerId: null });
   });
 
   it("does not call handleIssueLabeledEvent when opened without the task label", async () => {

--- a/tests/foreman.webhook-routing.test.ts
+++ b/tests/foreman.webhook-routing.test.ts
@@ -852,4 +852,38 @@ describe("foreman event filtering", () => {
 
     expect(await Task.getByIssue(42)).toBeNull();
   });
+
+  it("issues/closed is forwarded to the assigned worker", async () => {
+    await registerReady(taskManager, "42", 42, "owner/repo", "Issue 42", "Body", ["brunel:ready"]);
+
+    const ws = await connect();
+    send(ws, { type: "worker_hello", workerId: "w1", status: "idle" });
+    await nextMsgWhere(ws, (m) => m.type === "task_assigned");
+
+    const reply = nextMsgWhere(ws, m => m.type === "event_notification" && (m as any).event.name === "issues");
+    foremanWss.routeEvent("evt-closed", "issues", {
+      action: "closed",
+      issue: { number: 42, title: "Issue 42", body: "Body", labels: [{ name: "brunel:ready" }] },
+      repository: { html_url: "https://github.com/owner/repo" },
+    });
+    const msg = await reply;
+    expect((msg as any).event.payload.action).toBe("closed");
+  });
+
+  it("issues/reopened is forwarded to the assigned worker", async () => {
+    await registerReady(taskManager, "42", 42, "owner/repo", "Issue 42", "Body", ["brunel:ready"]);
+
+    const ws = await connect();
+    send(ws, { type: "worker_hello", workerId: "w1", status: "idle" });
+    await nextMsgWhere(ws, (m) => m.type === "task_assigned");
+
+    const reply = nextMsgWhere(ws, m => m.type === "event_notification" && (m as any).event.name === "issues");
+    foremanWss.routeEvent("evt-reopened", "issues", {
+      action: "reopened",
+      issue: { number: 42, title: "Issue 42", body: "Body", labels: [{ name: "brunel:ready" }] },
+      repository: { html_url: "https://github.com/owner/repo" },
+    });
+    const msg = await reply;
+    expect((msg as any).event.payload.action).toBe("reopened");
+  });
 });


### PR DESCRIPTION
## Summary

- `issues/closed` and `issues/reopened` events now fall through to `forwardEvent` instead of returning early after foreman-side effects
- `routeIssueEvent` is restructured into two explicit phases: foreman effects first, then a single `forwardEvent` at the bottom
- Explicit `return` statements are now reserved for cases with nothing to forward (`unlabeled`, enqueue path), making it structurally impossible to accidentally skip forwarding again

## Root cause

Both `closed` and `reopened` branches called `return routeResult(task)` after calling the task manager, skipping the `forwardEvent` call at the bottom. The worker's `issueClosed` flag was never set, so `confirmTaskQuit()` always showed "task is still open, quit anyway?" even when the issue was closed.

## Test plan

- [x] Added `issues/closed is forwarded to the assigned worker` test
- [x] Added `issues/reopened is forwarded to the assigned worker` test
- [x] All 1345 unit tests pass
- [x] TypeScript type check clean

Closes #755