### PR TITLE
test: link #770 (triple input) to existing #761 regression test

### DIFF
--- a/tests/worker.main.test.ts
+++ b/tests/worker.main.test.ts
@@ -320,7 +320,7 @@ describe("workerMain input cancel discipline", () => {
   });
 
   it("does not send user input to the agent multiple times when session events were queued during a query", async () => {
-    // Regression test for issue #761.
+    // Regression test for issues #761 and #770 (triple input after PR merged).
     //
     // The bug: when "prompts_ready" fires while the routing loop is executing (not
     // sleeping in nextRoutingEvent), cancel() in the event handler is a no-op because
@@ -328,7 +328,8 @@ describe("workerMain input cancel discipline", () => {
     // starts a new ask(), nextRoutingEvent() returns the stale event immediately, and
     // the routing loop processes it WITHOUT cancelling the newly-started ask(). That
     // ask() becomes orphaned — it stays pending, keeping an active stdin listener. When
-    // the user types something next, every orphaned listener fires, causing runQuery to
+    // the user types something next, every orphaned listener fires, causing the typed
+    // characters to be inserted once per listener (triplicating them) and runQuery to
     // be invoked once per orphaned ask instead of once.
     //
     // The mock tracks ALL pending ask() resolvers. Resolving every resolver simultaneously


### PR DESCRIPTION
## Summary

- Investigated issue #770 (triple input after PR merged) and confirmed it was caused by the same root cause as #761: orphaned stdin listeners accumulating when `ask()` calls are not cancelled before the routing loop processes queued session events
- The triplicate symptom happens because each orphaned listener receives the same stdin data event, inserting typed characters once per listener (so 3 listeners → each character appears 3 times in the buffer)
- The fix in #761 already resolves this by unconditionally calling `input.cancel()` when processing a session event in the routing loop
- Updated the existing regression test comment to reference #770 and explain the triplication symptom explicitly

## Investigation

The bug scenario:
1. Worker finishes a query (e.g. PR merged event is processed)
2. During the query, 2+ session events arrive → they're queued in `routingQueue` (the `cancel()` in the event handler is a no-op since no `ask()` is active yet)
3. After the query ends, the routing loop drains prompts, then calls `listenForInput()` for each queued session event → starts a new `ask()` each time
4. `nextRoutingEvent()` immediately returns the stale queued event before any user input arrives
5. **Before #761 fix**: the routing loop processed the session event WITHOUT calling `cancel()` on the newly-started `ask()`, leaving it as an orphaned listener
6. After N queued events, N listeners are on stdin — every keystroke inserts once per listener → triplication

The #761 fix adds `this.input.cancel()` unconditionally when processing a session event, ensuring each orphaned `ask()` is cancelled before the next one starts.

## Test plan

- [x] All 1370 unit tests pass
- [x] Existing regression test in `tests/worker.main.test.ts` verifies: only 1 pending ask resolver exists at steady state, so one user input invokes `runQuery` exactly once (not 3 times)

Closes #770