### PR TITLE
fix: restore task_id association for issues/labeled webhook event log

### DIFF
--- a/src/foreman/controllers/wss.ts
+++ b/src/foreman/controllers/wss.ts
@@ -556,7 +556,7 @@ export class ForemanWss {
         });
         if (!enqueued) return null;
         log(`[task #${issueNumber}] enqueued via issues/${action}`);
-        return null; // task just enqueued; no worker assigned yet, nothing to forward
+        return enqueued; // worker ignores labeled events; returned so task_id is logged in webhook_events
       }
       // No task found and not an enqueue event — still fall through so closed/reopened
       // can update blocker state (issue may be a dependency, not a task itself).

--- a/tests/foreman.event-router.handlers.test.ts
+++ b/tests/foreman.event-router.handlers.test.ts
@@ -334,7 +334,7 @@ describe("routeCheckEvent — via branch name", () => {
 // ── routeIssueEvent ───────────────────────────────────────────────────────────
 
 describe("routeIssueEvent — enqueue on labeled", () => {
-  it("calls handleIssueLabeledEvent and logs enqueue; returns null (no worker assigned yet)", async () => {
+  it("calls handleIssueLabeledEvent and returns the enqueued task", async () => {
     const task = Task.fromTest({ task_id: "42", issue_number: 42 });
     const { wss, taskManager } = makeDeps();
     taskManager.handleIssueLabeledEvent.mockResolvedValue(task);
@@ -348,7 +348,7 @@ describe("routeIssueEvent — enqueue on labeled", () => {
     expect(taskManager.handleIssueLabeledEvent).toHaveBeenCalledWith(
       42, "Do something", "details", ["brunel:ready"], "open",
     );
-    expect(result).toEqual({ taskId: null, workerId: null });
+    expect(result).toEqual({ taskId: "42", workerId: null });
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("enqueued via issues/labeled"));
   });
 
@@ -381,7 +381,7 @@ describe("routeIssueEvent — enqueue on labeled", () => {
 });
 
 describe("routeIssueEvent — enqueue on opened", () => {
-  it("calls handleIssueLabeledEvent when opened with the task label already attached; returns null (no worker yet)", async () => {
+  it("calls handleIssueLabeledEvent when opened with the task label already attached", async () => {
     const task = Task.fromTest({ task_id: "42", issue_number: 42 });
     const { wss, taskManager } = makeDeps();
     taskManager.handleIssueLabeledEvent.mockResolvedValue(task);
@@ -393,7 +393,7 @@ describe("routeIssueEvent — enqueue on opened", () => {
       42,
     );
     expect(taskManager.handleIssueLabeledEvent).toHaveBeenCalled();
-    expect(result).toEqual({ taskId: null, workerId: null });
+    expect(result).toEqual({ taskId: "42", workerId: null });
   });
 
   it("does not call handleIssueLabeledEvent when opened without the task label", async () => {

--- a/tests/pipeline.test.ts
+++ b/tests/pipeline.test.ts
@@ -566,6 +566,7 @@ describe("pipeline: PR events forwarded and logged to DB", () => {
     send(ws, { type: "worker_hello", workerId: "w-pr", status: "idle" });
     await q.next(); // hello_ack
     await q.next(); // task_assigned
+    await q.next(); // event_notification: issues/labeled (queued at enqueue time, flushed on assign)
 
     // 2. Worker opens a PR that closes issue #100 (forwarded as event_notification)
     //    and a check_run fires for the PR.  Both are routed before awaiting any


### PR DESCRIPTION
## Summary

- `applyIssueEffects` now returns the enqueued task so its ID is preserved in the `webhook_events` DB row for `issues/labeled` events (admin dashboard tracing)
- The worker safely ignores the resulting `issues/labeled` event notification — it only acts on `closed` and `reopened` actions
- Update `pipeline.test.ts` to consume the queued labeled notification that is flushed to the worker immediately after `task_assigned`

This was a minor regression introduced during the #755 refactor where returning `null` for the enqueue path lost the task_id association.

## Test plan

- [x] All 120 unit tests pass
- [x] `pipeline.test.ts` updated to account for the flushed event

🤖 Generated with [Claude Code](https://claude.com/claude-code)