### PR TITLE
feat: add repos table and Repo active-record model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Two independent processes: **foreman** (server) and **worker** (agent). They com
 
 MVC structure. Models own state; controllers handle external inputs.
 
-- **Models** (`models/`) — `ActiveRecord` is the abstract base class for all DB-backed models. `Task`, `WebhookEvent`, and `ForemanMessage` are the main active-record models. `TaskManager` owns ephemeral in-memory state (event queues, branch mappings, blocker state) and encapsulates all issue/PR event lifecycle logic. `Worker` is the in-memory model for connected workers (not DB-backed).
+- **Models** (`models/`) — `ActiveRecord` is the abstract base class for all DB-backed models. `Task`, `WebhookEvent`, `ForemanMessage`, and `Repo` are the main active-record models. `TaskManager` owns ephemeral in-memory state (event queues, branch mappings, blocker state) and encapsulates all issue/PR event lifecycle logic. `Worker` is the in-memory model for connected workers (not DB-backed).
 - **Controllers** (`controllers/`) — `http-server.ts` handles webhooks + REST + SPA. `wss.ts` (`ForemanWss`) is the WebSocket protocol layer for worker↔foreman communication. `admin-ws.ts` broadcasts to the admin dashboard.
 - **Clients** (`clients/`) — `db-client.ts` wires the shared Supabase client. `github.ts` wraps GitHub API calls.
 

--- a/src/database.types.ts
+++ b/src/database.types.ts
@@ -12,6 +12,27 @@ export type Json =
 export type Database = {
   public: {
     Tables: {
+      repos: {
+        Row: {
+          id: number
+          full_name: string
+          status: string
+          created_at: string
+        }
+        Insert: {
+          id?: never
+          full_name: string
+          status?: string
+          created_at?: string
+        }
+        Update: {
+          id?: never
+          full_name?: string
+          status?: string
+          created_at?: string
+        }
+        Relationships: []
+      }
       foreman_messages: {
         Row: {
           id: number

--- a/src/foreman/models/repo.ts
+++ b/src/foreman/models/repo.ts
@@ -1,0 +1,55 @@
+import { EventEmitter } from "node:events";
+import type { Database } from "../../database.types.js";
+import { db } from "../clients/db-client.js";
+import { ActiveRecord } from "./active-record.js";
+
+type DbRow = Database["public"]["Tables"]["repos"]["Row"];
+
+export type RepoStatus = "new" | "active";
+
+export class Repo extends ActiveRecord {
+  static readonly events = new EventEmitter();
+
+  protected static readonly tableName = "repos";
+  protected static readonly primaryKey = "id";
+
+  readonly id: number;
+  readonly fullName: string;
+  status: RepoStatus;
+  readonly createdAt: string;
+
+  private constructor(row: DbRow) {
+    super();
+    this.id = row.id;
+    this.fullName = row.full_name;
+    this.status = row.status as RepoStatus;
+    this.createdAt = row.created_at;
+  }
+
+  protected getPrimaryKeyValue(): number {
+    return this.id;
+  }
+
+  static async get(id: number): Promise<Repo | null> {
+    return super.get(id) as Promise<Repo | null>;
+  }
+
+  static async list(): Promise<Repo[]> {
+    return super.list() as Promise<Repo[]>;
+  }
+
+  /**
+   * Find or create a repo by full_name (e.g. "owner/repo").
+   * Upserts on full_name so it's safe to call on every webhook.
+   * Returns the persisted Repo instance.
+   */
+  static async findOrCreate(fullName: string): Promise<Repo> {
+    const { data, error } = await db.from("repos")
+      .upsert({ full_name: fullName }, { onConflict: "full_name" })
+      .select()
+      .single();
+    if (error) throw error;
+    Repo.events.emit("changed");
+    return new Repo(data);
+  }
+}

--- a/supabase/migrations/20260420000000_create_repos.sql
+++ b/supabase/migrations/20260420000000_create_repos.sql
@@ -1,0 +1,9 @@
+-- Stable identity for a GitHub repository, independent of repo name.
+-- status: 'new' = known but not yet activated, 'active' = in play.
+
+CREATE TABLE repos (
+  id         bigint      GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  full_name  text        NOT NULL UNIQUE,
+  status     text        NOT NULL DEFAULT 'new',
+  created_at timestamptz NOT NULL DEFAULT now()
+);

--- a/tests/db.repos.test.ts
+++ b/tests/db.repos.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Repo } from "../src/foreman/models/repo.js";
+import { initDb } from "../src/foreman/clients/db-client.js";
+import { createTestSupabase } from "./helpers/db.js";
+
+const supabase = createTestSupabase();
+initDb(supabase);
+
+// Use a unique prefix to avoid collisions with other DB test files running in parallel.
+const OWN_NAMES = ["dbr-owner/repo-a", "dbr-owner/repo-b"];
+
+beforeEach(async () => {
+  await supabase.from("repos").delete().in("full_name", OWN_NAMES);
+});
+
+describe("Repo.findOrCreate", () => {
+  it("creates a new repo with status 'new'", async () => {
+    const repo = await Repo.findOrCreate("dbr-owner/repo-a");
+    expect(repo.fullName).toBe("dbr-owner/repo-a");
+    expect(repo.status).toBe("new");
+    expect(repo.id).toBeGreaterThan(0);
+    expect(repo.createdAt).toBeTruthy();
+  });
+
+  it("is idempotent — calling twice returns the same row", async () => {
+    const first = await Repo.findOrCreate("dbr-owner/repo-a");
+    const second = await Repo.findOrCreate("dbr-owner/repo-a");
+    expect(second.id).toBe(first.id);
+    expect(second.fullName).toBe(first.fullName);
+  });
+
+  it("creates distinct rows for different full_names", async () => {
+    const a = await Repo.findOrCreate("dbr-owner/repo-a");
+    const b = await Repo.findOrCreate("dbr-owner/repo-b");
+    expect(a.id).not.toBe(b.id);
+  });
+});
+
+describe("Repo.get", () => {
+  it("returns the repo by id", async () => {
+    const created = await Repo.findOrCreate("dbr-owner/repo-a");
+    const found = await Repo.get(created.id);
+    expect(found).not.toBeNull();
+    expect(found!.fullName).toBe("dbr-owner/repo-a");
+  });
+
+  it("returns null for unknown id", async () => {
+    const found = await Repo.get(0);
+    expect(found).toBeNull();
+  });
+});
+
+describe("Repo.list", () => {
+  it("returns repos including the ones just created", async () => {
+    await Repo.findOrCreate("dbr-owner/repo-a");
+    await Repo.findOrCreate("dbr-owner/repo-b");
+    const all = await Repo.list();
+    const ours = all.filter((r) => r.fullName.startsWith("dbr-owner/"));
+    expect(ours).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Migration: `repos` table with `id`, `full_name` (unique), `status` (`'new'|'active'`), `created_at`
- `Repo` active-record model with `Repo.findOrCreate(fullName)` — upserts on `full_name`, returns the `Repo` object
- Updated `database.types.ts` manually to reflect the new table (run `supabase gen types typescript --local` after applying the migration to regenerate from live schema)
- DB tests in `tests/db.repos.test.ts` covering `findOrCreate` idempotency, `get`, and `list`

## Test plan

- [ ] `npm test` — all 1370 unit tests pass (DB tests require `supabase start`)
- [ ] `npx tsc --noEmit` — no type errors
- [ ] `npm run lint` — clean
- [ ] With `supabase start`: apply migration, run `npm test` to confirm `db.repos.test.ts` passes

Closes #783

🤖 Generated with [Claude Code](https://claude.com/claude-code)