### PR TITLE
test: assert forwardEvent call/no-call for every routing action

### DIFF
--- a/tests/foreman.event-router.handlers.test.ts
+++ b/tests/foreman.event-router.handlers.test.ts
@@ -24,6 +24,7 @@ function makeEvent(name = "pull_request"): WebhookEvent {
 interface TestDeps {
   wss: ForemanWss;
   sendMsg: ReturnType<typeof vi.fn>;
+  forwardEvent: ReturnType<typeof vi.spyOn>;
   taskManager: {
     queueEvent: ReturnType<typeof vi.fn>;
     dequeueIssue: ReturnType<typeof vi.fn>;
@@ -59,7 +60,8 @@ function makeDeps(): TestDeps {
     server: http.createServer(),
   });
   const sendMsg = vi.spyOn(wss, "sendMsg").mockImplementation(() => {});
-  return { wss, sendMsg, taskManager };
+  const forwardEvent = vi.spyOn(wss, "forwardEvent");
+  return { wss, sendMsg, forwardEvent, taskManager };
 }
 
 let taskStore: ReturnType<typeof setupInMemoryTasks>;
@@ -79,22 +81,24 @@ afterEach(() => {
 
 describe("routePrEvent — missing PR number", () => {
   it("returns null task when pull_request has no number", async () => {
-    const { wss } = makeDeps();
+    const { wss, forwardEvent } = makeDeps();
     const result = await wss.routePrEvent({ pull_request: {} }, makeEvent());
     expect(result).toEqual({ taskId: null, workerId: null });
+    expect(forwardEvent).not.toHaveBeenCalled();
   });
 });
 
 describe("routePrEvent — synchronize", () => {
   it("returns the task without forwarding when action is synchronize", async () => {
     taskStore.addTask({ task_id: "42", issue_number: 42, pr_number: 99 });
-    const { wss, sendMsg } = makeDeps();
+    const { wss, sendMsg, forwardEvent } = makeDeps();
     const result = await wss.routePrEvent(
       { action: "synchronize", pull_request: { number: 99 } },
       makeEvent(),
     );
     expect(result.taskId).toBe("42");
     expect(sendMsg).not.toHaveBeenCalled();
+    expect(forwardEvent).not.toHaveBeenCalled();
   });
 });
 
@@ -104,7 +108,7 @@ describe("routePrEvent — opened", () => {
     const w = Worker.register("worker-1", fakeWs());
     task.workerId = "worker-1";
     w.assign(task);
-    const { wss, sendMsg, taskManager } = makeDeps();
+    const { wss, sendMsg, forwardEvent, taskManager } = makeDeps();
     taskManager.handlePrOpenedEvent.mockResolvedValue(task);
     const result = await wss.routePrEvent(
       {
@@ -118,18 +122,20 @@ describe("routePrEvent — opened", () => {
       makeEvent(),
     );
     expect(taskManager.handlePrOpenedEvent).toHaveBeenCalledWith(99, "Closes #42", "feature-branch");
+    expect(forwardEvent).toHaveBeenCalledOnce();
     expect(sendMsg).toHaveBeenCalledOnce();
     expect(result.taskId).toBe("42");
   });
 
   it("returns null when handlePrOpenedEvent finds no linked issue", async () => {
-    const { wss, sendMsg, taskManager } = makeDeps();
+    const { wss, sendMsg, forwardEvent, taskManager } = makeDeps();
     taskManager.handlePrOpenedEvent.mockResolvedValue(null);
     const result = await wss.routePrEvent(
       { action: "opened", pull_request: { number: 99, body: "no link here", head: { ref: "branch" } } },
       makeEvent(),
     );
     expect(result).toEqual({ taskId: null, workerId: null });
+    expect(forwardEvent).not.toHaveBeenCalled();
     expect(sendMsg).not.toHaveBeenCalled();
   });
 });
@@ -140,25 +146,27 @@ describe("routePrEvent — closed without merge", () => {
     const w = Worker.register("worker-1", fakeWs());
     task.workerId = "worker-1";
     w.assign(task);
-    const { wss, sendMsg, taskManager } = makeDeps();
+    const { wss, sendMsg, forwardEvent, taskManager } = makeDeps();
     taskManager.handlePrClosedEvent.mockResolvedValue(task);
     const result = await wss.routePrEvent(
       { action: "closed", pull_request: { number: 99, merged: false } },
       makeEvent(),
     );
     expect(taskManager.handlePrClosedEvent).toHaveBeenCalledWith(99, false);
+    expect(forwardEvent).toHaveBeenCalledOnce();
     expect(sendMsg).toHaveBeenCalledOnce();
     expect(result.taskId).toBe("42");
   });
 
   it("returns null when no task owns the PR", async () => {
-    const { wss, sendMsg, taskManager } = makeDeps();
+    const { wss, forwardEvent, taskManager } = makeDeps();
     taskManager.handlePrClosedEvent.mockResolvedValue(null);
     const result = await wss.routePrEvent(
       { action: "closed", pull_request: { number: 99, merged: false } },
       makeEvent(),
     );
     expect(result).toEqual({ taskId: null, workerId: null });
+    expect(forwardEvent).not.toHaveBeenCalled();
   });
 });
 
@@ -168,24 +176,26 @@ describe("routePrEvent — closed with merge", () => {
     const w = Worker.register("worker-1", fakeWs());
     task.workerId = "worker-1";
     w.assign(task);
-    const { wss, sendMsg, taskManager } = makeDeps();
+    const { wss, sendMsg, forwardEvent, taskManager } = makeDeps();
     taskManager.handlePrClosedEvent.mockResolvedValue(task);
     const result = await wss.routePrEvent(
       { action: "closed", pull_request: { number: 99, merged: true } },
       makeEvent(),
     );
     expect(taskManager.handlePrClosedEvent).toHaveBeenCalledWith(99, true);
+    expect(forwardEvent).toHaveBeenCalledOnce();
     expect(sendMsg).toHaveBeenCalledOnce();
     expect(result.taskId).toBe("42");
   });
 
   it("returns null when no task owns the PR", async () => {
-    const { wss } = makeDeps();
+    const { wss, forwardEvent } = makeDeps();
     const result = await wss.routePrEvent(
       { action: "closed", pull_request: { number: 99, merged: true } },
       makeEvent(),
     );
     expect(result).toEqual({ taskId: null, workerId: null });
+    expect(forwardEvent).not.toHaveBeenCalled();
   });
 });
 
@@ -195,22 +205,24 @@ describe("routePrEvent — passthrough", () => {
     const w = Worker.register("worker-1", fakeWs());
     task.workerId = "worker-1";
     w.assign(task);
-    const { wss, sendMsg } = makeDeps();
+    const { wss, sendMsg, forwardEvent } = makeDeps();
     const result = await wss.routePrEvent(
       { action: "labeled", pull_request: { number: 99 } },
       makeEvent(),
     );
+    expect(forwardEvent).toHaveBeenCalledOnce();
     expect(sendMsg).toHaveBeenCalledOnce();
     expect(result.taskId).toBe("42");
   });
 
   it("returns null task when no task owns the PR", async () => {
-    const { wss } = makeDeps();
+    const { wss, forwardEvent } = makeDeps();
     const result = await wss.routePrEvent(
       { action: "labeled", pull_request: { number: 99 } },
       makeEvent(),
     );
     expect(result).toEqual({ taskId: null, workerId: null });
+    expect(forwardEvent).not.toHaveBeenCalled();
   });
 });
 
@@ -218,9 +230,10 @@ describe("routePrEvent — passthrough", () => {
 
 describe("routePrReviewEvent", () => {
   it("returns null when PR number is missing", async () => {
-    const { wss } = makeDeps();
+    const { wss, forwardEvent } = makeDeps();
     const result = await wss.routePrReviewEvent({ pull_request: {} }, makeEvent("pull_request_review"));
     expect(result).toEqual({ taskId: null, workerId: null });
+    expect(forwardEvent).not.toHaveBeenCalled();
   });
 
   it("forwards review events to the task that owns the PR", async () => {
@@ -228,22 +241,24 @@ describe("routePrReviewEvent", () => {
     const w = Worker.register("worker-1", fakeWs());
     task.workerId = "worker-1";
     w.assign(task);
-    const { wss, sendMsg } = makeDeps();
+    const { wss, sendMsg, forwardEvent } = makeDeps();
     const result = await wss.routePrReviewEvent(
       { pull_request: { number: 99 } },
       makeEvent("pull_request_review"),
     );
+    expect(forwardEvent).toHaveBeenCalledOnce();
     expect(sendMsg).toHaveBeenCalledOnce();
     expect(result.taskId).toBe("42");
   });
 
   it("returns null when no task owns the reviewed PR", async () => {
-    const { wss } = makeDeps();
+    const { wss, forwardEvent } = makeDeps();
     const result = await wss.routePrReviewEvent(
       { pull_request: { number: 99 } },
       makeEvent("pull_request_review"),
     );
     expect(result).toEqual({ taskId: null, workerId: null });
+    expect(forwardEvent).not.toHaveBeenCalled();
   });
 });
 
@@ -255,7 +270,7 @@ describe("routeCheckEvent — via PR number", () => {
     const w = Worker.register("worker-1", fakeWs());
     task.workerId = "worker-1";
     w.assign(task);
-    const { wss, sendMsg, taskManager } = makeDeps();
+    const { wss, sendMsg, forwardEvent, taskManager } = makeDeps();
     taskManager.getTaskForCheckEvent.mockResolvedValue({ task, ref: "PR #99" });
     const result = await wss.routeCheckEvent(
       { check_run: { pull_requests: [{ number: 99 }] } },
@@ -263,6 +278,7 @@ describe("routeCheckEvent — via PR number", () => {
       "check_run",
     );
     expect(taskManager.getTaskForCheckEvent).toHaveBeenCalledWith([99], "");
+    expect(forwardEvent).toHaveBeenCalledOnce();
     expect(sendMsg).toHaveBeenCalledOnce();
     expect(result.taskId).toBe("42");
   });
@@ -272,7 +288,7 @@ describe("routeCheckEvent — via PR number", () => {
     const w = Worker.register("worker-1", fakeWs());
     task.workerId = "worker-1";
     w.assign(task);
-    const { wss, sendMsg, taskManager } = makeDeps();
+    const { wss, sendMsg, forwardEvent, taskManager } = makeDeps();
     taskManager.getTaskForCheckEvent.mockResolvedValue({ task, ref: "PR #99" });
     const result = await wss.routeCheckEvent(
       { check_suite: { pull_requests: [{ number: 99 }] } },
@@ -280,6 +296,7 @@ describe("routeCheckEvent — via PR number", () => {
       "check_suite",
     );
     expect(taskManager.getTaskForCheckEvent).toHaveBeenCalledWith([99], "");
+    expect(forwardEvent).toHaveBeenCalledOnce();
     expect(sendMsg).toHaveBeenCalledOnce();
     expect(result.taskId).toBe("42");
   });
@@ -291,7 +308,7 @@ describe("routeCheckEvent — via branch name", () => {
     const w = Worker.register("worker-1", fakeWs());
     task.workerId = "worker-1";
     w.assign(task);
-    const { wss, sendMsg, taskManager } = makeDeps();
+    const { wss, sendMsg, forwardEvent, taskManager } = makeDeps();
     taskManager.getTaskForCheckEvent.mockResolvedValue({ task, ref: "branch feature-branch" });
     const result = await wss.routeCheckEvent(
       { check_run: { pull_requests: [], check_suite: { head_branch: "feature-branch" } } },
@@ -299,6 +316,7 @@ describe("routeCheckEvent — via branch name", () => {
       "check_run",
     );
     expect(taskManager.getTaskForCheckEvent).toHaveBeenCalledWith([], "feature-branch");
+    expect(forwardEvent).toHaveBeenCalledOnce();
     expect(sendMsg).toHaveBeenCalledOnce();
     expect(result.taskId).toBe("42");
   });
@@ -308,7 +326,7 @@ describe("routeCheckEvent — via branch name", () => {
     const w = Worker.register("worker-1", fakeWs());
     task.workerId = "worker-1";
     w.assign(task);
-    const { wss, sendMsg, taskManager } = makeDeps();
+    const { wss, sendMsg, forwardEvent, taskManager } = makeDeps();
     taskManager.getTaskForCheckEvent.mockResolvedValue({ task, ref: "branch feature-branch" });
     const result = await wss.routeCheckEvent(
       { check_suite: { pull_requests: [], head_branch: "feature-branch" } },
@@ -316,18 +334,20 @@ describe("routeCheckEvent — via branch name", () => {
       "check_suite",
     );
     expect(taskManager.getTaskForCheckEvent).toHaveBeenCalledWith([], "feature-branch");
+    expect(forwardEvent).toHaveBeenCalledOnce();
     expect(sendMsg).toHaveBeenCalledOnce();
     expect(result.taskId).toBe("42");
   });
 
   it("returns null when getTaskForCheckEvent finds nothing", async () => {
-    const { wss } = makeDeps();
+    const { wss, forwardEvent } = makeDeps();
     const result = await wss.routeCheckEvent(
       { check_run: { pull_requests: [], check_suite: { head_branch: "unknown-branch" } } },
       makeEvent("check_run"),
       "check_run",
     );
     expect(result).toEqual({ taskId: null, workerId: null });
+    expect(forwardEvent).not.toHaveBeenCalled();
   });
 });
 
@@ -336,7 +356,7 @@ describe("routeCheckEvent — via branch name", () => {
 describe("routeIssueEvent — enqueue on labeled", () => {
   it("calls handleIssueLabeledEvent and returns the enqueued task", async () => {
     const task = Task.fromTest({ task_id: "42", issue_number: 42 });
-    const { wss, taskManager } = makeDeps();
+    const { wss, forwardEvent, taskManager } = makeDeps();
     taskManager.handleIssueLabeledEvent.mockResolvedValue(task);
     const issue = { number: 42, title: "Do something", body: "details", state: "open", labels: [{ name: "brunel:ready" }] };
     const result = await wss.routeIssueEvent(
@@ -350,10 +370,13 @@ describe("routeIssueEvent — enqueue on labeled", () => {
     );
     expect(result).toEqual({ taskId: "42", workerId: null });
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("enqueued via issues/labeled"));
+    // The labeled event is queued for the worker to receive once assigned; forwardEvent is called
+    // but sendMsg is not (no worker connected yet).
+    expect(forwardEvent).toHaveBeenCalledOnce();
   });
 
   it("returns null when handleIssueLabeledEvent returns null (e.g. closed issue)", async () => {
-    const { wss, taskManager } = makeDeps();
+    const { wss, forwardEvent, taskManager } = makeDeps();
     taskManager.handleIssueLabeledEvent.mockResolvedValue(null);
     const issue = { number: 42, title: "Do something", body: "", state: "closed", labels: [{ name: "brunel:ready" }] };
     const result = await wss.routeIssueEvent(
@@ -364,10 +387,11 @@ describe("routeIssueEvent — enqueue on labeled", () => {
     );
     expect(taskManager.handleIssueLabeledEvent).toHaveBeenCalled();
     expect(result).toEqual({ taskId: null, workerId: null });
+    expect(forwardEvent).not.toHaveBeenCalled();
   });
 
   it("ignores a labeled event for a different label", async () => {
-    const { wss, taskManager } = makeDeps();
+    const { wss, forwardEvent, taskManager } = makeDeps();
     const issue = { number: 42, title: "Do something", body: "", state: "open", labels: [] };
     const result = await wss.routeIssueEvent(
       { action: "labeled", label: { name: "other-label" } },
@@ -377,13 +401,14 @@ describe("routeIssueEvent — enqueue on labeled", () => {
     );
     expect(taskManager.handleIssueLabeledEvent).not.toHaveBeenCalled();
     expect(result).toEqual({ taskId: null, workerId: null });
+    expect(forwardEvent).not.toHaveBeenCalled();
   });
 });
 
 describe("routeIssueEvent — enqueue on opened", () => {
   it("calls handleIssueLabeledEvent when opened with the task label already attached", async () => {
     const task = Task.fromTest({ task_id: "42", issue_number: 42 });
-    const { wss, taskManager } = makeDeps();
+    const { wss, forwardEvent, taskManager } = makeDeps();
     taskManager.handleIssueLabeledEvent.mockResolvedValue(task);
     const issue = { number: 42, title: "Do something", body: "details", state: "open", labels: [{ name: "brunel:ready" }] };
     const result = await wss.routeIssueEvent(
@@ -394,10 +419,11 @@ describe("routeIssueEvent — enqueue on opened", () => {
     );
     expect(taskManager.handleIssueLabeledEvent).toHaveBeenCalled();
     expect(result).toEqual({ taskId: "42", workerId: null });
+    expect(forwardEvent).toHaveBeenCalledOnce();
   });
 
   it("does not call handleIssueLabeledEvent when opened without the task label", async () => {
-    const { wss, taskManager } = makeDeps();
+    const { wss, forwardEvent, taskManager } = makeDeps();
     const issue = { number: 42, title: "Do something", body: "", state: "open", labels: [] };
     const result = await wss.routeIssueEvent(
       { action: "opened" },
@@ -407,13 +433,14 @@ describe("routeIssueEvent — enqueue on opened", () => {
     );
     expect(taskManager.handleIssueLabeledEvent).not.toHaveBeenCalled();
     expect(result).toEqual({ taskId: null, workerId: null });
+    expect(forwardEvent).not.toHaveBeenCalled();
   });
 });
 
 describe("routeIssueEvent — unlabeled (dequeue)", () => {
   it("dequeues the task when the task label is removed", async () => {
     taskStore.addTask({ task_id: "42", issue_number: 42 });
-    const { wss, taskManager } = makeDeps();
+    const { wss, forwardEvent, taskManager } = makeDeps();
     const issue = { number: 42 };
     await wss.routeIssueEvent(
       { action: "unlabeled", label: { name: "brunel:ready" } },
@@ -423,11 +450,13 @@ describe("routeIssueEvent — unlabeled (dequeue)", () => {
     );
     expect(taskManager.dequeueIssue).toHaveBeenCalledWith(42);
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("dequeued"));
+    // Worker does not need to know the label was removed
+    expect(forwardEvent).not.toHaveBeenCalled();
   });
 
   it("does not dequeue when a different label is removed", async () => {
     taskStore.addTask({ task_id: "42", issue_number: 42 });
-    const { wss, taskManager } = makeDeps();
+    const { wss, forwardEvent, taskManager } = makeDeps();
     const issue = { number: 42 };
     await wss.routeIssueEvent(
       { action: "unlabeled", label: { name: "other-label" } },
@@ -436,12 +465,14 @@ describe("routeIssueEvent — unlabeled (dequeue)", () => {
       42,
     );
     expect(taskManager.dequeueIssue).not.toHaveBeenCalled();
+    // Non-task label removal falls through: task exists, so the event is forwarded to the worker
+    expect(forwardEvent).toHaveBeenCalledOnce();
   });
 });
 
 describe("routeIssueEvent — closed", () => {
   it("calls closeIssue when an issue is closed", async () => {
-    const { wss, taskManager } = makeDeps();
+    const { wss, forwardEvent, taskManager } = makeDeps();
     const issue = { number: 42 };
     await wss.routeIssueEvent(
       { action: "closed" },
@@ -450,12 +481,28 @@ describe("routeIssueEvent — closed", () => {
       42,
     );
     expect(taskManager.closeIssue).toHaveBeenCalledWith(42);
+    // No tracked task → nothing to forward
+    expect(forwardEvent).not.toHaveBeenCalled();
+  });
+
+  it("calls forwardEvent when a tracked task exists", async () => {
+    taskStore.addTask({ task_id: "42", issue_number: 42 });
+    const { wss, forwardEvent, taskManager } = makeDeps();
+    const issue = { number: 42 };
+    await wss.routeIssueEvent(
+      { action: "closed" },
+      makeEvent("issues"),
+      issue,
+      42,
+    );
+    expect(taskManager.closeIssue).toHaveBeenCalledWith(42);
+    expect(forwardEvent).toHaveBeenCalledOnce();
   });
 });
 
 describe("routeIssueEvent — reopened", () => {
   it("calls reopenIssue when an issue is reopened", async () => {
-    const { wss, taskManager } = makeDeps();
+    const { wss, forwardEvent, taskManager } = makeDeps();
     const issue = { number: 42 };
     await wss.routeIssueEvent(
       { action: "reopened" },
@@ -464,13 +511,29 @@ describe("routeIssueEvent — reopened", () => {
       42,
     );
     expect(taskManager.reopenIssue).toHaveBeenCalledWith(42);
+    // No tracked task → nothing to forward
+    expect(forwardEvent).not.toHaveBeenCalled();
+  });
+
+  it("calls forwardEvent when a tracked task exists", async () => {
+    taskStore.addTask({ task_id: "42", issue_number: 42 });
+    const { wss, forwardEvent, taskManager } = makeDeps();
+    const issue = { number: 42 };
+    await wss.routeIssueEvent(
+      { action: "reopened" },
+      makeEvent("issues"),
+      issue,
+      42,
+    );
+    expect(taskManager.reopenIssue).toHaveBeenCalledWith(42);
+    expect(forwardEvent).toHaveBeenCalledOnce();
   });
 });
 
 describe("routeIssueEvent — edited", () => {
   it("calls handleIssueBodyEditedEvent when the issue body is edited for a tracked task", async () => {
     taskStore.addTask({ task_id: "42", issue_number: 42 });
-    const { wss, taskManager } = makeDeps();
+    const { wss, forwardEvent, taskManager } = makeDeps();
     const issue = { number: 42, body: "updated body" };
     await wss.routeIssueEvent(
       { action: "edited", changes: { body: { from: "old body" } } },
@@ -481,11 +544,12 @@ describe("routeIssueEvent — edited", () => {
     expect(taskManager.handleIssueBodyEditedEvent).toHaveBeenCalledWith(
       42, "updated body",
     );
+    expect(forwardEvent).toHaveBeenCalledOnce();
   });
 
   it("does not call handleIssueBodyEditedEvent when the body was not changed", async () => {
     taskStore.addTask({ task_id: "42", issue_number: 42 });
-    const { wss, taskManager } = makeDeps();
+    const { wss, forwardEvent, taskManager } = makeDeps();
     const issue = { number: 42, title: "updated title" };
     await wss.routeIssueEvent(
       { action: "edited", changes: { title: { from: "old title" } } },
@@ -494,10 +558,12 @@ describe("routeIssueEvent — edited", () => {
       42,
     );
     expect(taskManager.handleIssueBodyEditedEvent).not.toHaveBeenCalled();
+    // Task exists, so the event is still forwarded even when body didn't change
+    expect(forwardEvent).toHaveBeenCalledOnce();
   });
 
   it("does not call handleIssueBodyEditedEvent when the issue is not tracked", async () => {
-    const { wss, taskManager } = makeDeps();
+    const { wss, forwardEvent, taskManager } = makeDeps();
     const issue = { number: 42, body: "updated body" };
     await wss.routeIssueEvent(
       { action: "edited", changes: { body: { from: "old body" } } },
@@ -506,6 +572,7 @@ describe("routeIssueEvent — edited", () => {
       42,
     );
     expect(taskManager.handleIssueBodyEditedEvent).not.toHaveBeenCalled();
+    expect(forwardEvent).not.toHaveBeenCalled();
   });
 });
 
@@ -515,7 +582,7 @@ describe("routeIssueEvent — passthrough forwarding", () => {
     const w = Worker.register("worker-1", fakeWs());
     task.workerId = "worker-1";
     w.assign(task);
-    const { wss, sendMsg } = makeDeps();
+    const { wss, sendMsg, forwardEvent } = makeDeps();
     const issue = { number: 42 };
     const result = await wss.routeIssueEvent(
       { action: "assigned" },
@@ -523,6 +590,7 @@ describe("routeIssueEvent — passthrough forwarding", () => {
       issue,
       42,
     );
+    expect(forwardEvent).toHaveBeenCalledOnce();
     expect(sendMsg).toHaveBeenCalledOnce();
     expect(result.taskId).toBe("42");
   });
@@ -532,7 +600,7 @@ describe("routeIssueEvent — passthrough forwarding", () => {
     const w = Worker.register("worker-1", fakeWs());
     task.workerId = "worker-1";
     w.assign(task);
-    const { wss, sendMsg } = makeDeps();
+    const { wss, sendMsg, forwardEvent } = makeDeps();
     const issue = { number: 99 }; // PR number in issue.number
     const result = await wss.routeIssueEvent(
       { action: "created" },
@@ -540,6 +608,7 @@ describe("routeIssueEvent — passthrough forwarding", () => {
       issue,
       99,
     );
+    expect(forwardEvent).toHaveBeenCalledOnce();
     expect(sendMsg).toHaveBeenCalledOnce();
     expect(result.taskId).toBe("42");
   });


### PR DESCRIPTION
## Summary

- Adds a `forwardEvent` spy to `makeDeps()` in `foreman.event-router.handlers.test.ts` and asserts call/no-call for every routing action
- The `issues/closed` forwarding bug (#755) went undetected because tests verified foreman-side effects (e.g. `closeIssue`) but not whether the worker was actually notified; this PR closes that gap
- Adds two new test cases — `issues/closed` with a tracked task and `issues/reopened` with a tracked task — to explicitly cover the "worker needs to know" forwarding path

Key behaviors now regression-proof:
- `issues/labeled` → `forwardEvent` called (event queued; no worker assigned yet)
- `issues/unlabeled` (task label) → `forwardEvent` NOT called
- `issues/closed` with tracked task → `forwardEvent` called
- `issues/reopened` with tracked task → `forwardEvent` called
- `pull_request/opened`, `pull_request/closed` → `forwardEvent` called
- `pull_request/synchronize` → `forwardEvent` NOT called

## Test plan

- [x] All 34 tests in `foreman.event-router.handlers.test.ts` pass
- [x] Full test suite (1349 tests) passes (DB-only failures are pre-existing)

Closes #762

🤖 Generated with [Claude Code](https://claude.com/claude-code)