### PR TITLE
fix: reposition status bar below prompt when ask() starts

### DIFF
--- a/src/agent/views/input.ts
+++ b/src/agent/views/input.ts
@@ -92,8 +92,13 @@ export class Input {
 
       if (this._promptLine) process.stdout.write("\x1b[?25h"); // show cursor when there's a visible prompt
       process.stdout.write(promptStr);
-      // If buffer was pre-populated from stash, render it immediately.
-      if (this._buffer) this._fullRedraw(0, this._computeMatches());
+      // Redraw the full prompt area (including status bars below) whenever there
+      // is a visible prompt. This is required even when the buffer is empty: if
+      // the status bar is active the cursor was sitting on the blank separator
+      // row above it, so the leading \n in promptStr moves into the bar line and
+      // `[agent] > ` overwrites its beginning.  _fullRedraw clears the bar line
+      // and calls drawRaw() to position the bar below the fresh prompt.
+      if (this._promptLine) this._fullRedraw(0, this._computeMatches());
 
       // Register the fresh-redraw hook so print() can notify us.
       if (this._promptLine) {

--- a/tests/repl.input.test.ts
+++ b/tests/repl.input.test.ts
@@ -623,6 +623,52 @@ describe("ask() - blank line suppression with \\n prefix prompt", () => {
   });
 });
 
+describe("ask() - status bar repositioning on start (issue #757)", () => {
+  it("ask() with active persistent status bar calls drawRaw() immediately to position bar below prompt", async () => {
+    // Regression test for issue #757: when ask() starts after a query, the cursor
+    // sits on the blank separator row above the persistent status bar. The leading
+    // \n in "\n[agent] > " moves the cursor INTO the bar line and the prompt text
+    // overwrites its beginning.  ask() must call _fullRedraw() unconditionally (not
+    // only when the buffer is pre-populated from stash) so that drawRaw() is called
+    // and the bar is repositioned below the fresh prompt.
+    const statusBar = new StatusBar({ agentId: "test-agent" });
+    statusBar.persistentActive = true; // simulate post-query state with bar active
+    const display = new Display(getConfig(), statusBar);
+    const input = new Input(display);
+    const drawRawSpy = vi.spyOn(statusBar, "drawRaw");
+    const writeSpy = vi.mocked(process.stdout.write);
+    writeSpy.mockClear();
+
+    await withFakeStdin(async (stdin) => {
+      const p = input.ask("\n[agent] > ");
+
+      // drawRaw() must have been called during ask() initialisation —
+      // before any user input arrives.
+      expect(drawRawSpy).toHaveBeenCalled();
+
+      stdin.push("\r");
+      await p;
+    });
+  });
+
+  it("ask() with no active status bar still works correctly (drawRaw no-ops)", async () => {
+    // With no active bars drawRaw() returns 0 without writing; calling it is
+    // harmless, but the prompt should still render correctly.
+    const statusBar = new StatusBar({ agentId: "test-agent" }); // persistentActive defaults false
+    const display = new Display(getConfig(), statusBar);
+    const input = new Input(display);
+    const drawRawSpy = vi.spyOn(statusBar, "drawRaw");
+
+    await withFakeStdin(async (stdin) => {
+      const p = input.ask("\n[agent] > ");
+      // drawRaw() is called but returns 0 (no rows written); prompt still resolves
+      expect(drawRawSpy).toHaveBeenCalled();
+      stdin.push("hello\r");
+      expect(await p).toBe("hello");
+    });
+  });
+});
+
 describe("promptLine()", () => {
   it("resolves with typed text on Enter", async () => {
     await withFakeStdin(async (stdin) => {


### PR DESCRIPTION
## Summary

- When `ask()` starts after a query finishes, the cursor is on the blank separator row above the persistent status bar. The leading `\n` in `"\n[agent] > "` moves the cursor into the bar line, and the prompt text overwrites its beginning — producing the corrupted display from issue #757.
- Previously `_fullRedraw()` was only called when the buffer was pre-populated from stash. Changed the condition to `if (this._promptLine)` so the status bar is always repositioned below the fresh prompt whenever there is a visible prompt.
- Added two regression tests verifying `drawRaw()` is called during `ask()` initialisation with and without an active persistent status bar.

## Test plan

- [ ] `npm test` passes (all 1345 non-DB tests green)
- [ ] `npx tsc --noEmit` passes (no type errors)
- [ ] In a live worker session, run a task to completion and verify the status bar appears cleanly below the `[agent] >` prompt (not merged into the same line)

Closes #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)