### PR TITLE
test: encapsulate terminal width — remove process.stdout.columns patching

### DIFF
--- a/src/agent/views/display.ts
+++ b/src/agent/views/display.ts
@@ -35,6 +35,12 @@ export class Display {
   private readonly _toolUseInputs = new Map<string, Record<string, unknown>>();
   readonly renderer: Renderer;
 
+  /**
+   * Returns the current terminal column count. Defaults to reading
+   * `process.stdout.columns`; override in tests to avoid global patching.
+   */
+  getColumns: () => number | undefined = () => process.stdout.columns;
+
   constructor(readonly config: BrunelConfig, readonly statusBar: StatusBar) {
     this.renderer = new Renderer(this);
   }
@@ -45,7 +51,7 @@ export class Display {
   get verbose(): boolean { return this.config.verbose; }
 
   effectiveWidth(fallback = W): number {
-    return (process.stdout.columns ?? fallback) - (this.verbose ? VERBOSE_PREFIX_LEN : 0);
+    return (this.getColumns() ?? fallback) - (this.verbose ? VERBOSE_PREFIX_LEN : 0);
   }
 
   private _printLine(line: string): void {

--- a/src/agent/views/input.ts
+++ b/src/agent/views/input.ts
@@ -120,7 +120,7 @@ export class Input {
   // Row 0 is the line that contains the visual start of the prompt.
 
   private _screenPosOf(pos: number): { row: number; col: number } {
-    const cols = process.stdout.columns || 80;
+    const cols = this.display.getColumns() || 80;
     // Pasted newlines are rendered as \r\n    (CR + LF + 4-space indent)
     const disp = this._buffer.slice(0, pos).replace(/\n/g, "\r\n    ");
     let row = 0;
@@ -140,7 +140,7 @@ export class Input {
 
   private _renderSuggestions(suggestions: CommandSuggestion[], selIdx = -1): string[] {
     if (suggestions.length === 0) return [];
-    const cols = process.stdout.columns || 80;
+    const cols = this.display.getColumns() || 80;
     const maxNameLen = Math.max(...suggestions.map(s => s.name.length));
     return suggestions.map((s, i) => {
       const isSelected = i === selIdx;

--- a/src/agent/views/status-bar.ts
+++ b/src/agent/views/status-bar.ts
@@ -70,9 +70,16 @@ export class StatusBar extends EventEmitter {
   // prompt area including any leading blank line (see issue #418).
   inputClear: (() => void) | null = null;
 
-  constructor({ agentId, settings, ...initial }: { agentId: string; settings?: Settings } & Omit<WorkerStatusPatch, "reconnectAt">) {
+  /**
+   * Returns the current terminal column count. Defaults to reading
+   * `process.stdout.columns`; override in tests to avoid global patching.
+   */
+  getColumns: () => number | undefined = () => process.stdout.columns;
+
+  constructor({ agentId, settings, getColumns, ...initial }: { agentId: string; settings?: Settings; getColumns?: () => number | undefined } & Omit<WorkerStatusPatch, "reconnectAt">) {
     super();
     this.agentId = agentId;
+    if (getColumns) this.getColumns = getColumns;
     if ("connectionStatus" in initial) this._connectionStatus = initial.connectionStatus!;
     if ("disconnectCode" in initial) this._disconnectCode = initial.disconnectCode;
     if ("taskNumber" in initial) this._taskNumber = initial.taskNumber;
@@ -142,7 +149,7 @@ export class StatusBar extends EventEmitter {
   }
 
   private _fmtWorkerStatus(): string {
-    const width = (process.stdout.columns ?? W) - 1; // -1 to avoid last-column wrap
+    const width = (this.getColumns() ?? W) - 1; // -1 to avoid last-column wrap
 
     // Right side: connection status
     const retryInSeconds = this._reconnectAt != null

--- a/tests/display.worker-status.test.ts
+++ b/tests/display.worker-status.test.ts
@@ -19,8 +19,9 @@ function getStatus(opts: {
   disconnectCode?: number;
   reconnectAt?: number;
   verbose?: boolean;
+  getColumns?: () => number | undefined;
 }): string {
-  const bar = new StatusBar({ agentId: opts.agentId });
+  const bar = new StatusBar({ agentId: opts.agentId, getColumns: opts.getColumns });
   if (opts.verbose !== undefined) getConfig().verbose = opts.verbose;
   bar.update({
     connectionStatus: opts.connectionStatus,
@@ -52,25 +53,19 @@ describe("StatusBar status text", () => {
   });
 
   it("with task, PR, and branch", () => {
-    const origColumns = Object.getOwnPropertyDescriptor(process.stdout, "columns");
-    Object.defineProperty(process.stdout, "columns", { value: 120, configurable: true });
-    try {
-      const result = getStatus({
-        agentId: "7c254628-abcd-1234-efgh-000000000000",
-        taskNumber: 374,
-        prNumber: 406,
-        branch: "db-single-source-of-truth",
-        connectionStatus: "connected",
-      });
-      expect(result).toContain("worker 7c254628");
-      expect(result).toContain("task #374");
-      expect(result).toContain("PR #406");
-      expect(result).toContain("db-single-source-of-truth");
-      expect(result).toContain("Connected");
-    } finally {
-      if (origColumns) Object.defineProperty(process.stdout, "columns", origColumns);
-      else delete (process.stdout as { columns?: number }).columns;
-    }
+    const result = getStatus({
+      agentId: "7c254628-abcd-1234-efgh-000000000000",
+      taskNumber: 374,
+      prNumber: 406,
+      branch: "db-single-source-of-truth",
+      connectionStatus: "connected",
+      getColumns: () => 120,
+    });
+    expect(result).toContain("worker 7c254628");
+    expect(result).toContain("task #374");
+    expect(result).toContain("PR #406");
+    expect(result).toContain("db-single-source-of-truth");
+    expect(result).toContain("Connected");
   });
 
   it("disconnected shows Disconnected on right", () => {
@@ -161,25 +156,15 @@ describe("StatusBar status text", () => {
   });
 
   it("result fits within terminal width", () => {
-    const origColumns = Object.getOwnPropertyDescriptor(process.stdout, "columns");
-    Object.defineProperty(process.stdout, "columns", { value: 80, configurable: true });
-    try {
-      const result = getStatus({
-        agentId: "7c254628-abcd-1234-efgh-000000000000",
-        taskNumber: 374,
-        prNumber: 406,
-        branch: "my-very-long-branch-name-that-is-quite-verbose",
-        connectionStatus: "connected",
-      });
-      expect(result.length).toBe(79); // width - 1 (last-column wrap avoidance)
-    } finally {
-      if (origColumns) {
-        Object.defineProperty(process.stdout, "columns", origColumns);
-      } else {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        delete (process.stdout as any).columns;
-      }
-    }
+    const result = getStatus({
+      agentId: "7c254628-abcd-1234-efgh-000000000000",
+      taskNumber: 374,
+      prNumber: 406,
+      branch: "my-very-long-branch-name-that-is-quite-verbose",
+      connectionStatus: "connected",
+      getColumns: () => 80,
+    });
+    expect(result.length).toBe(79); // width - 1 (last-column wrap avoidance)
   });
 
   it("shows 'sonnet' when model is undefined", () => {

--- a/tests/repl.markdown.test.ts
+++ b/tests/repl.markdown.test.ts
@@ -21,7 +21,7 @@ function printText(text: string): string {
 }
 
 const setColumns = (n: number | undefined) => {
-  Object.defineProperty(process.stdout, "columns", { value: n, writable: true, configurable: true });
+  testDisplay.getColumns = () => n;
 };
 
 beforeEach(() => {
@@ -244,10 +244,6 @@ describe("renderMarkdown - tables", () => {
 });
 
 describe("renderTable - text wrapping", () => {
-  let savedColumns: number | undefined;
-
-  beforeEach(() => { savedColumns = process.stdout.columns; });
-  afterEach(() => { setColumns(savedColumns); });
 
   it("table that fits within maxWidth is not wrapped", () => {
     setColumns(80);
@@ -307,10 +303,6 @@ describe("renderTable - text wrapping", () => {
 });
 
 describe("renderTable - inline formatting column widths", () => {
-  let savedColumns: number | undefined;
-
-  beforeEach(() => { savedColumns = process.stdout.columns; });
-  afterEach(() => { setColumns(savedColumns); });
 
   it("all rows have equal visible column widths when mixing bold and plain cells", () => {
     setColumns(80);

--- a/tests/repl.multiline.test.ts
+++ b/tests/repl.multiline.test.ts
@@ -13,7 +13,6 @@ function makeStdin() {
 }
 
 let origStdin: NodeJS.ReadStream;
-let origColumns: number | undefined;
 
 function withFakeStdin(fn: (stdin: PassThrough) => Promise<void>): Promise<void> {
   const stdin = makeStdin();
@@ -24,7 +23,7 @@ function withFakeStdin(fn: (stdin: PassThrough) => Promise<void>): Promise<void>
 }
 
 function setColumns(n: number) {
-  Object.defineProperty(process.stdout, "columns", { value: n, configurable: true, writable: true });
+  testDisplay.getColumns = () => n;
 }
 
 function collectOutput(spy: ReturnType<typeof vi.spyOn>): string {
@@ -38,15 +37,11 @@ beforeEach(() => {
   testDisplay = new Display(getConfig(), new StatusBar({ agentId: "test-agent" }));
   testInput = new Input(testDisplay);
   origStdin = process.stdin;
-  origColumns = process.stdout.columns;
   vi.spyOn(process.stdout, "write").mockImplementation(() => true);
 });
 
 afterEach(() => {
   Object.defineProperty(process, "stdin", { value: origStdin, configurable: true });
-  if (origColumns !== undefined) {
-    setColumns(origColumns);
-  }
   vi.restoreAllMocks();
 });
 

--- a/tests/status-bar.test.ts
+++ b/tests/status-bar.test.ts
@@ -60,19 +60,12 @@ describe("StatusBar getStatusText", () => {
   });
 
   it("shows task, PR, and branch when set", () => {
-    const origColumns = Object.getOwnPropertyDescriptor(process.stdout, "columns");
-    Object.defineProperty(process.stdout, "columns", { value: 120, configurable: true });
-    try {
-      const bar = new StatusBar({ agentId: "7c254628-abcd-1234-efgh-000000000000" });
-      bar.update({ taskNumber: 374, prNumber: 406, branch: "db-single-source-of-truth", connectionStatus: "connected" });
-      const result = stripAnsi(bar.getStatusText());
-      expect(result).toContain("task #374");
-      expect(result).toContain("PR #406");
-      expect(result).toContain("db-single-source-of-truth");
-    } finally {
-      if (origColumns) Object.defineProperty(process.stdout, "columns", origColumns);
-      else delete (process.stdout as { columns?: number }).columns;
-    }
+    const bar = new StatusBar({ agentId: "7c254628-abcd-1234-efgh-000000000000", getColumns: () => 120 });
+    bar.update({ taskNumber: 374, prNumber: 406, branch: "db-single-source-of-truth", connectionStatus: "connected" });
+    const result = stripAnsi(bar.getStatusText());
+    expect(result).toContain("task #374");
+    expect(result).toContain("PR #406");
+    expect(result).toContain("db-single-source-of-truth");
   });
 });
 
@@ -144,17 +137,11 @@ describe("StatusBar class", () => {
       bar.startPersistent();
       stdoutWrite.mockClear();
 
-      const origColumns = Object.getOwnPropertyDescriptor(process.stdout, "columns");
-      Object.defineProperty(process.stdout, "columns", { value: 40, configurable: true });
-      try {
-        process.stdout.emit("resize");
-        const writes = stdoutWrite.mock.calls.map(a => String(a[0]));
-        expect(writes.length).toBeGreaterThan(0);
-        expect(writes.join("")).toContain("Connected");
-      } finally {
-        if (origColumns) Object.defineProperty(process.stdout, "columns", origColumns);
-        else delete (process.stdout as { columns?: number }).columns;
-      }
+      bar.getColumns = () => 40;
+      process.stdout.emit("resize");
+      const writes = stdoutWrite.mock.calls.map(a => String(a[0]));
+      expect(writes.length).toBeGreaterThan(0);
+      expect(writes.join("")).toContain("Connected");
     });
 
     it("does not register multiple resize listeners on repeated startPersistent calls", () => {


### PR DESCRIPTION
## Summary

- Add `getColumns: () => number | undefined` as an injectable property on `StatusBar` and `Display` (defaults to `() => process.stdout.columns`)
- Update `Input._screenPosOf()` and `Input._renderSuggestions()` to call `this.display.getColumns()` instead of reading `process.stdout.columns` directly
- Replace all `Object.defineProperty(process.stdout, 'columns', ...)` calls in tests with simple property assignments (`bar.getColumns = () => 120`, `testDisplay.getColumns = () => 80`, etc.)

## Test plan

- [ ] `npm test` — all 1347 existing tests pass, no new failures
- [ ] `npx tsc --noEmit` — no type errors
- [ ] Grep for `Object.defineProperty.*stdout.*columns` in tests — zero matches

Closes #765

🤖 Generated with [Claude Code](https://claude.com/claude-code)