### PR TITLE
feat: auto-stash prompt buffer when worker message interrupts

### DIFF
--- a/src/agent/views/input.ts
+++ b/src/agent/views/input.ts
@@ -55,6 +55,13 @@ export class Input {
     const totalUp = endRow + this._prefixRows;
     if (totalUp > 0) process.stdout.write(`\x1b[${totalUp}A`);
     process.stdout.write("\r\x1b[J");
+    // Auto-stash: if the user had typed something, save it so the next ask()
+    // call restores it — prevents input from being silently lost when a
+    // foreman message interrupts the prompt (issue #777).
+    if (this._buffer) {
+      this._stash = this._buffer;
+      process.stdout.write(c.darkGray("✦ Prompt stashed — will be restored on next input\r\n"));
+    }
     const resolve = this._resolve;
     this._cleanup();
     resolve(null);

--- a/tests/repl.input.test.ts
+++ b/tests/repl.input.test.ts
@@ -925,6 +925,95 @@ describe("pickMultiple() - multi-selection picker", () => {
   });
 });
 
+describe("ask() - cancel() auto-stash", () => {
+  it("cancel() with non-empty buffer stashes the buffer for next ask()", async () => {
+    await withFakeStdin(async (stdin) => {
+      const p = testInput.ask("> ", () => []);
+      stdin.push("hello world");
+      // Give the data event a chance to process
+      await new Promise(r => setTimeout(r, 0));
+      testInput.cancel();
+      await p;
+
+      // Next ask() should be pre-populated with the stashed text
+      const p2 = testInput.ask("> ", () => []);
+      stdin.push("\r");
+      const result = await p2;
+      expect(result).toBe("hello world");
+    });
+  });
+
+  it("cancel() with empty buffer does NOT stash anything", async () => {
+    await withFakeStdin(async (stdin) => {
+      const p = testInput.ask("> ", () => []);
+      testInput.cancel();
+      await p;
+
+      // Next ask() should start empty (no stash)
+      const p2 = testInput.ask("> ", () => []);
+      stdin.push("\r");
+      const result = await p2;
+      expect(result).toBe("");
+    });
+  });
+
+  it("cancel() with non-empty buffer writes a stash notification", async () => {
+    const writeSpy = vi.mocked(process.stdout.write);
+
+    await withFakeStdin(async (stdin) => {
+      const p = testInput.ask("> ", () => []);
+      stdin.push("test");
+      await new Promise(r => setTimeout(r, 0));
+      writeSpy.mockClear();
+      testInput.cancel();
+      await p;
+    });
+
+    const out = writeSpy.mock.calls.map((c) => String(c[0])).join("");
+    expect(out).toContain("stashed");
+  });
+
+  it("cancel() with empty buffer does NOT write a stash notification", async () => {
+    const writeSpy = vi.mocked(process.stdout.write);
+
+    await withFakeStdin(async (_stdin) => {
+      const p = testInput.ask("> ", () => []);
+      writeSpy.mockClear();
+      testInput.cancel();
+      await p;
+    });
+
+    const out = writeSpy.mock.calls.map((c) => String(c[0])).join("");
+    expect(out).not.toContain("stashed");
+  });
+
+  it("cancel() auto-stash overwrites existing stash with full buffer", async () => {
+    await withFakeStdin(async (stdin) => {
+      // First ask: manually stash "old"
+      const p1 = testInput.ask("> ", () => []);
+      stdin.push("old");
+      await new Promise(r => setTimeout(r, 0));
+      stdin.push("\x13"); // ^S stash "old"
+      stdin.push("\r");
+      await p1;
+
+      // Second ask: stash "old" is restored into the buffer; user appends "new"
+      // making the buffer "oldnew"; then cancel auto-stashes the full buffer
+      const p2 = testInput.ask("> ", () => []);
+      stdin.push("new"); // buffer becomes "oldnew" (appended to restored stash)
+      await new Promise(r => setTimeout(r, 0));
+      testInput.cancel();
+      await p2;
+
+      // Third ask: should restore "oldnew" (the full buffer at cancel time)
+      const p3 = testInput.ask("> ", () => []);
+      stdin.push("\r");
+      const result = await p3;
+      expect(result).toBe("oldnew");
+    });
+  });
+});
+
 describe("ask() - stash (^S)", () => {
   it("^S with non-empty buffer clears buffer so ask resolves to ''", async () => {
     await withFakeStdin(async (stdin) => {


### PR DESCRIPTION
## Summary

- When a foreman message arrives while the user is typing, `cancel()` is called to clear the prompt — previously this silently discarded whatever the user had typed
- Now `cancel()` automatically saves a non-empty buffer to `_stash` so it is restored as the initial value of the next `ask()` call
- A dark-gray "✦ Prompt stashed — will be restored on next input" notification is written (same style as the manual `^S` stash) so the user knows their input was saved
- Empty buffers are not stashed (no-op), matching the existing `^S` behavior

## Test plan

- [x] `cancel() with non-empty buffer stashes the buffer for next ask()`
- [x] `cancel() with empty buffer does NOT stash anything`
- [x] `cancel() with non-empty buffer writes a stash notification`
- [x] `cancel() with empty buffer does NOT write a stash notification`
- [x] `cancel() auto-stash overwrites existing stash with full buffer`
- [x] All existing tests still pass (80 total in `repl.input.test.ts`, 1379 total non-DB)

Closes #777

🤖 Generated with [Claude Code](https://claude.com/claude-code)