### PR TITLE
Fix UNIQUE(issue_number) → UNIQUE(issue_number, repo_id)

### DIFF
--- a/src/database.types.ts
+++ b/src/database.types.ts
@@ -68,6 +68,7 @@ export type Database = {
           task_id: string
           issue_number: number
           repo: string
+          repo_id: number
           title: string
           body: string
           labels: string[]
@@ -84,6 +85,7 @@ export type Database = {
           task_id: string
           issue_number: number
           repo: string
+          repo_id: number
           title: string
           body?: string
           labels?: string[]
@@ -100,6 +102,7 @@ export type Database = {
           task_id?: string
           issue_number?: number
           repo?: string
+          repo_id?: number
           title?: string
           body?: string
           labels?: string[]
@@ -112,7 +115,15 @@ export type Database = {
           issue_closed_at?: string | null
           pr_merged_at?: string | null
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "tasks_repo_id_fkey"
+            columns: ["repo_id"]
+            isOneToOne: false
+            referencedRelation: "repos"
+            referencedColumns: ["id"]
+          }
+        ]
       }
       webhook_events: {
         Row: {

--- a/src/foreman/models/task.ts
+++ b/src/foreman/models/task.ts
@@ -6,6 +6,7 @@ import * as Wire from "../../../shared/wire.js";
 import { fetchNativeBlockers } from "../clients/github.js";
 import { db } from "../clients/db-client.js";
 import { ActiveRecord } from "./active-record.js";
+import { Repo } from "./repo.js";
 
 type DbRow = Database["public"]["Tables"]["tasks"]["Row"];
 
@@ -17,6 +18,7 @@ export class Task extends ActiveRecord {
 
   readonly taskId: string;
   issueNumber: number;
+  repoId: number;
   repo: string;
   title: string;
   body: string;
@@ -44,6 +46,7 @@ export class Task extends ActiveRecord {
     super();
     this.taskId = row.task_id;
     this.issueNumber = row.issue_number;
+    this.repoId = row.repo_id;
     this.repo = row.repo;
     this.title = row.title;
     this.body = row.body;
@@ -103,6 +106,7 @@ export class Task extends ActiveRecord {
   static fromTest(fields: Partial<DbRow> & { task_id: string; issue_number: number }): Task {
     const row: DbRow = {
       repo: "",
+      repo_id: 0,
       title: "",
       body: "",
       labels: [],
@@ -203,12 +207,14 @@ export class Task extends ActiveRecord {
   }
 
   static async upsert(taskId: string, issueNumber: number, repo: string, title: string, body: string, labels: string[]): Promise<Task> {
-    // On conflict (task already exists), only update content fields (title, body, labels, repo, issue_number).
+    // Ensure the repo exists and get its id.
+    const repoRecord = await Repo.findOrCreate(repo);
+    // On conflict (task already exists), only update content fields (title, body, labels, repo, repo_id, issue_number).
     // Status fields (worker_id, assigned_at, completed_at, issue_closed_at, pr_merged_at) are intentionally
     // omitted so that existing assignments and status are preserved — e.g. during startup sync.
     // For new tasks, those columns default to null in the DB schema.
     const { data, error } = await db.from("tasks").upsert(
-      { task_id: taskId, issue_number: issueNumber, repo, title, body, labels },
+      { task_id: taskId, issue_number: issueNumber, repo_id: repoRecord.id, repo, title, body, labels },
       { onConflict: "task_id" },
     ).select().maybeSingle();
     if (error) throw error;

--- a/supabase/migrations/20260421000000_tasks_repo_id.sql
+++ b/supabase/migrations/20260421000000_tasks_repo_id.sql
@@ -1,0 +1,27 @@
+-- Fix UNIQUE(issue_number) → UNIQUE(issue_number, repo_id)
+-- Issue numbers are repo-scoped; two different repos can both have issue #42.
+
+-- 1. Add repo_id as a nullable FK so existing rows don't immediately fail.
+ALTER TABLE tasks ADD COLUMN repo_id bigint REFERENCES repos(id);
+
+-- 2. Ensure all repos referenced by tasks exist in the repos table.
+INSERT INTO repos (full_name)
+SELECT DISTINCT repo FROM tasks
+WHERE repo IS NOT NULL AND repo != ''
+  AND repo NOT IN (SELECT full_name FROM repos)
+ON CONFLICT (full_name) DO NOTHING;
+
+-- 3. Populate repo_id from the existing repo text column.
+UPDATE tasks t
+SET repo_id = r.id
+FROM repos r
+WHERE r.full_name = t.repo;
+
+-- 4. Make repo_id NOT NULL now that all rows are populated.
+ALTER TABLE tasks ALTER COLUMN repo_id SET NOT NULL;
+
+-- 5. Drop the old single-column unique constraint.
+ALTER TABLE tasks DROP CONSTRAINT IF EXISTS tasks_issue_number_unique;
+
+-- 6. Add the new composite unique constraint.
+ALTER TABLE tasks ADD CONSTRAINT tasks_issue_number_repo_id_unique UNIQUE (issue_number, repo_id);

--- a/tests/db.tasks.test.ts
+++ b/tests/db.tasks.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Task } from "../src/foreman/models/task.js";
+import { Repo } from "../src/foreman/models/repo.js";
 import { Worker } from "../src/foreman/models/worker.js";
 import { initDb } from "../src/foreman/clients/db-client.js";
 import { createTestSupabase } from "./helpers/db.js";
@@ -29,8 +30,9 @@ function own(tasks: Task[]) {
  * Use this for tests that need a stable row but aren't testing upsert itself.
  */
 async function insertProtected(taskId: string, issueNumber: number, repo: string, title: string, extra: Record<string, unknown> = {}) {
+  const repoRecord = await Repo.findOrCreate(repo);
   const { error } = await supabase.from("tasks").upsert({
-    task_id: taskId, issue_number: issueNumber, repo, title,
+    task_id: taskId, issue_number: issueNumber, repo, repo_id: repoRecord.id, title,
     body: "", labels: [],
     assigned_at: "2026-01-01T00:00:00Z",
     ...extra,
@@ -164,20 +166,21 @@ describe("Task.list (Supabase)", () => {
   it("returns rows in descending created_at order", async () => {
     // Insert with explicit timestamps so order is predictable.
     // Set assigned_at to protect from parallel reconcile in pipeline.test.ts.
+    const rrRepo = await Repo.findOrCreate("r/r");
     await supabase.from("tasks").insert({
-      task_id: "dbt-1", issue_number: 9001, repo: "r/r", title: "First",
+      task_id: "dbt-1", issue_number: 9001, repo: "r/r", repo_id: rrRepo.id, title: "First",
       body: "", labels: [],
       created_at: "2026-03-27T01:00:00Z",
       assigned_at: "2026-01-01T00:00:00Z",
     });
     await supabase.from("tasks").insert({
-      task_id: "dbt-2", issue_number: 9002, repo: "r/r", title: "Second",
+      task_id: "dbt-2", issue_number: 9002, repo: "r/r", repo_id: rrRepo.id, title: "Second",
       body: "", labels: [],
       created_at: "2026-03-27T03:00:00Z",
       assigned_at: "2026-01-01T00:00:00Z",
     });
     await supabase.from("tasks").insert({
-      task_id: "dbt-3", issue_number: 9003, repo: "r/r", title: "Third",
+      task_id: "dbt-3", issue_number: 9003, repo: "r/r", repo_id: rrRepo.id, title: "Third",
       body: "", labels: [],
       created_at: "2026-03-27T02:00:00Z",
       assigned_at: "2026-01-01T00:00:00Z",
@@ -333,5 +336,27 @@ describe("Task lookup methods (Supabase)", () => {
     await t!.assign(Worker.register("w1", fakeWs));
     const task = await Task.getByWorker("w1");
     expect(task?.taskId).toBe("dbt-42");
+  });
+});
+
+// ── Tests: UNIQUE(issue_number, repo_id) constraint ───────────────────────────
+
+describe("Task.upsert UNIQUE(issue_number, repo_id)", () => {
+  const EXTRA_IDS = ["dbt-r1-9042", "dbt-r2-9042"];
+
+  beforeEach(async () => {
+    await supabase.from("tasks").delete().in("task_id", EXTRA_IDS);
+  });
+
+  it("allows the same issue_number in two different repos", async () => {
+    await Task.upsert("dbt-r1-9042", 9042, "dbt-owner/repo-1", "Title 1", "", []);
+    await expect(
+      Task.upsert("dbt-r2-9042", 9042, "dbt-owner/repo-2", "Title 2", "", []),
+    ).resolves.toBeDefined();
+  });
+
+  it("stores repoId on the task", async () => {
+    const task = await Task.upsert("dbt-42", 9042, "owner/repo", "Title", "", []);
+    expect(task.repoId).toBeGreaterThan(0);
   });
 });

--- a/tests/helpers/memory-db.ts
+++ b/tests/helpers/memory-db.ts
@@ -1,12 +1,13 @@
 /**
  * In-memory Supabase client shim for use when Supabase is not configured.
- * Implements just the query patterns that Task (task.ts) uses.
+ * Implements just the query patterns that Task (task.ts) and Repo (repo.ts) use.
  */
 
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "../../src/database.types.js";
 
 type DbRow = Database["public"]["Tables"]["tasks"]["Row"];
+type RepoRow = Database["public"]["Tables"]["repos"]["Row"];
 type Filters = Array<{ col: keyof DbRow; op: "eq" | "is"; val: unknown }>;
 
 function applyFilters(rows: DbRow[], filters: Filters): DbRow[] {
@@ -27,6 +28,43 @@ function ok<T>(data: T): Promise<{ data: T; error: null }> {
 /** Returns a fake Supabase client backed by an in-memory Map. */
 export function createMemoryTaskDb(): SupabaseClient<Database> {
   const store = new Map<string, DbRow>();
+
+  // ── Repos store ───────────────────────────────────────────────────────────
+  const reposStore = new Map<string, RepoRow>();
+  let nextRepoId = 1;
+
+  function buildReposTable() {
+    return {
+      upsert(rowData: { full_name: string; status?: string }, _opts?: unknown) {
+        if (!reposStore.has(rowData.full_name)) {
+          reposStore.set(rowData.full_name, {
+            id: nextRepoId++,
+            full_name: rowData.full_name,
+            status: rowData.status ?? "new",
+            created_at: new Date().toISOString(),
+          });
+        }
+        const result = reposStore.get(rowData.full_name)!;
+        const sb = {
+          select() { return sb; },
+          single() { return ok(result); },
+          maybeSingle() { return ok(result); },
+        };
+        return sb;
+      },
+      select(_cols?: string) {
+        const rows = [...reposStore.values()];
+        const sb = {
+          eq(_col: string, _val: unknown) { return sb; },
+          order(_col: string, _opts?: unknown) { return sb; },
+          limit(n: number) { return ok(rows.slice(0, n)); },
+          maybeSingle() { return ok(rows[0] ?? null); },
+          single() { return ok(rows[0] ?? null); },
+        };
+        return sb;
+      },
+    };
+  }
 
   function buildSelectQuery(filters: Filters) {
     const sb = {
@@ -98,6 +136,9 @@ export function createMemoryTaskDb(): SupabaseClient<Database> {
 
   return {
     from(table: string) {
+      if (table === "repos") {
+        return buildReposTable();
+      }
       if (table !== "tasks") {
         return emptyBuilder;
       }
@@ -111,6 +152,7 @@ export function createMemoryTaskDb(): SupabaseClient<Database> {
           const row: DbRow = {
             // Defaults for new rows:
             repo: "",
+            repo_id: 0,
             title: "",
             body: "",
             labels: [],

--- a/tests/helpers/task.ts
+++ b/tests/helpers/task.ts
@@ -28,6 +28,7 @@ export async function seedTask(
 ): Promise<Task> {
   await db.from("tasks").upsert({
     repo: "",
+    repo_id: 0,
     title: "",
     body: "",
     labels: [],


### PR DESCRIPTION
## Summary

- **Migration** (`20260421000000_tasks_repo_id.sql`): adds `repo_id bigint NOT NULL REFERENCES repos(id)` to `tasks`, populates it from the existing `repo` text column (inserting any missing repo rows first), drops the old `UNIQUE(issue_number)` constraint, and adds `UNIQUE(issue_number, repo_id)`
- **`database.types.ts`**: updated manually to reflect the new column and FK relationship
- **`Task` model**: exposes `repoId: number`; `Task.upsert()` calls `Repo.findOrCreate(repo)` internally to obtain the `repo_id` before inserting — public API is unchanged
- **`memory-db` shim**: extended to support `from("repos").upsert().select().single()` so unit tests that call `Task.upsert()` continue to work without Supabase
- **`db.tasks.test.ts`**: `insertProtected` and direct inserts now supply `repo_id` via `Repo.findOrCreate`; new tests verify the constraint allows the same issue number across different repos and that `repoId` is populated on the returned task

## Test plan

- [ ] All 1370 non-DB unit tests pass (`npm test` — DB tests skip without Supabase)
- [ ] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] ESLint passes (`npm run lint`)
- [ ] DB tests pass in CI (require Supabase): `db.tasks.test.ts`, `db.repos.test.ts`, `pipeline.test.ts`
- [ ] New constraint test: two tasks with the same issue number in different repos can coexist

Closes #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)