### PR TITLE
fix: suppress prompt while worker waits for next task

### DIFF
--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -235,6 +235,11 @@ export class WorkerSession extends EventEmitter {
     return this.pendingPrompts.length > 0;
   }
 
+  /** Returns true if a task is currently assigned to this worker. */
+  hasTask(): boolean {
+    return this.currentTaskId !== undefined;
+  }
+
   /** Dequeues and returns the next prompt, or undefined if empty. */
   takeNextPrompt(): QueuedPrompt | undefined {
     return this.pendingPrompts.shift();

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -240,8 +240,12 @@ export class BrunelAgent {
 
     // One round of readline: shows the prompt and pushes to the channel when the
     // user submits real input. Fire-and-forget — the loop calls this when ready.
+    // In worker mode with no active task, use an empty prompt so stdin remains
+    // active (^D / ^C still work) but no "[agent] > " is displayed while waiting.
     const listenForInput = (): void => {
-      const promptStr = session ? "\n[agent] > " : "\n> ";
+      const promptStr = session
+        ? (session.hasTask() ? "\n[agent] > " : "")
+        : "\n> ";
       void this.input.ask(promptStr, () => this.controller.listCommands()).then((line) => {
         if (line !== null) enqueueRoutingEvent({ type: "line", value: line });
       });

--- a/tests/worker.main.test.ts
+++ b/tests/worker.main.test.ts
@@ -300,6 +300,94 @@ describe("workerMain exit behavior", () => {
   });
 });
 
+describe("workerMain prompt suppression while waiting for task", () => {
+  let chdirSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    makeMockInput();
+    chdirSpy = vi.spyOn(process, "chdir").mockImplementation(() => {});
+    vi.mocked(confirmIfUnsafe).mockResolvedValue(true);
+    fakeWorkspace.isCreated = false;
+    vi.mocked(fakeWorkspace.destroy).mockResolvedValue(undefined);
+    vi.mocked(fakeWorkspace.checkSafety).mockResolvedValue({ uncommittedFiles: [], unpushedCommits: [], noUpstream: false });
+    vi.mocked(fakeWorkspace.create).mockImplementation(async () => { fakeWorkspace.isCreated = true; });
+    capturedSession.current = null;
+  });
+
+  afterEach(() => {
+    chdirSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it("uses empty prompt string while waiting for a task, not '[agent] > '", async () => {
+    // Regression test for issue #774.
+    //
+    // The bug: after completing a task (or before any task is assigned), the routing
+    // loop used "\n[agent] > " as the prompt string unconditionally, displaying the
+    // interactive prompt even though the worker was idle and waiting for a task.
+    //
+    // The fix: use an empty prompt string when session.hasTask() is false. stdin
+    // remains active (^D / ^C still work) but no "[agent] > " is shown.
+
+    const promptsUsed: string[] = [];
+    const pendingResolvers: Array<(val: string | null) => void> = [];
+
+    mockInput.ask.mockImplementation((promptStr: string) => {
+      promptsUsed.push(promptStr);
+      return new Promise<string | null>((resolve) => pendingResolvers.push(resolve));
+    });
+    mockInput.cancel.mockImplementation(() => {
+      if (pendingResolvers.length > 0) pendingResolvers.pop()!(null);
+    });
+
+    const runQueryFn = vi.fn().mockResolvedValue(undefined);
+    installMocks(runQueryFn);
+
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("__process_exit__");
+    }) as unknown as ReturnType<typeof vi.spyOn>;
+
+    let agentError: unknown;
+    const agentDone = new BrunelAgent(getConfig()).start(true).then(
+      () => {},
+      (err: unknown) => { if (!(err instanceof Error && err.message === "__process_exit__")) agentError = err; },
+    );
+
+    // Wait for the first ask() call — the routing loop starts immediately.
+    await vi.waitFor(() => expect(promptsUsed.length).toBeGreaterThanOrEqual(1));
+
+    // With the fix: prompt should be empty string (no task assigned yet).
+    expect(promptsUsed[0]).toBe("");
+
+    // Now assign a task so hasTask() returns true, then wake the routing loop via
+    // prompts_ready (cancel the current empty-prompt ask, loop continues, calls
+    // listenForInput() again with the real prompt).
+    const session = capturedSession.current!;
+    (session as any).currentTaskId = "task-123";
+    (session as any).currentIssue = { number: 42, title: "Test task", body: "", labels: [], repoUrl: "" };
+    session.emit("prompts_ready"); // cancel() + enqueueRoutingEvent handled by session listener
+
+    // Wait for the next ask() call — now with task active, prompt should be "[agent] > ".
+    await vi.waitFor(() => expect(promptsUsed.length).toBeGreaterThanOrEqual(2));
+    expect(promptsUsed[1]).toBe("\n[agent] > ");
+
+    // Complete the task — user types /worker:complete (clears currentTaskId).
+    pendingResolvers.pop()!("/worker:complete");
+    await vi.waitFor(() => expect(session.hasTask()).toBe(false));
+
+    // The loop should issue another ask() with empty prompt (no task again).
+    await vi.waitFor(() => expect(promptsUsed.length).toBeGreaterThanOrEqual(3));
+    expect(promptsUsed[2]).toBe("");
+
+    // Exit cleanly via __eof__ on the current (empty-prompt) ask.
+    pendingResolvers.pop()!("__eof__");
+
+    await agentDone;
+    exitSpy.mockRestore();
+    if (agentError) throw agentError;
+  });
+});
+
 describe("workerMain input cancel discipline", () => {
   let chdirSpy: ReturnType<typeof vi.spyOn>;
 

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1730,3 +1730,23 @@ describe("confirmTaskQuit", () => {
     expect(options).toHaveLength(3);
   });
 });
+
+// ── hasTask ───────────────────────────────────────────────────────────────────
+
+describe("hasTask", () => {
+  it("returns false when no task is assigned", () => {
+    expect(session.hasTask()).toBe(false);
+  });
+
+  it("returns true after task_assigned", () => {
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue: makeIssue() });
+    expect(session.hasTask()).toBe(true);
+  });
+
+  it("returns false after completeCurrentTask", async () => {
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue: makeIssue() });
+    expect(session.hasTask()).toBe(true);
+    await session.completeCurrentTask();
+    expect(session.hasTask()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- After `/worker:complete`, the routing loop was using `"\n[agent] > "` as the prompt unconditionally, so the interactive prompt appeared even though the worker was idle waiting for the next task
- Fix: `listenForInput()` now uses an empty prompt string when `session.hasTask()` is false — stdin stays active (^D / ^C still work) but no `[agent] > ` is shown while waiting
- Adds `WorkerSession.hasTask()` as the predicate

## Test plan

- [ ] New unit tests for `WorkerSession.hasTask()` in `tests/worker.test.ts` (false initially, true after `task_assigned`, false after `completeCurrentTask`)
- [ ] New integration test in `tests/worker.main.test.ts` verifying the prompt string is `""` when no task is assigned and `"\n[agent] > "` when a task is active, and reverts to `""` after task completion
- [ ] All existing tests continue to pass (existing tests rely on `ask()` still being called — it is, just with an empty prompt)

Closes #774

🤖 Generated with [Claude Code](https://claude.com/claude-code)