### PR TITLE
Refactor TaskManager to per-repo instances with static registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Two independent processes: **foreman** (server) and **worker** (agent). They com
 
 MVC structure. Models own state; controllers handle external inputs.
 
-- **Models** (`models/`) — `ActiveRecord` is the abstract base class for all DB-backed models. `Task`, `WebhookEvent`, `ForemanMessage`, and `Repo` are the main active-record models. `TaskManager` owns ephemeral in-memory state (event queues, branch mappings, blocker state) and encapsulates all issue/PR event lifecycle logic. `Worker` is the in-memory model for connected workers (not DB-backed).
+- **Models** (`models/`) — `ActiveRecord` is the abstract base class for all DB-backed models. `Task`, `WebhookEvent`, `ForemanMessage`, and `Repo` are the main active-record models. `TaskManager` owns ephemeral in-memory state (event queues, branch mappings, blocker state) and encapsulates all issue/PR event lifecycle logic — one instance per repo, managed via a static registry (`TaskManager.forRepo(repo)`). `Repo` provides a convenience `get taskManager()` getter. `Worker` is the in-memory model for connected workers (not DB-backed).
 - **Controllers** (`controllers/`) — `http-server.ts` handles webhooks + REST + SPA. `wss.ts` (`ForemanWss`) is the WebSocket protocol layer for worker↔foreman communication. `admin-ws.ts` broadcasts to the admin dashboard.
 - **Clients** (`clients/`) — `db-client.ts` wires the shared Supabase client. `github.ts` wraps GitHub API calls.
 
@@ -95,5 +95,5 @@ See **`docs/type-system.md`** for the full design. In brief: one server model cl
 - **Real-time UIs**: prefer event-based designs — a model holds state and emits on change; the UI subscribes once rather than scattering manual refresh calls.
 - **Pass model objects, not IDs**: controllers look up model objects from wire message IDs first, then pass the objects to helpers.
 - **Wire types**: all live in `shared/wire.ts`, imported as `import * as Wire from "../../shared/wire.js"`.
-- **Tests**: the DB is initialised globally with an in-memory shim via `tests/setup.ts`. See test helper files in `tests/helpers/` for utilities like `seedTask()`, `resetDb()`, and `registerTestCommands()`.
+- **Tests**: the DB is initialised globally with an in-memory shim via `tests/setup.ts`. See test helper files in `tests/helpers/` for utilities like `seedTask()`, `resetDb()`, `createTestRepo()`, `createTestTaskManager()`, and `registerTestCommands()`. `resetDb()` also clears the TaskManager registry.
 - **Browser tests**: the server is shared across all tests — use unique issue numbers per test rather than resetting server state.

--- a/src/foreman/clients/github.ts
+++ b/src/foreman/clients/github.ts
@@ -18,7 +18,8 @@ function ghHeaders(token: string) {
 export async function loadIssuesToQueue(
   taskModel: TaskManager,
 ): Promise<void> {
-  const { githubRepo: repo, githubToken: token, taskLabel, githubApiUrl: apiUrl = "https://api.github.com" } = getConfig();
+  const { githubToken: token, taskLabel, githubApiUrl: apiUrl = "https://api.github.com" } = getConfig();
+  const repo = taskModel.repo.fullName;
   const [owner, repoName] = repo.split("/");
   const url = `${apiUrl}/repos/${owner}/${repoName}/issues?labels=${encodeURIComponent(taskLabel)}&state=open&per_page=100`;
   const res = await fetch(url, { headers: ghHeaders(token) });

--- a/src/foreman/controllers/http-server.ts
+++ b/src/foreman/controllers/http-server.ts
@@ -5,7 +5,6 @@ import { join, extname } from "path";
 import { fileURLToPath } from "url";
 import { Hono } from "hono";
 import { getRequestListener } from "@hono/node-server";
-import type { TaskManager } from "../models/task-manager.js";
 import { Task } from "../models/task.js";
 import { queryActivityLog } from "../models/activity-log.js";
 import type { TaskStatus } from "../../../shared/wire.js";
@@ -14,10 +13,9 @@ import { fmtError, log } from "../../utils.js";
 export interface HttpServerOptions {
   webhooks: InstanceType<typeof Webhooks> | null;
   routeEvent: (id: string, name: string, payload: unknown) => void | Promise<void>;
-  taskManager?: TaskManager;
 }
 
-export function createHttpServer({ webhooks, routeEvent, taskManager }: HttpServerOptions): http.Server {
+export function createHttpServer({ webhooks, routeEvent }: HttpServerOptions): http.Server {
   const app = new Hono();
 
   // ── Webhook ────────────────────────────────────────────────────────────────
@@ -94,7 +92,7 @@ export function createHttpServer({ webhooks, routeEvent, taskManager }: HttpServ
   app.get("/api/tasks", async (c) => {
     try {
       const statusFilter = c.req.query("status") as TaskStatus | undefined;
-      const tasks = taskManager ? await Task.list() : [];
+      const tasks = await Task.list();
       const filtered = statusFilter
         ? tasks.filter((t) => t.status === statusFilter)
         : tasks.filter((t) => t.status !== "complete");

--- a/src/foreman/controllers/wss.ts
+++ b/src/foreman/controllers/wss.ts
@@ -7,7 +7,8 @@ import type { AdminWss } from "./admin-ws.js";
 import { fmtError, log } from "../../utils.js";
 import { shortWorkerId } from "../../../shared/utils.js";
 import type { BrunelConfig } from "../../config.js";
-import type { TaskManager } from "../models/task-manager.js";
+import { TaskManager } from "../models/task-manager.js";
+import { Repo } from "../models/repo.js";
 import { Task } from "../models/task.js";
 import { Worker } from "../models/worker.js";
 
@@ -45,27 +46,24 @@ function routeResult(task: { taskId: string; workerId: string | null } | null | 
 
 type ForemanWssOptions = {
   config: Pick<BrunelConfig, "taskLabel" | "githubRepo" | "githubToken" | "githubApiUrl" | "workerSecret" | "pingIntervalMs">;
-  taskManager: TaskManager;
   server: http.Server;
   adminWss?: AdminWss;
 };
 
 export class ForemanWss {
   readonly wss: WebSocketServer;
-  private readonly taskManager: TaskManager;
   private readonly config: Pick<BrunelConfig, "taskLabel" | "githubRepo" | "githubToken" | "githubApiUrl" | "workerSecret" | "pingIntervalMs">;
   private readonly adminWss?: AdminWss;
   private nextBroadcastId = 1;
 
-  constructor({ config, server, taskManager, adminWss }: ForemanWssOptions) {
-    this.taskManager = taskManager;
+  constructor({ config, server, adminWss }: ForemanWssOptions) {
     this.config = config;
     this.adminWss = adminWss;
 
     const debouncedBroadcast = debounce(() => this.broadcastSnapshot(), 10);
-    taskManager.on("changed", debouncedBroadcast);
+    TaskManager.events.on("changed", debouncedBroadcast);
     Worker.events.on("changed", debouncedBroadcast);
-    taskManager.on("deps_loaded", () => {
+    TaskManager.events.on("deps_loaded", () => {
       this.assignWork().catch((err) => log(`ERROR assignWork after deps_loaded: ${fmtError(err)}`));
     });
 
@@ -283,7 +281,7 @@ export class ForemanWss {
   private async broadcastSnapshot(): Promise<void> {
     if (!this.adminWss) return;
     this.adminWss.broadcastSnapshot({
-      tasks: await this.taskManager.getTasksForBroadcast(),
+      tasks: (await Promise.all(TaskManager.all().map(tm => tm.getTasksForBroadcast()))).flat(),
       workers: Worker.all().map((w) => w.toWire()),
     });
   }
@@ -309,7 +307,9 @@ export class ForemanWss {
   // ── Hello handlers ───────────────────────────────────────────────────────────
 
   private flushQueuedEvents(worker: Worker, task: Task): void {
-    for (const evt of this.taskManager.drainEvents(task)) {
+    const tm = TaskManager.getByRepoId(task.repoId);
+    if (!tm) return;
+    for (const evt of tm.drainEvents(task)) {
       this.sendMsg(worker, { type: "event_notification", taskId: task.taskId, event: evt.toWorkerPayload() });
       this.workerLog(worker.workerId, `→ event_notification #${task.issueNumber} ${evt.eventName} (queued)`);
     }
@@ -418,6 +418,7 @@ export class ForemanWss {
   // ── Routing ─────────────────────────────────────────────────────────────────
 
   forwardEvent(task: Task, evt: WebhookEvent, ref: string): void {
+    const tm = TaskManager.getByRepoId(task.repoId);
     if (task.workerId) {
       const worker = Worker.get(task.workerId);
       if (worker && worker.currentTask?.taskId !== task.taskId) {
@@ -425,7 +426,7 @@ export class ForemanWss {
         return;
       }
       if (worker?.status === "disconnected") {
-        this.taskManager.queueEvent(task, evt);
+        tm?.queueEvent(task, evt);
         log(`[task ${ref}] ${evt.eventName} queued (worker ${shortWorkerId(task.workerId)} disconnected)`);
       } else if (worker) {
         this.sendMsg(worker, { type: "event_notification", taskId: task.taskId, event: evt.toWorkerPayload() });
@@ -434,30 +435,38 @@ export class ForemanWss {
         log(`[task ${ref}] ${evt.eventName} DROPPED — worker ${shortWorkerId(task.workerId)} not in registry (disconnected?)`);
       }
     } else if (task.status === "pending" || task.status === "blocked") {
-      this.taskManager.queueEvent(task, evt);
+      tm?.queueEvent(task, evt);
       log(`[task ${ref}] ${evt.eventName} queued (no worker assigned)`);
     }
   }
 
   async assignWork(): Promise<void> {
-    for (const outcome of await this.taskManager.assignIdleWorkers()) {
-      if (!outcome.ok) {
-        log(`ERROR Failed to persist assignment: ${fmtError(outcome.err)}`);
-        log(`[worker ${shortWorkerId(outcome.worker.workerId)}] → idle (DB write failed)`);
-        continue;
-      }
-      const { task, queued, worker } = outcome;
-      this.sendMsg(worker, {
-        type: "task_assigned",
-        taskId: task.taskId,
-        issue: task.toAssignmentPayload(),
-      });
-      log(`[worker ${shortWorkerId(worker.workerId)}] → task_assigned #${task.issueNumber} "${task.title}"`);
-      for (const evt of queued) {
-        this.sendMsg(worker, { type: "event_notification", taskId: task.taskId, event: evt.toWorkerPayload() });
-        log(`[worker ${shortWorkerId(worker.workerId)}] → event_notification #${task.issueNumber} ${evt.eventName} (queued)`);
+    for (const tm of TaskManager.all()) {
+      for (const outcome of await tm.assignIdleWorkers()) {
+        if (!outcome.ok) {
+          log(`ERROR Failed to persist assignment: ${fmtError(outcome.err)}`);
+          log(`[worker ${shortWorkerId(outcome.worker.workerId)}] → idle (DB write failed)`);
+          continue;
+        }
+        const { task, queued, worker } = outcome;
+        this.sendMsg(worker, {
+          type: "task_assigned",
+          taskId: task.taskId,
+          issue: task.toAssignmentPayload(),
+        });
+        log(`[worker ${shortWorkerId(worker.workerId)}] → task_assigned #${task.issueNumber} "${task.title}"`);
+        for (const evt of queued) {
+          this.sendMsg(worker, { type: "event_notification", taskId: task.taskId, event: evt.toWorkerPayload() });
+          log(`[worker ${shortWorkerId(worker.workerId)}] → event_notification #${task.issueNumber} ${evt.eventName} (queued)`);
+        }
       }
     }
+  }
+
+  /** Resolve the Repo from a webhook payload's repository.full_name, creating it if needed. */
+  private async resolveRepo(p: R): Promise<Repo> {
+    const repoFullName = strProp(p.repository, "full_name") ?? this.config.githubRepo;
+    return Repo.findOrCreate(repoFullName);
   }
 
   async routePrEvent(p: R, evt: WebhookEvent): Promise<RouteResult> {
@@ -467,14 +476,17 @@ export class ForemanWss {
 
     if (p.action === "synchronize") return routeResult(await Task.getByPr(prNumber));
 
+    const repo = await this.resolveRepo(p);
+    const tm = repo.taskManager;
+
     if (p.action === "opened" && pr) {
-      const task = await this.taskManager.handlePrOpenedEvent(prNumber, String(pr.body ?? ""), strProp(pr.head, "ref"));
+      const task = await tm.handlePrOpenedEvent(prNumber, String(pr.body ?? ""), strProp(pr.head, "ref"));
       if (task) this.forwardEvent(task, evt, `PR #${prNumber}`);
       return routeResult(task);
     }
 
     if (p.action === "closed" && pr) {
-      const task = await this.taskManager.handlePrClosedEvent(prNumber, !!pr.merged);
+      const task = await tm.handlePrClosedEvent(prNumber, !!pr.merged);
       if (task) this.forwardEvent(task, evt, `PR #${prNumber}`);
       return routeResult(task);
     }
@@ -483,7 +495,7 @@ export class ForemanWss {
       const changes = p.changes as R | undefined;
       let task: Task | null = null;
       if (changes?.body) {
-        task = await this.taskManager.handlePrEditedEvent(prNumber, String(pr.body ?? ""), strProp(pr.head, "ref"));
+        task = await tm.handlePrEditedEvent(prNumber, String(pr.body ?? ""), strProp(pr.head, "ref"));
       }
       if (!task) task = await Task.getByPr(prNumber);
       if (task) this.forwardEvent(task, evt, `PR #${prNumber}`);
@@ -511,7 +523,8 @@ export class ForemanWss {
       ? strProp(inner?.check_suite, "head_branch") ?? ""
       : strProp(inner, "head_branch") ?? "";
 
-    const found = await this.taskManager.getTaskForCheckEvent(
+    const repo = await this.resolveRepo(p);
+    const found = await repo.taskManager.getTaskForCheckEvent(
       prs?.map((pr) => pr.number) ?? [],
       headBranch,
     );
@@ -532,6 +545,8 @@ export class ForemanWss {
     if (!task) task = await Task.getByPr(issueNumber);
 
     const action = p.action as string | undefined;
+    const repo = await this.resolveRepo(p);
+    const tm = repo.taskManager;
 
     if (!task) {
       // Check if this webhook should enqueue a new task.
@@ -544,7 +559,7 @@ export class ForemanWss {
 
       if (labeledNow || openedWithLabel) {
         const labels = (issue.labels as Array<{ name: string }> | undefined)?.map((l) => l.name) ?? [];
-        const enqueued = await this.taskManager.handleIssueLabeledEvent(
+        const enqueued = await tm.handleIssueLabeledEvent(
           issueNumber,
           String(issue.title ?? ""),
           String(issue.body ?? ""),
@@ -567,7 +582,7 @@ export class ForemanWss {
       (p.label as R | undefined)?.name === this.config.taskLabel
     ) {
       try {
-        await this.taskManager.dequeueIssue(issueNumber);
+        await tm.dequeueIssue(issueNumber);
         log(`[task #${issueNumber}] dequeued (label removed)`);
       } catch (err) {
         log(`ERROR Failed to dequeue task #${issueNumber}: ${fmtError(err)}`);
@@ -579,7 +594,7 @@ export class ForemanWss {
 
     if (action === "closed") {
       try {
-        await this.taskManager.closeIssue(issueNumber);
+        await tm.closeIssue(issueNumber);
       } catch (err) {
         log(`ERROR Failed to close issue #${issueNumber}: ${fmtError(err)}`);
         return null; // error: skip notification to avoid inconsistency
@@ -589,7 +604,7 @@ export class ForemanWss {
 
     if (action === "reopened") {
       try {
-        await this.taskManager.reopenIssue(issueNumber);
+        await tm.reopenIssue(issueNumber);
       } catch (err) {
         log(`ERROR Failed to reopen issue #${issueNumber}: ${fmtError(err)}`);
         return null; // error: skip notification to avoid inconsistency
@@ -600,7 +615,7 @@ export class ForemanWss {
     if (action === "edited") {
       const changes = p.changes as R | undefined;
       if (changes?.body && task) {
-        this.taskManager.handleIssueBodyEditedEvent(
+        tm.handleIssueBodyEditedEvent(
           issueNumber,
           String(issue.body ?? ""),
         );

--- a/src/foreman/controllers/wss.ts
+++ b/src/foreman/controllers/wss.ts
@@ -63,8 +63,8 @@ export class ForemanWss {
     const debouncedBroadcast = debounce(() => this.broadcastSnapshot(), 10);
     TaskManager.events.on("changed", debouncedBroadcast);
     Worker.events.on("changed", debouncedBroadcast);
-    TaskManager.events.on("deps_loaded", () => {
-      this.assignWork().catch((err) => log(`ERROR assignWork after deps_loaded: ${fmtError(err)}`));
+    TaskManager.events.on("deps_loaded", (taskManager: TaskManager) => {
+      this.assignWorkForRepo(taskManager).catch((err) => log(`ERROR assignWork after deps_loaded: ${fmtError(err)}`));
     });
 
     const wss = new WebSocketServer({ noServer: true });
@@ -281,7 +281,7 @@ export class ForemanWss {
   private async broadcastSnapshot(): Promise<void> {
     if (!this.adminWss) return;
     this.adminWss.broadcastSnapshot({
-      tasks: (await Promise.all(TaskManager.all().map(tm => tm.getTasksForBroadcast()))).flat(),
+      tasks: await TaskManager.getAllTasksForBroadcast(),
       workers: Worker.all().map((w) => w.toWire()),
     });
   }
@@ -307,9 +307,7 @@ export class ForemanWss {
   // ── Hello handlers ───────────────────────────────────────────────────────────
 
   private flushQueuedEvents(worker: Worker, task: Task): void {
-    const tm = TaskManager.getByRepoId(task.repoId);
-    if (!tm) return;
-    for (const evt of tm.drainEvents(task)) {
+    for (const evt of task.drainEvents()) {
       this.sendMsg(worker, { type: "event_notification", taskId: task.taskId, event: evt.toWorkerPayload() });
       this.workerLog(worker.workerId, `→ event_notification #${task.issueNumber} ${evt.eventName} (queued)`);
     }
@@ -418,7 +416,6 @@ export class ForemanWss {
   // ── Routing ─────────────────────────────────────────────────────────────────
 
   forwardEvent(task: Task, evt: WebhookEvent, ref: string): void {
-    const tm = TaskManager.getByRepoId(task.repoId);
     if (task.workerId) {
       const worker = Worker.get(task.workerId);
       if (worker && worker.currentTask?.taskId !== task.taskId) {
@@ -426,7 +423,7 @@ export class ForemanWss {
         return;
       }
       if (worker?.status === "disconnected") {
-        tm?.queueEvent(task, evt);
+        task.queueEvent(evt);
         log(`[task ${ref}] ${evt.eventName} queued (worker ${shortWorkerId(task.workerId)} disconnected)`);
       } else if (worker) {
         this.sendMsg(worker, { type: "event_notification", taskId: task.taskId, event: evt.toWorkerPayload() });
@@ -435,30 +432,34 @@ export class ForemanWss {
         log(`[task ${ref}] ${evt.eventName} DROPPED — worker ${shortWorkerId(task.workerId)} not in registry (disconnected?)`);
       }
     } else if (task.status === "pending" || task.status === "blocked") {
-      tm?.queueEvent(task, evt);
+      task.queueEvent(evt);
       log(`[task ${ref}] ${evt.eventName} queued (no worker assigned)`);
     }
   }
 
   async assignWork(): Promise<void> {
-    for (const tm of TaskManager.all()) {
-      for (const outcome of await tm.assignIdleWorkers()) {
-        if (!outcome.ok) {
-          log(`ERROR Failed to persist assignment: ${fmtError(outcome.err)}`);
-          log(`[worker ${shortWorkerId(outcome.worker.workerId)}] → idle (DB write failed)`);
-          continue;
-        }
-        const { task, queued, worker } = outcome;
-        this.sendMsg(worker, {
-          type: "task_assigned",
-          taskId: task.taskId,
-          issue: task.toAssignmentPayload(),
-        });
-        log(`[worker ${shortWorkerId(worker.workerId)}] → task_assigned #${task.issueNumber} "${task.title}"`);
-        for (const evt of queued) {
-          this.sendMsg(worker, { type: "event_notification", taskId: task.taskId, event: evt.toWorkerPayload() });
-          log(`[worker ${shortWorkerId(worker.workerId)}] → event_notification #${task.issueNumber} ${evt.eventName} (queued)`);
-        }
+    for (const taskManager of TaskManager.all()) {
+      await this.assignWorkForRepo(taskManager);
+    }
+  }
+
+  private async assignWorkForRepo(taskManager: TaskManager): Promise<void> {
+    for (const outcome of await taskManager.assignIdleWorkers()) {
+      if (!outcome.ok) {
+        log(`ERROR Failed to persist assignment: ${fmtError(outcome.err)}`);
+        log(`[worker ${shortWorkerId(outcome.worker.workerId)}] → idle (DB write failed)`);
+        continue;
+      }
+      const { task, queued, worker } = outcome;
+      this.sendMsg(worker, {
+        type: "task_assigned",
+        taskId: task.taskId,
+        issue: task.toAssignmentPayload(),
+      });
+      log(`[worker ${shortWorkerId(worker.workerId)}] → task_assigned #${task.issueNumber} "${task.title}"`);
+      for (const evt of queued) {
+        this.sendMsg(worker, { type: "event_notification", taskId: task.taskId, event: evt.toWorkerPayload() });
+        log(`[worker ${shortWorkerId(worker.workerId)}] → event_notification #${task.issueNumber} ${evt.eventName} (queued)`);
       }
     }
   }
@@ -477,16 +478,16 @@ export class ForemanWss {
     if (p.action === "synchronize") return routeResult(await Task.getByPr(prNumber));
 
     const repo = await this.resolveRepo(p);
-    const tm = repo.taskManager;
+    const manager = repo.taskManager;
 
     if (p.action === "opened" && pr) {
-      const task = await tm.handlePrOpenedEvent(prNumber, String(pr.body ?? ""), strProp(pr.head, "ref"));
+      const task = await manager.handlePrOpenedEvent(prNumber, String(pr.body ?? ""), strProp(pr.head, "ref"));
       if (task) this.forwardEvent(task, evt, `PR #${prNumber}`);
       return routeResult(task);
     }
 
     if (p.action === "closed" && pr) {
-      const task = await tm.handlePrClosedEvent(prNumber, !!pr.merged);
+      const task = await manager.handlePrClosedEvent(prNumber, !!pr.merged);
       if (task) this.forwardEvent(task, evt, `PR #${prNumber}`);
       return routeResult(task);
     }
@@ -495,7 +496,7 @@ export class ForemanWss {
       const changes = p.changes as R | undefined;
       let task: Task | null = null;
       if (changes?.body) {
-        task = await tm.handlePrEditedEvent(prNumber, String(pr.body ?? ""), strProp(pr.head, "ref"));
+        task = await manager.handlePrEditedEvent(prNumber, String(pr.body ?? ""), strProp(pr.head, "ref"));
       }
       if (!task) task = await Task.getByPr(prNumber);
       if (task) this.forwardEvent(task, evt, `PR #${prNumber}`);
@@ -546,7 +547,7 @@ export class ForemanWss {
 
     const action = p.action as string | undefined;
     const repo = await this.resolveRepo(p);
-    const tm = repo.taskManager;
+    const manager = repo.taskManager;
 
     if (!task) {
       // Check if this webhook should enqueue a new task.
@@ -559,7 +560,7 @@ export class ForemanWss {
 
       if (labeledNow || openedWithLabel) {
         const labels = (issue.labels as Array<{ name: string }> | undefined)?.map((l) => l.name) ?? [];
-        const enqueued = await tm.handleIssueLabeledEvent(
+        const enqueued = await manager.handleIssueLabeledEvent(
           issueNumber,
           String(issue.title ?? ""),
           String(issue.body ?? ""),
@@ -582,7 +583,7 @@ export class ForemanWss {
       (p.label as R | undefined)?.name === this.config.taskLabel
     ) {
       try {
-        await tm.dequeueIssue(issueNumber);
+        await manager.dequeueIssue(issueNumber);
         log(`[task #${issueNumber}] dequeued (label removed)`);
       } catch (err) {
         log(`ERROR Failed to dequeue task #${issueNumber}: ${fmtError(err)}`);
@@ -594,7 +595,7 @@ export class ForemanWss {
 
     if (action === "closed") {
       try {
-        await tm.closeIssue(issueNumber);
+        await manager.closeIssue(issueNumber);
       } catch (err) {
         log(`ERROR Failed to close issue #${issueNumber}: ${fmtError(err)}`);
         return null; // error: skip notification to avoid inconsistency
@@ -604,7 +605,7 @@ export class ForemanWss {
 
     if (action === "reopened") {
       try {
-        await tm.reopenIssue(issueNumber);
+        await manager.reopenIssue(issueNumber);
       } catch (err) {
         log(`ERROR Failed to reopen issue #${issueNumber}: ${fmtError(err)}`);
         return null; // error: skip notification to avoid inconsistency
@@ -615,7 +616,7 @@ export class ForemanWss {
     if (action === "edited") {
       const changes = p.changes as R | undefined;
       if (changes?.body && task) {
-        tm.handleIssueBodyEditedEvent(
+        manager.handleIssueBodyEditedEvent(
           issueNumber,
           String(issue.body ?? ""),
         );

--- a/src/foreman/index.ts
+++ b/src/foreman/index.ts
@@ -6,6 +6,7 @@ import type { Database } from "../database.types.js";
 import { Webhooks } from "@octokit/webhooks";
 import { loadConfig } from "../config.js";
 import { TaskManager } from "./models/task-manager.js";
+import { Repo } from "./models/repo.js";
 import { initDb } from "./clients/db-client.js";
 import { Worker } from "./models/worker.js";
 import { createHttpServer } from "./controllers/http-server.js";
@@ -23,25 +24,24 @@ if (isMain) {
     ? new Webhooks({ secret: config.webhookSecret })
     : null;
 
-  // Setup DB and task manager (share the same Supabase client)
+  // Setup DB (share the same Supabase client)
   if (!config.supabaseUrl || !config.supabaseSecretKey) {
     log("ERROR Supabase is required. Set BRUNEL_SUPABASE_URL and BRUNEL_SUPABASE_SECRET_KEY.");
     process.exit(1);
   }
   const supabase = createClient<Database>(config.supabaseUrl, config.supabaseSecretKey);
-  const taskManager = new TaskManager();
   initDb(supabase);
 
   let foremanWss: ForemanWss;
-  const server = createHttpServer({ webhooks, routeEvent: (id, name, payload) => foremanWss.routeEvent(id, name, payload), taskManager });
+  const server = createHttpServer({ webhooks, routeEvent: (id, name, payload) => foremanWss.routeEvent(id, name, payload) });
 
-  // Admin WebSocket broadcaster
+  // Admin WebSocket broadcaster — aggregates tasks from all per-repo TaskManagers
   const adminWss = createAdminWss(server, async () => ({
-    tasks: await taskManager.getTasksForBroadcast(),
+    tasks: (await Promise.all(TaskManager.all().map(tm => tm.getTasksForBroadcast()))).flat(),
     workers: Worker.all().map((w) => w.toWire()),
   }));
 
-  foremanWss = new ForemanWss({ config, taskManager, server, adminWss });
+  foremanWss = new ForemanWss({ config, server, adminWss });
 
   if (webhooks) {
     webhooks.onAny(async ({ id, name, payload }) => {
@@ -51,10 +51,13 @@ if (isMain) {
 
   // Load all state before accepting WebSocket connections.
 
-  // Step 1: Load active tasks from DB (primary source of truth).
+  // Step 1: Bootstrap per-repo TaskManagers from known repos, then load active tasks.
   log("[startup] step 1: loading active tasks from DB...");
   try {
-    await taskManager.loadActiveTasksFromDb();
+    const repos = await Repo.list();
+    for (const repo of repos) {
+      await repo.taskManager.loadActiveTasksFromDb();
+    }
   } catch (err) {
     log(`ERROR Failed to load tasks from DB: ${fmtError(err)}`);
     process.exit(1);
@@ -63,7 +66,9 @@ if (isMain) {
   // Step 2: Fetch brunel:ready issues from GitHub for reconciliation.
   log("[startup] step 2: fetching brunel:ready issues from GitHub for reconciliation...");
   try {
-    await taskManager.loadIssuesFromGithub();
+    for (const tm of TaskManager.all()) {
+      await tm.loadIssuesFromGithub();
+    }
     await foremanWss.reconcile();
   } catch (err) {
     log(`ERROR Failed to load issues from GitHub: ${fmtError(err)}`);

--- a/src/foreman/index.ts
+++ b/src/foreman/index.ts
@@ -37,7 +37,7 @@ if (isMain) {
 
   // Admin WebSocket broadcaster — aggregates tasks from all per-repo TaskManagers
   const adminWss = createAdminWss(server, async () => ({
-    tasks: (await Promise.all(TaskManager.all().map(tm => tm.getTasksForBroadcast()))).flat(),
+    tasks: await TaskManager.getAllTasksForBroadcast(),
     workers: Worker.all().map((w) => w.toWire()),
   }));
 

--- a/src/foreman/models/repo.ts
+++ b/src/foreman/models/repo.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from "node:events";
 import type { Database } from "../../database.types.js";
 import { db } from "../clients/db-client.js";
 import { ActiveRecord } from "./active-record.js";
+import { TaskManager } from "./task-manager.js";
 
 type DbRow = Database["public"]["Tables"]["repos"]["Row"];
 
@@ -36,6 +37,11 @@ export class Repo extends ActiveRecord {
 
   static async list(): Promise<Repo[]> {
     return super.list() as Promise<Repo[]>;
+  }
+
+  /** Convenience accessor — returns the per-repo TaskManager instance. */
+  get taskManager(): TaskManager {
+    return TaskManager.forRepo(this);
   }
 
   /**

--- a/src/foreman/models/task-manager.ts
+++ b/src/foreman/models/task-manager.ts
@@ -38,14 +38,17 @@ export class TaskManager extends EventEmitter {
     return tm;
   }
 
+  /** Look up the TaskManager for a repo ID. Throws if not registered — used by Task.manager
+   *  where the TaskManager is guaranteed to exist (tasks can only be created via a TaskManager). */
+  static forRepoId(repoId: number): TaskManager {
+    const tm = TaskManager.registry.get(repoId);
+    if (!tm) throw new Error(`No TaskManager registered for repo ID ${repoId}`);
+    return tm;
+  }
+
   /** All active TaskManager instances (one per known repo). */
   static all(): TaskManager[] {
     return Array.from(TaskManager.registry.values());
-  }
-
-  /** Look up a TaskManager by repo ID. Used internally by Task.manager. */
-  static getByRepoId(repoId: number): TaskManager | undefined {
-    return TaskManager.registry.get(repoId);
   }
 
   /** Aggregate active tasks from all repos for admin broadcast. */

--- a/src/foreman/models/task-manager.ts
+++ b/src/foreman/models/task-manager.ts
@@ -43,9 +43,14 @@ export class TaskManager extends EventEmitter {
     return Array.from(TaskManager.registry.values());
   }
 
-  /** Look up a TaskManager by repo ID (returns undefined if not registered). */
+  /** Look up a TaskManager by repo ID. Used internally by Task.manager. */
   static getByRepoId(repoId: number): TaskManager | undefined {
     return TaskManager.registry.get(repoId);
+  }
+
+  /** Aggregate active tasks from all repos for admin broadcast. */
+  static async getAllTasksForBroadcast(): Promise<Wire.Task[]> {
+    return (await Promise.all(TaskManager.all().map(tm => tm.getTasksForBroadcast()))).flat();
   }
 
   /** Reset the registry — for tests only. */
@@ -81,7 +86,7 @@ export class TaskManager extends EventEmitter {
     Task.events.on("changed", () => this.emit("changed"));
     // Forward instance events to static aggregator
     this.on("changed", () => TaskManager.events.emit("changed"));
-    this.on("deps_loaded", () => TaskManager.events.emit("deps_loaded"));
+    this.on("deps_loaded", () => TaskManager.events.emit("deps_loaded", this));
   }
 
   // ── Read operations (async — always reads from Task statics) ──────────────

--- a/src/foreman/models/task-manager.ts
+++ b/src/foreman/models/task-manager.ts
@@ -6,22 +6,57 @@ import { EventQueue } from "./event-queue.js";
 import { Task } from "./task.js";
 import { Worker } from "./worker.js";
 import { fmtError, log } from "../../utils.js";
-import { getConfig } from "../../config.js";
+import type { Repo } from "./repo.js";
 
 
 // ── TaskManager ────────────────────────────────────────────────────────────────
-// Owns all ephemeral in-memory state (event queues, branch mappings, open-issue
-// tracking, blocker state) that has no DB backing.  DB reads/writes go through
-// Task statics and instance methods.
+// One instance per repo. Owns all ephemeral in-memory state (event queues,
+// branch mappings, open-issue tracking, blocker state) scoped to a single repo.
+// DB reads/writes go through Task statics and instance methods.
 //
 // Emits "changed" after every Task mutation (by subscribing to Task.events)
 // and after every worker registry change so the admin dashboard can refresh.
+// Static `events` emitter aggregates all per-instance events for cross-repo
+// subscribers (e.g. admin dashboard, work assignment).
 
 export type AssignOutcome =
   | { ok: true; task: Task; queued: WebhookEvent[]; worker: Worker }
   | { ok: false; worker: Worker; err: unknown };
 
 export class TaskManager extends EventEmitter {
+  // ── Static registry ──────────────────────────────────────────────────────
+  private static registry = new Map<number, TaskManager>();
+  static readonly events = new EventEmitter();
+
+  /** Find or create the TaskManager for a given repo. */
+  static forRepo(repo: Repo): TaskManager {
+    let tm = TaskManager.registry.get(repo.id);
+    if (!tm) {
+      tm = new TaskManager(repo);
+      TaskManager.registry.set(repo.id, tm);
+    }
+    return tm;
+  }
+
+  /** All active TaskManager instances (one per known repo). */
+  static all(): TaskManager[] {
+    return Array.from(TaskManager.registry.values());
+  }
+
+  /** Look up a TaskManager by repo ID (returns undefined if not registered). */
+  static getByRepoId(repoId: number): TaskManager | undefined {
+    return TaskManager.registry.get(repoId);
+  }
+
+  /** Reset the registry — for tests only. */
+  static _resetRegistry(): void {
+    TaskManager.registry.clear();
+    TaskManager.events.removeAllListeners();
+  }
+
+  // ── Instance state ───────────────────────────────────────────────────────
+  readonly repo: Repo;
+
   // ── Ephemeral in-memory state (no DB backing) ────────────────────────────
   private eventQueue = new EventQueue();
   private branchToTaskId = new Map<string, string>();
@@ -37,12 +72,16 @@ export class TaskManager extends EventEmitter {
   private _blockers: Map<number, number[]>;
   private _blockersLoaded: Set<number>;
 
-  constructor() {
+  constructor(repo: Repo) {
     super();
+    this.repo = repo;
     this._openIssues = new Set();
     this._blockers = new Map();
     this._blockersLoaded = new Set();
     Task.events.on("changed", () => this.emit("changed"));
+    // Forward instance events to static aggregator
+    this.on("changed", () => TaskManager.events.emit("changed"));
+    this.on("deps_loaded", () => TaskManager.events.emit("deps_loaded"));
   }
 
   // ── Read operations (async — always reads from Task statics) ──────────────
@@ -256,8 +295,7 @@ export class TaskManager extends EventEmitter {
       log(`[task #${issueNumber}] labeled: ignoring — issue is closed`);
       return null;
     }
-    const { githubRepo: repo } = getConfig();
-    const task = await this.enqueueIssue(String(issueNumber), issueNumber, repo, title, body, labels);
+    const task = await this.enqueueIssue(String(issueNumber), issueNumber, this.repo.fullName, title, body, labels);
     this.startDepsLoad(issueNumber, body);
     return task;
   }

--- a/src/foreman/models/task.ts
+++ b/src/foreman/models/task.ts
@@ -1,12 +1,14 @@
 import { EventEmitter } from "node:events";
 import type { TaskStatus } from "../../../shared/wire.js";
 import type { Worker } from "./worker.js";
+import type { WebhookEvent } from "./webhook-event.js";
 import type { Database } from "../../database.types.js";
 import * as Wire from "../../../shared/wire.js";
 import { fetchNativeBlockers } from "../clients/github.js";
 import { db } from "../clients/db-client.js";
 import { ActiveRecord } from "./active-record.js";
 import { Repo } from "./repo.js";
+import { TaskManager } from "./task-manager.js";
 
 type DbRow = Database["public"]["Tables"]["tasks"]["Row"];
 
@@ -101,6 +103,21 @@ export class Task extends ActiveRecord {
       labels: this.labels,
       repoUrl: this.repoUrl,
     };
+  }
+
+  /** The per-repo TaskManager that owns this task's ephemeral state. */
+  get manager(): TaskManager {
+    return TaskManager.getByRepoId(this.repoId)!;
+  }
+
+  /** Queue a webhook event for later delivery (worker disconnected or unassigned). */
+  queueEvent(event: WebhookEvent): void {
+    this.manager.queueEvent(this, event);
+  }
+
+  /** Drain all queued events for this task (on reconnect or assignment). */
+  drainEvents(): WebhookEvent[] {
+    return this.manager.drainEvents(this);
   }
 
   static fromTest(fields: Partial<DbRow> & { task_id: string; issue_number: number }): Task {

--- a/src/foreman/models/task.ts
+++ b/src/foreman/models/task.ts
@@ -107,7 +107,7 @@ export class Task extends ActiveRecord {
 
   /** The per-repo TaskManager that owns this task's ephemeral state. */
   get manager(): TaskManager {
-    return TaskManager.getByRepoId(this.repoId)!;
+    return TaskManager.forRepoId(this.repoId);
   }
 
   /** Queue a webhook event for later delivery (worker disconnected or unassigned). */

--- a/tests/browser/dashboard.spec.ts
+++ b/tests/browser/dashboard.spec.ts
@@ -53,7 +53,7 @@ test("initial load: task list and worker list are visible", async ({ page }) => 
       body: "",
       labels: [{ name: "brunel:ready" }],
     },
-    repository: { html_url: "https://github.com/test/repo" },
+    repository: { full_name: "owner/repo" },
   });
 
   // Seed: connect an idle worker so the workers section is non-empty
@@ -103,7 +103,7 @@ test("live task assignment: dashboard updates without page reload", async ({
         body: "",
         labels: [{ name: "brunel:ready" }],
       },
-      repository: { html_url: "https://github.com/test/repo" },
+      repository: { full_name: "owner/repo" },
     });
 
     // Task row should appear and transition to "assigned" in real time.
@@ -138,7 +138,7 @@ test("log stream: webhook events appear in recent events with correct summaries"
   await postWebhook("push", {
     ref: "refs/heads/main",
     commits: [{ id: "abc123" }],
-    repository: { full_name: "test/repo" },
+    repository: { full_name: "owner/repo" },
     sender: { login: "dev" },
   });
 
@@ -156,7 +156,7 @@ test("log stream: webhook events appear in recent events with correct summaries"
       body: "",
       labels: [{ name: "brunel:ready" }],
     },
-    repository: { full_name: "test/repo" },
+    repository: { full_name: "owner/repo" },
     sender: { login: "dev" },
   });
 

--- a/tests/browser/server.ts
+++ b/tests/browser/server.ts
@@ -141,7 +141,7 @@ async function handleTestRoute(
 // ── Admin WebSocket ───────────────────────────────────────────────────────────
 
 const adminWss = createAdminWss(server, async () => ({
-  tasks: (await Promise.all(TaskManager.all().map(tm => tm.getTasksForBroadcast()))).flat(),
+  tasks: await TaskManager.getAllTasksForBroadcast(),
   workers: Worker.all().map((w) => w.toWire()),
 }));
 

--- a/tests/browser/server.ts
+++ b/tests/browser/server.ts
@@ -39,10 +39,10 @@ import { WebSocket } from "ws";
 import { Worker } from "../../src/foreman/models/worker.js";
 import { ForemanWss } from "../../src/foreman/controllers/wss.js";
 import { createHttpServer } from "../../src/foreman/controllers/http-server.js";
-import { TaskManager } from "../../src/foreman/models/task-manager.js";
 import { Task } from "../../src/foreman/models/task.js";
 import { initDb } from "../../src/foreman/clients/db-client.js";
 import { createMemoryTaskDb } from "../helpers/memory-db.js";
+import { createTestTaskManager } from "../helpers/task.js";
 import { createAdminWss } from "../../src/foreman/controllers/admin-ws.js";
 import { loadDefaultConfig } from "../../src/config.js";
 
@@ -52,9 +52,8 @@ const cfg = await loadDefaultConfig();
 
 // ── Foreman state ─────────────────────────────────────────────────────────────
 
-const taskModel = new TaskManager();
 initDb(createMemoryTaskDb());
-Task.events.on("changed", () => taskModel.emit("changed"));
+const taskModel = await createTestTaskManager();
 
 // Mock workers managed by /test/connect-worker and /test/workers/:id
 const mockWorkers = new Map<string, WebSocket>();
@@ -147,7 +146,7 @@ const adminWss = createAdminWss(server, async () => ({
 
 // ── Foreman WebSocket ─────────────────────────────────────────────────────────
 
-foremanWss = new ForemanWss({ taskManager: taskModel, server, config: cfg, adminWss });
+foremanWss = new ForemanWss({ server, config: cfg, adminWss });
 
 // ── Start ─────────────────────────────────────────────────────────────────────
 

--- a/tests/browser/server.ts
+++ b/tests/browser/server.ts
@@ -43,6 +43,7 @@ import { Task } from "../../src/foreman/models/task.js";
 import { initDb } from "../../src/foreman/clients/db-client.js";
 import { createMemoryTaskDb } from "../helpers/memory-db.js";
 import { createTestTaskManager } from "../helpers/task.js";
+import { TaskManager } from "../../src/foreman/models/task-manager.js";
 import { createAdminWss } from "../../src/foreman/controllers/admin-ws.js";
 import { loadDefaultConfig } from "../../src/config.js";
 
@@ -53,7 +54,7 @@ const cfg = await loadDefaultConfig();
 // ── Foreman state ─────────────────────────────────────────────────────────────
 
 initDb(createMemoryTaskDb());
-const taskModel = await createTestTaskManager();
+const taskModel = await createTestTaskManager("owner/repo");
 
 // Mock workers managed by /test/connect-worker and /test/workers/:id
 const mockWorkers = new Map<string, WebSocket>();
@@ -140,7 +141,7 @@ async function handleTestRoute(
 // ── Admin WebSocket ───────────────────────────────────────────────────────────
 
 const adminWss = createAdminWss(server, async () => ({
-  tasks: await taskModel.getTasksForBroadcast(),
+  tasks: (await Promise.all(TaskManager.all().map(tm => tm.getTasksForBroadcast()))).flat(),
   workers: Worker.all().map((w) => w.toWire()),
 }));
 

--- a/tests/browser/task-detail.spec.ts
+++ b/tests/browser/task-detail.spec.ts
@@ -35,7 +35,7 @@ test("task detail page: shows correct task ID in heading", async ({ page }) => {
       body: "",
       labels: [{ name: "brunel:ready" }],
     },
-    repository: { html_url: "https://github.com/test/repo" },
+    repository: { full_name: "owner/repo" },
   });
 
   await page.goto("/tasks/4001");
@@ -56,7 +56,7 @@ test("task detail page: live events appear as webhooks arrive for that task", as
       body: "",
       labels: [{ name: "brunel:ready" }],
     },
-    repository: { html_url: "https://github.com/test/repo" },
+    repository: { full_name: "owner/repo" },
   });
 
   // Set up admin WS listener BEFORE navigating — same pattern as worker-detail
@@ -84,7 +84,7 @@ test("task detail page: live events appear as webhooks arrive for that task", as
     comment: {
       body: "LGTM",
     },
-    repository: { full_name: "test/repo" },
+    repository: { full_name: "owner/repo" },
     sender: { login: "reviewer" },
   });
 

--- a/tests/dependencies.test.ts
+++ b/tests/dependencies.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Task } from "../src/foreman/models/task.js";
 import { TaskManager } from "../src/foreman/models/task-manager.js";
-import { resetDb } from "./helpers/task.js";
+import { resetDb, createTestTaskManager } from "./helpers/task.js";
 import { getConfig } from "../src/config.js";
 
 describe("Task.parseBodyBlockers", () => {
@@ -61,8 +61,8 @@ describe("Task.parseBodyBlockers", () => {
 describe("TaskManager — setBlockers / isBlocked", () => {
   let tm: TaskManager;
 
-  beforeEach(() => {
-    tm = new TaskManager();
+  beforeEach(async () => {
+    tm = await createTestTaskManager();
     resetDb();
   });
 

--- a/tests/foreman.admin-broadcast.test.ts
+++ b/tests/foreman.admin-broadcast.test.ts
@@ -20,7 +20,7 @@ import { Worker } from "../src/foreman/models/worker.js";
 import { ForemanWss } from "../src/foreman/controllers/wss.js";
 import { TaskManager } from "../src/foreman/models/task-manager.js";
 import { Task } from "../src/foreman/models/task.js";
-import { resetDb } from "./helpers/task.js";
+import { resetDb, createTestTaskManager } from "./helpers/task.js";
 import { loadDefaultConfig } from "../src/config.js";
 const defaultCfg = await loadDefaultConfig();
 import type { AdminWss, AdminSnapshot, LogEntry } from "../src/foreman/controllers/admin-ws.js";
@@ -79,18 +79,18 @@ function connect(): Promise<WebSocket> {
   return connectWorker(port).then((ws) => { openClients.push(ws); return ws; });
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   Worker._reset();
   vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
   process.env.GITHUB_REPO = "owner/repo";
   process.env.GITHUB_TOKEN = "token";
 
-  taskManager = new TaskManager();
   resetDb();
+  taskManager = await createTestTaskManager("owner/repo");
 
   adminWss = makeMockAdminWss();
   httpServer = http.createServer();
-  foremanWss = new ForemanWss({ taskManager, server: httpServer, config: defaultCfg, adminWss });
+  foremanWss = new ForemanWss({ server: httpServer, config: defaultCfg, adminWss });
   ({ wss } = foremanWss);
 
   return new Promise<void>((resolve) => {

--- a/tests/foreman.blockers.test.ts
+++ b/tests/foreman.blockers.test.ts
@@ -3,7 +3,7 @@ import { Worker } from "../src/foreman/models/worker.js";
 import { ForemanWss } from "../src/foreman/controllers/wss.js";
 import { TaskManager } from "../src/foreman/models/task-manager.js";
 import { Task } from "../src/foreman/models/task.js";
-import { resetDb } from "./helpers/task.js";
+import { resetDb, createTestTaskManager } from "./helpers/task.js";
 import { loadDefaultConfig } from "../src/config.js";
 import http from "http";
 
@@ -14,10 +14,10 @@ const defaultCfg = await loadDefaultConfig();
 describe("foreman — blocker transitions via routeEvent", () => {
   let taskManager: TaskManager;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     Worker._reset();
-    taskManager = new TaskManager();
     resetDb();
+    taskManager = await createTestTaskManager("owner/repo");
   });
 
   afterEach(() => {
@@ -33,7 +33,7 @@ describe("foreman — blocker transitions via routeEvent", () => {
     taskManager.markBlockersLoaded(10);
     taskManager.setIssueOpenState(5, true); // blocker is open
 
-    const { wss } = new ForemanWss({ taskManager, server, config: { ...defaultCfg, taskLabel: "brunel:ready", workerReclaimTimeoutMs: 300_000 } });
+    const { wss } = new ForemanWss({ server, config: { ...defaultCfg, taskLabel: "brunel:ready", workerReclaimTimeoutMs: 300_000 } });
     wss.close();
 
     const snapshots = await taskManager.getTasksForBroadcast();
@@ -49,7 +49,7 @@ describe("foreman — blocker transitions via routeEvent", () => {
     taskManager.markBlockersLoaded(10);
     taskManager.setIssueOpenState(5, true);
 
-    const foremanWss = new ForemanWss({ taskManager, server, config: { ...defaultCfg, taskLabel: "brunel:ready" } });
+    const foremanWss = new ForemanWss({ server, config: { ...defaultCfg, taskLabel: "brunel:ready" } });
     const { wss } = foremanWss;
     wss.close();
 
@@ -79,7 +79,7 @@ describe("foreman — blocker transitions via routeEvent", () => {
     taskManager.setIssueOpenState(5, true);
     taskManager.setIssueOpenState(6, true);
 
-    const foremanWss = new ForemanWss({ taskManager, server, config: { ...defaultCfg, taskLabel: "brunel:ready" } });
+    const foremanWss = new ForemanWss({ server, config: { ...defaultCfg, taskLabel: "brunel:ready" } });
     const { wss } = foremanWss;
     wss.close();
 

--- a/tests/foreman.event-router.handlers.test.ts
+++ b/tests/foreman.event-router.handlers.test.ts
@@ -5,10 +5,11 @@
 import http from "http";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ForemanWss } from "../src/foreman/controllers/wss.js";
+import { TaskManager } from "../src/foreman/models/task-manager.js";
 import { Task } from "../src/foreman/models/task.js";
 import { Worker } from "../src/foreman/models/worker.js";
 import { WebhookEvent } from "../src/foreman/models/webhook-event.js";
-import { resetDb, seedTask } from "./helpers/task.js";
+import { resetDb, seedTask, createTestRepo } from "./helpers/task.js";
 import * as utils from "../src/utils.js";
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
@@ -25,38 +26,25 @@ interface TestDeps {
   wss: ForemanWss;
   sendMsg: ReturnType<typeof vi.fn>;
   forwardEvent: ReturnType<typeof vi.spyOn>;
-  taskManager: {
-    queueEvent: ReturnType<typeof vi.fn>;
-    dequeueIssue: ReturnType<typeof vi.fn>;
-    closeIssue: ReturnType<typeof vi.fn>;
-    reopenIssue: ReturnType<typeof vi.fn>;
-    assignIdleWorkers: ReturnType<typeof vi.fn>;
-    handleIssueLabeledEvent: ReturnType<typeof vi.fn>;
-    handleIssueBodyEditedEvent: ReturnType<typeof vi.fn>;
-    handlePrOpenedEvent: ReturnType<typeof vi.fn>;
-    handlePrClosedEvent: ReturnType<typeof vi.fn>;
-    getTaskForCheckEvent: ReturnType<typeof vi.fn>;
-    on: ReturnType<typeof vi.fn>;
-  };
+  taskManager: TaskManager;
 }
 
-function makeDeps(): TestDeps {
-  const taskManager = {
-    queueEvent: vi.fn(),
-    dequeueIssue: vi.fn().mockResolvedValue(undefined),
-    closeIssue: vi.fn().mockResolvedValue(undefined),
-    reopenIssue: vi.fn().mockResolvedValue(undefined),
-    assignIdleWorkers: vi.fn().mockResolvedValue([]),
-    handleIssueLabeledEvent: vi.fn().mockResolvedValue(null),
-    handleIssueBodyEditedEvent: vi.fn(),
-    handlePrOpenedEvent: vi.fn().mockResolvedValue(null),
-    handlePrClosedEvent: vi.fn().mockResolvedValue(null),
-    getTaskForCheckEvent: vi.fn().mockResolvedValue(null),
-    on: vi.fn(),
-  };
+async function makeDeps(): Promise<TestDeps> {
+  const repo = await createTestRepo("owner/repo");
+  const taskManager = repo.taskManager;
+  // Spy on all TaskManager methods so the tests can assert calls without side effects
+  vi.spyOn(taskManager, "queueEvent").mockImplementation(() => {});
+  vi.spyOn(taskManager, "dequeueIssue").mockResolvedValue(undefined);
+  vi.spyOn(taskManager, "closeIssue").mockResolvedValue(undefined);
+  vi.spyOn(taskManager, "reopenIssue").mockResolvedValue(undefined);
+  vi.spyOn(taskManager, "assignIdleWorkers").mockResolvedValue([]);
+  vi.spyOn(taskManager, "handleIssueLabeledEvent").mockResolvedValue(null);
+  vi.spyOn(taskManager, "handleIssueBodyEditedEvent").mockImplementation(() => {});
+  vi.spyOn(taskManager, "handlePrOpenedEvent").mockResolvedValue(null);
+  vi.spyOn(taskManager, "handlePrClosedEvent").mockResolvedValue(null);
+  vi.spyOn(taskManager, "getTaskForCheckEvent").mockResolvedValue(null);
   const wss = new ForemanWss({
     config: { taskLabel: "brunel:ready", githubRepo: "owner/repo", githubToken: "token", workerSecret: undefined, pingIntervalMs: 1e9 },
-    taskManager: taskManager as any,
     server: http.createServer(),
   });
   const sendMsg = vi.spyOn(wss, "sendMsg").mockImplementation(() => {});
@@ -80,7 +68,7 @@ afterEach(() => {
 
 describe("routePrEvent — missing PR number", () => {
   it("returns null task when pull_request has no number", async () => {
-    const { wss, forwardEvent } = makeDeps();
+    const { wss, forwardEvent } = await makeDeps();
     const result = await wss.routePrEvent({ pull_request: {} }, makeEvent());
     expect(result).toEqual({ taskId: null, workerId: null });
     expect(forwardEvent).not.toHaveBeenCalled();
@@ -90,7 +78,7 @@ describe("routePrEvent — missing PR number", () => {
 describe("routePrEvent — synchronize", () => {
   it("returns the task without forwarding when action is synchronize", async () => {
     await seedTask({ task_id: "42", issue_number: 42, pr_number: 99 });
-    const { wss, sendMsg, forwardEvent } = makeDeps();
+    const { wss, sendMsg, forwardEvent } = await makeDeps();
     const result = await wss.routePrEvent(
       { action: "synchronize", pull_request: { number: 99 } },
       makeEvent(),
@@ -106,7 +94,7 @@ describe("routePrEvent — opened", () => {
     const w = Worker.register("worker-1", fakeWs());
     const task = await seedTask({ task_id: "42", issue_number: 42, worker_id: "worker-1", assigned_at: new Date().toISOString() });
     w.assign(task);
-    const { wss, sendMsg, forwardEvent, taskManager } = makeDeps();
+    const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
     taskManager.handlePrOpenedEvent.mockResolvedValue(task);
     const result = await wss.routePrEvent(
       {
@@ -126,7 +114,7 @@ describe("routePrEvent — opened", () => {
   });
 
   it("returns null when handlePrOpenedEvent finds no linked issue", async () => {
-    const { wss, sendMsg, forwardEvent, taskManager } = makeDeps();
+    const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
     taskManager.handlePrOpenedEvent.mockResolvedValue(null);
     const result = await wss.routePrEvent(
       { action: "opened", pull_request: { number: 99, body: "no link here", head: { ref: "branch" } } },
@@ -143,7 +131,7 @@ describe("routePrEvent — closed without merge", () => {
     const w = Worker.register("worker-1", fakeWs());
     const task = await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, worker_id: "worker-1", assigned_at: new Date().toISOString() });
     w.assign(task);
-    const { wss, sendMsg, forwardEvent, taskManager } = makeDeps();
+    const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
     taskManager.handlePrClosedEvent.mockResolvedValue(task);
     const result = await wss.routePrEvent(
       { action: "closed", pull_request: { number: 99, merged: false } },
@@ -156,7 +144,7 @@ describe("routePrEvent — closed without merge", () => {
   });
 
   it("returns null when no task owns the PR", async () => {
-    const { wss, forwardEvent, taskManager } = makeDeps();
+    const { wss, forwardEvent, taskManager } = await makeDeps();
     taskManager.handlePrClosedEvent.mockResolvedValue(null);
     const result = await wss.routePrEvent(
       { action: "closed", pull_request: { number: 99, merged: false } },
@@ -172,7 +160,7 @@ describe("routePrEvent — closed with merge", () => {
     const w = Worker.register("worker-1", fakeWs());
     const task = await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, worker_id: "worker-1", assigned_at: new Date().toISOString() });
     w.assign(task);
-    const { wss, sendMsg, forwardEvent, taskManager } = makeDeps();
+    const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
     taskManager.handlePrClosedEvent.mockResolvedValue(task);
     const result = await wss.routePrEvent(
       { action: "closed", pull_request: { number: 99, merged: true } },
@@ -185,7 +173,7 @@ describe("routePrEvent — closed with merge", () => {
   });
 
   it("returns null when no task owns the PR", async () => {
-    const { wss, forwardEvent } = makeDeps();
+    const { wss, forwardEvent } = await makeDeps();
     const result = await wss.routePrEvent(
       { action: "closed", pull_request: { number: 99, merged: true } },
       makeEvent(),
@@ -200,7 +188,7 @@ describe("routePrEvent — passthrough", () => {
     const w = Worker.register("worker-1", fakeWs());
     const task = await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, worker_id: "worker-1", assigned_at: new Date().toISOString() });
     w.assign(task);
-    const { wss, sendMsg, forwardEvent } = makeDeps();
+    const { wss, sendMsg, forwardEvent } = await makeDeps();
     const result = await wss.routePrEvent(
       { action: "labeled", pull_request: { number: 99 } },
       makeEvent(),
@@ -211,7 +199,7 @@ describe("routePrEvent — passthrough", () => {
   });
 
   it("returns null task when no task owns the PR", async () => {
-    const { wss, forwardEvent } = makeDeps();
+    const { wss, forwardEvent } = await makeDeps();
     const result = await wss.routePrEvent(
       { action: "labeled", pull_request: { number: 99 } },
       makeEvent(),
@@ -225,7 +213,7 @@ describe("routePrEvent — passthrough", () => {
 
 describe("routePrReviewEvent", () => {
   it("returns null when PR number is missing", async () => {
-    const { wss, forwardEvent } = makeDeps();
+    const { wss, forwardEvent } = await makeDeps();
     const result = await wss.routePrReviewEvent({ pull_request: {} }, makeEvent("pull_request_review"));
     expect(result).toEqual({ taskId: null, workerId: null });
     expect(forwardEvent).not.toHaveBeenCalled();
@@ -235,7 +223,7 @@ describe("routePrReviewEvent", () => {
     const w = Worker.register("worker-1", fakeWs());
     const task = await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, worker_id: "worker-1", assigned_at: new Date().toISOString() });
     w.assign(task);
-    const { wss, sendMsg, forwardEvent } = makeDeps();
+    const { wss, sendMsg, forwardEvent } = await makeDeps();
     const result = await wss.routePrReviewEvent(
       { pull_request: { number: 99 } },
       makeEvent("pull_request_review"),
@@ -246,7 +234,7 @@ describe("routePrReviewEvent", () => {
   });
 
   it("returns null when no task owns the reviewed PR", async () => {
-    const { wss, forwardEvent } = makeDeps();
+    const { wss, forwardEvent } = await makeDeps();
     const result = await wss.routePrReviewEvent(
       { pull_request: { number: 99 } },
       makeEvent("pull_request_review"),
@@ -263,7 +251,7 @@ describe("routeCheckEvent — via PR number", () => {
     const w = Worker.register("worker-1", fakeWs());
     const task = await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, worker_id: "worker-1", assigned_at: new Date().toISOString() });
     w.assign(task);
-    const { wss, sendMsg, forwardEvent, taskManager } = makeDeps();
+    const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
     taskManager.getTaskForCheckEvent.mockResolvedValue({ task, ref: "PR #99" });
     const result = await wss.routeCheckEvent(
       { check_run: { pull_requests: [{ number: 99 }] } },
@@ -280,7 +268,7 @@ describe("routeCheckEvent — via PR number", () => {
     const w = Worker.register("worker-1", fakeWs());
     const task = await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, worker_id: "worker-1", assigned_at: new Date().toISOString() });
     w.assign(task);
-    const { wss, sendMsg, forwardEvent, taskManager } = makeDeps();
+    const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
     taskManager.getTaskForCheckEvent.mockResolvedValue({ task, ref: "PR #99" });
     const result = await wss.routeCheckEvent(
       { check_suite: { pull_requests: [{ number: 99 }] } },
@@ -299,7 +287,7 @@ describe("routeCheckEvent — via branch name", () => {
     const w = Worker.register("worker-1", fakeWs());
     const task = await seedTask({ task_id: "42", issue_number: 42, worker_id: "worker-1", assigned_at: new Date().toISOString() });
     w.assign(task);
-    const { wss, sendMsg, forwardEvent, taskManager } = makeDeps();
+    const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
     taskManager.getTaskForCheckEvent.mockResolvedValue({ task, ref: "branch feature-branch" });
     const result = await wss.routeCheckEvent(
       { check_run: { pull_requests: [], check_suite: { head_branch: "feature-branch" } } },
@@ -316,7 +304,7 @@ describe("routeCheckEvent — via branch name", () => {
     const w = Worker.register("worker-1", fakeWs());
     const task = await seedTask({ task_id: "42", issue_number: 42, worker_id: "worker-1", assigned_at: new Date().toISOString() });
     w.assign(task);
-    const { wss, sendMsg, forwardEvent, taskManager } = makeDeps();
+    const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
     taskManager.getTaskForCheckEvent.mockResolvedValue({ task, ref: "branch feature-branch" });
     const result = await wss.routeCheckEvent(
       { check_suite: { pull_requests: [], head_branch: "feature-branch" } },
@@ -330,7 +318,7 @@ describe("routeCheckEvent — via branch name", () => {
   });
 
   it("returns null when getTaskForCheckEvent finds nothing", async () => {
-    const { wss, forwardEvent } = makeDeps();
+    const { wss, forwardEvent } = await makeDeps();
     const result = await wss.routeCheckEvent(
       { check_run: { pull_requests: [], check_suite: { head_branch: "unknown-branch" } } },
       makeEvent("check_run"),
@@ -346,7 +334,7 @@ describe("routeCheckEvent — via branch name", () => {
 describe("routeIssueEvent — enqueue on labeled", () => {
   it("calls handleIssueLabeledEvent and returns the enqueued task", async () => {
     const task = Task.fromTest({ task_id: "42", issue_number: 42 });
-    const { wss, forwardEvent, taskManager } = makeDeps();
+    const { wss, forwardEvent, taskManager } = await makeDeps();
     taskManager.handleIssueLabeledEvent.mockResolvedValue(task);
     const issue = { number: 42, title: "Do something", body: "details", state: "open", labels: [{ name: "brunel:ready" }] };
     const result = await wss.routeIssueEvent(
@@ -366,7 +354,7 @@ describe("routeIssueEvent — enqueue on labeled", () => {
   });
 
   it("returns null when handleIssueLabeledEvent returns null (e.g. closed issue)", async () => {
-    const { wss, forwardEvent, taskManager } = makeDeps();
+    const { wss, forwardEvent, taskManager } = await makeDeps();
     taskManager.handleIssueLabeledEvent.mockResolvedValue(null);
     const issue = { number: 42, title: "Do something", body: "", state: "closed", labels: [{ name: "brunel:ready" }] };
     const result = await wss.routeIssueEvent(
@@ -381,7 +369,7 @@ describe("routeIssueEvent — enqueue on labeled", () => {
   });
 
   it("ignores a labeled event for a different label", async () => {
-    const { wss, forwardEvent, taskManager } = makeDeps();
+    const { wss, forwardEvent, taskManager } = await makeDeps();
     const issue = { number: 42, title: "Do something", body: "", state: "open", labels: [] };
     const result = await wss.routeIssueEvent(
       { action: "labeled", label: { name: "other-label" } },
@@ -398,7 +386,7 @@ describe("routeIssueEvent — enqueue on labeled", () => {
 describe("routeIssueEvent — enqueue on opened", () => {
   it("calls handleIssueLabeledEvent when opened with the task label already attached", async () => {
     const task = Task.fromTest({ task_id: "42", issue_number: 42 });
-    const { wss, forwardEvent, taskManager } = makeDeps();
+    const { wss, forwardEvent, taskManager } = await makeDeps();
     taskManager.handleIssueLabeledEvent.mockResolvedValue(task);
     const issue = { number: 42, title: "Do something", body: "details", state: "open", labels: [{ name: "brunel:ready" }] };
     const result = await wss.routeIssueEvent(
@@ -413,7 +401,7 @@ describe("routeIssueEvent — enqueue on opened", () => {
   });
 
   it("does not call handleIssueLabeledEvent when opened without the task label", async () => {
-    const { wss, forwardEvent, taskManager } = makeDeps();
+    const { wss, forwardEvent, taskManager } = await makeDeps();
     const issue = { number: 42, title: "Do something", body: "", state: "open", labels: [] };
     const result = await wss.routeIssueEvent(
       { action: "opened" },
@@ -430,7 +418,7 @@ describe("routeIssueEvent — enqueue on opened", () => {
 describe("routeIssueEvent — unlabeled (dequeue)", () => {
   it("dequeues the task when the task label is removed", async () => {
     await seedTask({ task_id: "42", issue_number: 42 });
-    const { wss, forwardEvent, taskManager } = makeDeps();
+    const { wss, forwardEvent, taskManager } = await makeDeps();
     const issue = { number: 42 };
     await wss.routeIssueEvent(
       { action: "unlabeled", label: { name: "brunel:ready" } },
@@ -446,7 +434,7 @@ describe("routeIssueEvent — unlabeled (dequeue)", () => {
 
   it("does not dequeue when a different label is removed", async () => {
     await seedTask({ task_id: "42", issue_number: 42 });
-    const { wss, forwardEvent, taskManager } = makeDeps();
+    const { wss, forwardEvent, taskManager } = await makeDeps();
     const issue = { number: 42 };
     await wss.routeIssueEvent(
       { action: "unlabeled", label: { name: "other-label" } },
@@ -462,7 +450,7 @@ describe("routeIssueEvent — unlabeled (dequeue)", () => {
 
 describe("routeIssueEvent — closed", () => {
   it("calls closeIssue when an issue is closed", async () => {
-    const { wss, forwardEvent, taskManager } = makeDeps();
+    const { wss, forwardEvent, taskManager } = await makeDeps();
     const issue = { number: 42 };
     await wss.routeIssueEvent(
       { action: "closed" },
@@ -477,7 +465,7 @@ describe("routeIssueEvent — closed", () => {
 
   it("calls forwardEvent when a tracked task exists", async () => {
     await seedTask({ task_id: "42", issue_number: 42 });
-    const { wss, forwardEvent, taskManager } = makeDeps();
+    const { wss, forwardEvent, taskManager } = await makeDeps();
     const issue = { number: 42 };
     await wss.routeIssueEvent(
       { action: "closed" },
@@ -492,7 +480,7 @@ describe("routeIssueEvent — closed", () => {
 
 describe("routeIssueEvent — reopened", () => {
   it("calls reopenIssue when an issue is reopened", async () => {
-    const { wss, forwardEvent, taskManager } = makeDeps();
+    const { wss, forwardEvent, taskManager } = await makeDeps();
     const issue = { number: 42 };
     await wss.routeIssueEvent(
       { action: "reopened" },
@@ -507,7 +495,7 @@ describe("routeIssueEvent — reopened", () => {
 
   it("calls forwardEvent when a tracked task exists", async () => {
     await seedTask({ task_id: "42", issue_number: 42 });
-    const { wss, forwardEvent, taskManager } = makeDeps();
+    const { wss, forwardEvent, taskManager } = await makeDeps();
     const issue = { number: 42 };
     await wss.routeIssueEvent(
       { action: "reopened" },
@@ -523,7 +511,7 @@ describe("routeIssueEvent — reopened", () => {
 describe("routeIssueEvent — edited", () => {
   it("calls handleIssueBodyEditedEvent when the issue body is edited for a tracked task", async () => {
     await seedTask({ task_id: "42", issue_number: 42 });
-    const { wss, forwardEvent, taskManager } = makeDeps();
+    const { wss, forwardEvent, taskManager } = await makeDeps();
     const issue = { number: 42, body: "updated body" };
     await wss.routeIssueEvent(
       { action: "edited", changes: { body: { from: "old body" } } },
@@ -539,7 +527,7 @@ describe("routeIssueEvent — edited", () => {
 
   it("does not call handleIssueBodyEditedEvent when the body was not changed", async () => {
     await seedTask({ task_id: "42", issue_number: 42 });
-    const { wss, forwardEvent, taskManager } = makeDeps();
+    const { wss, forwardEvent, taskManager } = await makeDeps();
     const issue = { number: 42, title: "updated title" };
     await wss.routeIssueEvent(
       { action: "edited", changes: { title: { from: "old title" } } },
@@ -553,7 +541,7 @@ describe("routeIssueEvent — edited", () => {
   });
 
   it("does not call handleIssueBodyEditedEvent when the issue is not tracked", async () => {
-    const { wss, forwardEvent, taskManager } = makeDeps();
+    const { wss, forwardEvent, taskManager } = await makeDeps();
     const issue = { number: 42, body: "updated body" };
     await wss.routeIssueEvent(
       { action: "edited", changes: { body: { from: "old body" } } },
@@ -571,7 +559,7 @@ describe("routeIssueEvent — passthrough forwarding", () => {
     const w = Worker.register("worker-1", fakeWs());
     const task = await seedTask({ task_id: "42", issue_number: 42, worker_id: "worker-1", assigned_at: new Date().toISOString() });
     w.assign(task);
-    const { wss, sendMsg, forwardEvent } = makeDeps();
+    const { wss, sendMsg, forwardEvent } = await makeDeps();
     const issue = { number: 42 };
     const result = await wss.routeIssueEvent(
       { action: "assigned" },
@@ -588,7 +576,7 @@ describe("routeIssueEvent — passthrough forwarding", () => {
     const w = Worker.register("worker-1", fakeWs());
     const task = await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, worker_id: "worker-1", assigned_at: new Date().toISOString() });
     w.assign(task);
-    const { wss, sendMsg, forwardEvent } = makeDeps();
+    const { wss, sendMsg, forwardEvent } = await makeDeps();
     const issue = { number: 99 }; // PR number in issue.number
     const result = await wss.routeIssueEvent(
       { action: "created" },

--- a/tests/foreman.event-router.handlers.test.ts
+++ b/tests/foreman.event-router.handlers.test.ts
@@ -53,10 +53,13 @@ async function makeDeps(): Promise<TestDeps> {
 }
 
 let logSpy: ReturnType<typeof vi.spyOn>;
+let testRepoId: number;
 
-beforeEach(() => {
+beforeEach(async () => {
   Worker._reset();
   resetDb();
+  const repo = await createTestRepo("owner/repo");
+  testRepoId = repo.id;
   logSpy = vi.spyOn(utils, "log").mockImplementation(() => {});
 });
 
@@ -77,7 +80,7 @@ describe("routePrEvent — missing PR number", () => {
 
 describe("routePrEvent — synchronize", () => {
   it("returns the task without forwarding when action is synchronize", async () => {
-    await seedTask({ task_id: "42", issue_number: 42, pr_number: 99 });
+    await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, repo_id: testRepoId });
     const { wss, sendMsg, forwardEvent } = await makeDeps();
     const result = await wss.routePrEvent(
       { action: "synchronize", pull_request: { number: 99 } },
@@ -92,7 +95,7 @@ describe("routePrEvent — synchronize", () => {
 describe("routePrEvent — opened", () => {
   it("calls handlePrOpenedEvent and forwards event when a linked task is found", async () => {
     const w = Worker.register("worker-1", fakeWs());
-    const task = await seedTask({ task_id: "42", issue_number: 42, worker_id: "worker-1", assigned_at: new Date().toISOString() });
+    const task = await seedTask({ task_id: "42", issue_number: 42, repo_id: testRepoId, worker_id: "worker-1", assigned_at: new Date().toISOString() });
     w.assign(task);
     const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
     taskManager.handlePrOpenedEvent.mockResolvedValue(task);
@@ -129,7 +132,7 @@ describe("routePrEvent — opened", () => {
 describe("routePrEvent — closed without merge", () => {
   it("calls handlePrClosedEvent and forwards the event to the task", async () => {
     const w = Worker.register("worker-1", fakeWs());
-    const task = await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, worker_id: "worker-1", assigned_at: new Date().toISOString() });
+    const task = await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, repo_id: testRepoId, worker_id: "worker-1", assigned_at: new Date().toISOString() });
     w.assign(task);
     const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
     taskManager.handlePrClosedEvent.mockResolvedValue(task);
@@ -158,7 +161,7 @@ describe("routePrEvent — closed without merge", () => {
 describe("routePrEvent — closed with merge", () => {
   it("calls handlePrClosedEvent with merged=true and forwards the event", async () => {
     const w = Worker.register("worker-1", fakeWs());
-    const task = await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, worker_id: "worker-1", assigned_at: new Date().toISOString() });
+    const task = await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, repo_id: testRepoId, worker_id: "worker-1", assigned_at: new Date().toISOString() });
     w.assign(task);
     const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
     taskManager.handlePrClosedEvent.mockResolvedValue(task);
@@ -186,7 +189,7 @@ describe("routePrEvent — closed with merge", () => {
 describe("routePrEvent — passthrough", () => {
   it("forwards other PR events to the task", async () => {
     const w = Worker.register("worker-1", fakeWs());
-    const task = await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, worker_id: "worker-1", assigned_at: new Date().toISOString() });
+    const task = await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, repo_id: testRepoId, worker_id: "worker-1", assigned_at: new Date().toISOString() });
     w.assign(task);
     const { wss, sendMsg, forwardEvent } = await makeDeps();
     const result = await wss.routePrEvent(
@@ -221,7 +224,7 @@ describe("routePrReviewEvent", () => {
 
   it("forwards review events to the task that owns the PR", async () => {
     const w = Worker.register("worker-1", fakeWs());
-    const task = await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, worker_id: "worker-1", assigned_at: new Date().toISOString() });
+    const task = await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, repo_id: testRepoId, worker_id: "worker-1", assigned_at: new Date().toISOString() });
     w.assign(task);
     const { wss, sendMsg, forwardEvent } = await makeDeps();
     const result = await wss.routePrReviewEvent(
@@ -249,7 +252,7 @@ describe("routePrReviewEvent", () => {
 describe("routeCheckEvent — via PR number", () => {
   it("forwards check_run to the task when getTaskForCheckEvent finds it by PR", async () => {
     const w = Worker.register("worker-1", fakeWs());
-    const task = await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, worker_id: "worker-1", assigned_at: new Date().toISOString() });
+    const task = await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, repo_id: testRepoId, worker_id: "worker-1", assigned_at: new Date().toISOString() });
     w.assign(task);
     const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
     taskManager.getTaskForCheckEvent.mockResolvedValue({ task, ref: "PR #99" });
@@ -266,7 +269,7 @@ describe("routeCheckEvent — via PR number", () => {
 
   it("forwards check_suite to the task when getTaskForCheckEvent finds it by PR", async () => {
     const w = Worker.register("worker-1", fakeWs());
-    const task = await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, worker_id: "worker-1", assigned_at: new Date().toISOString() });
+    const task = await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, repo_id: testRepoId, worker_id: "worker-1", assigned_at: new Date().toISOString() });
     w.assign(task);
     const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
     taskManager.getTaskForCheckEvent.mockResolvedValue({ task, ref: "PR #99" });
@@ -285,7 +288,7 @@ describe("routeCheckEvent — via PR number", () => {
 describe("routeCheckEvent — via branch name", () => {
   it("passes head_branch to getTaskForCheckEvent for check_run", async () => {
     const w = Worker.register("worker-1", fakeWs());
-    const task = await seedTask({ task_id: "42", issue_number: 42, worker_id: "worker-1", assigned_at: new Date().toISOString() });
+    const task = await seedTask({ task_id: "42", issue_number: 42, repo_id: testRepoId, worker_id: "worker-1", assigned_at: new Date().toISOString() });
     w.assign(task);
     const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
     taskManager.getTaskForCheckEvent.mockResolvedValue({ task, ref: "branch feature-branch" });
@@ -302,7 +305,7 @@ describe("routeCheckEvent — via branch name", () => {
 
   it("passes head_branch to getTaskForCheckEvent for check_suite", async () => {
     const w = Worker.register("worker-1", fakeWs());
-    const task = await seedTask({ task_id: "42", issue_number: 42, worker_id: "worker-1", assigned_at: new Date().toISOString() });
+    const task = await seedTask({ task_id: "42", issue_number: 42, repo_id: testRepoId, worker_id: "worker-1", assigned_at: new Date().toISOString() });
     w.assign(task);
     const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
     taskManager.getTaskForCheckEvent.mockResolvedValue({ task, ref: "branch feature-branch" });
@@ -333,12 +336,12 @@ describe("routeCheckEvent — via branch name", () => {
 
 describe("routeIssueEvent — enqueue on labeled", () => {
   it("calls handleIssueLabeledEvent and returns the enqueued task", async () => {
-    const task = Task.fromTest({ task_id: "42", issue_number: 42 });
+    const task = Task.fromTest({ task_id: "42", issue_number: 42, repo_id: testRepoId });
     const { wss, forwardEvent, taskManager } = await makeDeps();
     taskManager.handleIssueLabeledEvent.mockResolvedValue(task);
     const issue = { number: 42, title: "Do something", body: "details", state: "open", labels: [{ name: "brunel:ready" }] };
     const result = await wss.routeIssueEvent(
-      { action: "labeled", label: { name: "brunel:ready" }, repository: { html_url: "https://github.com/owner/repo" } },
+      { action: "labeled", label: { name: "brunel:ready" }, repository: { full_name: "owner/repo" } },
       makeEvent("issues"),
       issue,
       42,
@@ -385,12 +388,12 @@ describe("routeIssueEvent — enqueue on labeled", () => {
 
 describe("routeIssueEvent — enqueue on opened", () => {
   it("calls handleIssueLabeledEvent when opened with the task label already attached", async () => {
-    const task = Task.fromTest({ task_id: "42", issue_number: 42 });
+    const task = Task.fromTest({ task_id: "42", issue_number: 42, repo_id: testRepoId });
     const { wss, forwardEvent, taskManager } = await makeDeps();
     taskManager.handleIssueLabeledEvent.mockResolvedValue(task);
     const issue = { number: 42, title: "Do something", body: "details", state: "open", labels: [{ name: "brunel:ready" }] };
     const result = await wss.routeIssueEvent(
-      { action: "opened", repository: { html_url: "https://github.com/owner/repo" } },
+      { action: "opened", repository: { full_name: "owner/repo" } },
       makeEvent("issues"),
       issue,
       42,
@@ -417,7 +420,7 @@ describe("routeIssueEvent — enqueue on opened", () => {
 
 describe("routeIssueEvent — unlabeled (dequeue)", () => {
   it("dequeues the task when the task label is removed", async () => {
-    await seedTask({ task_id: "42", issue_number: 42 });
+    await seedTask({ task_id: "42", issue_number: 42, repo_id: testRepoId });
     const { wss, forwardEvent, taskManager } = await makeDeps();
     const issue = { number: 42 };
     await wss.routeIssueEvent(
@@ -433,7 +436,7 @@ describe("routeIssueEvent — unlabeled (dequeue)", () => {
   });
 
   it("does not dequeue when a different label is removed", async () => {
-    await seedTask({ task_id: "42", issue_number: 42 });
+    await seedTask({ task_id: "42", issue_number: 42, repo_id: testRepoId });
     const { wss, forwardEvent, taskManager } = await makeDeps();
     const issue = { number: 42 };
     await wss.routeIssueEvent(
@@ -464,7 +467,7 @@ describe("routeIssueEvent — closed", () => {
   });
 
   it("calls forwardEvent when a tracked task exists", async () => {
-    await seedTask({ task_id: "42", issue_number: 42 });
+    await seedTask({ task_id: "42", issue_number: 42, repo_id: testRepoId });
     const { wss, forwardEvent, taskManager } = await makeDeps();
     const issue = { number: 42 };
     await wss.routeIssueEvent(
@@ -494,7 +497,7 @@ describe("routeIssueEvent — reopened", () => {
   });
 
   it("calls forwardEvent when a tracked task exists", async () => {
-    await seedTask({ task_id: "42", issue_number: 42 });
+    await seedTask({ task_id: "42", issue_number: 42, repo_id: testRepoId });
     const { wss, forwardEvent, taskManager } = await makeDeps();
     const issue = { number: 42 };
     await wss.routeIssueEvent(
@@ -510,7 +513,7 @@ describe("routeIssueEvent — reopened", () => {
 
 describe("routeIssueEvent — edited", () => {
   it("calls handleIssueBodyEditedEvent when the issue body is edited for a tracked task", async () => {
-    await seedTask({ task_id: "42", issue_number: 42 });
+    await seedTask({ task_id: "42", issue_number: 42, repo_id: testRepoId });
     const { wss, forwardEvent, taskManager } = await makeDeps();
     const issue = { number: 42, body: "updated body" };
     await wss.routeIssueEvent(
@@ -526,7 +529,7 @@ describe("routeIssueEvent — edited", () => {
   });
 
   it("does not call handleIssueBodyEditedEvent when the body was not changed", async () => {
-    await seedTask({ task_id: "42", issue_number: 42 });
+    await seedTask({ task_id: "42", issue_number: 42, repo_id: testRepoId });
     const { wss, forwardEvent, taskManager } = await makeDeps();
     const issue = { number: 42, title: "updated title" };
     await wss.routeIssueEvent(
@@ -557,7 +560,7 @@ describe("routeIssueEvent — edited", () => {
 describe("routeIssueEvent — passthrough forwarding", () => {
   it("forwards other issue events to the tracked task", async () => {
     const w = Worker.register("worker-1", fakeWs());
-    const task = await seedTask({ task_id: "42", issue_number: 42, worker_id: "worker-1", assigned_at: new Date().toISOString() });
+    const task = await seedTask({ task_id: "42", issue_number: 42, repo_id: testRepoId, worker_id: "worker-1", assigned_at: new Date().toISOString() });
     w.assign(task);
     const { wss, sendMsg, forwardEvent } = await makeDeps();
     const issue = { number: 42 };
@@ -574,7 +577,7 @@ describe("routeIssueEvent — passthrough forwarding", () => {
 
   it("routes issue_comment on a PR via getByPr fallback", async () => {
     const w = Worker.register("worker-1", fakeWs());
-    const task = await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, worker_id: "worker-1", assigned_at: new Date().toISOString() });
+    const task = await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, repo_id: testRepoId, worker_id: "worker-1", assigned_at: new Date().toISOString() });
     w.assign(task);
     const { wss, sendMsg, forwardEvent } = await makeDeps();
     const issue = { number: 99 }; // PR number in issue.number

--- a/tests/foreman.event-router.test.ts
+++ b/tests/foreman.event-router.test.ts
@@ -10,9 +10,11 @@
 import http from "http";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ForemanWss } from "../src/foreman/controllers/wss.js";
+import { TaskManager } from "../src/foreman/models/task-manager.js";
 import { Task } from "../src/foreman/models/task.js";
 import { Worker } from "../src/foreman/models/worker.js";
 import { WebhookEvent } from "../src/foreman/models/webhook-event.js";
+import { resetDb, createTestRepo } from "./helpers/task.js";
 import * as utils from "../src/utils.js";
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
@@ -25,10 +27,9 @@ function makeEvent(name = "issue_comment"): WebhookEvent {
   return WebhookEvent.fromIncoming("evt-1", name, {});
 }
 
-function makeWss(taskManager: any): { wss: ForemanWss; sendMsg: ReturnType<typeof vi.fn> } {
+function makeWss(_taskManager?: any): { wss: ForemanWss; sendMsg: ReturnType<typeof vi.fn> } {
   const wss = new ForemanWss({
     config: { taskLabel: "brunel:ready", githubRepo: "owner/repo", githubToken: "token", workerSecret: undefined, pingIntervalMs: 1e9 },
-    taskManager,
     server: http.createServer(),
   });
   const sendMsg = vi.spyOn(wss, "sendMsg").mockImplementation(() => {});
@@ -36,9 +37,15 @@ function makeWss(taskManager: any): { wss: ForemanWss; sendMsg: ReturnType<typeo
 }
 
 let logSpy: ReturnType<typeof vi.spyOn>;
+let testRepoId: number;
 
-beforeEach(() => {
+beforeEach(async () => {
   Worker._reset();
+  resetDb();
+  const repo = await createTestRepo("owner/repo");
+  testRepoId = repo.id;
+  // Ensure TaskManager is registered for this repo
+  repo.taskManager;
   logSpy = vi.spyOn(utils, "log").mockImplementation(() => {});
 });
 
@@ -164,14 +171,15 @@ describe("forwardEvent — active tasks still receive events", () => {
   });
 
   it("queues event for a pending task with no worker", () => {
-    const task = Task.fromTest({ task_id: "42", issue_number: 42 });
+    const task = Task.fromTest({ task_id: "42", issue_number: 42, repo_id: testRepoId });
     task.blockersLoaded = true; // no open blockers → status is "pending"
-    const taskManager = { queueEvent: vi.fn(), assignIdleWorkers: vi.fn().mockResolvedValue([]), on: vi.fn() };
-    const { wss, sendMsg } = makeWss(taskManager);
+    const tm = TaskManager.getByRepoId(testRepoId)!;
+    const queueSpy = vi.spyOn(tm, "queueEvent");
+    const { wss, sendMsg } = makeWss();
 
     wss.forwardEvent(task, makeEvent(), "#42");
 
-    expect(taskManager.queueEvent).toHaveBeenCalledOnce();
+    expect(queueSpy).toHaveBeenCalledOnce();
     expect(sendMsg).not.toHaveBeenCalled();
   });
 });

--- a/tests/foreman.event-router.test.ts
+++ b/tests/foreman.event-router.test.ts
@@ -173,8 +173,7 @@ describe("forwardEvent — active tasks still receive events", () => {
   it("queues event for a pending task with no worker", () => {
     const task = Task.fromTest({ task_id: "42", issue_number: 42, repo_id: testRepoId });
     task.blockersLoaded = true; // no open blockers → status is "pending"
-    const tm = TaskManager.getByRepoId(testRepoId)!;
-    const queueSpy = vi.spyOn(tm, "queueEvent");
+    const queueSpy = vi.spyOn(task.manager, "queueEvent");
     const { wss, sendMsg } = makeWss();
 
     wss.forwardEvent(task, makeEvent(), "#42");

--- a/tests/foreman.github.test.ts
+++ b/tests/foreman.github.test.ts
@@ -1,9 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { loadIssuesToQueue, fetchIssueStates, fetchNativeBlockers } from "../src/foreman/clients/github.js";
-import { TaskManager } from "../src/foreman/models/task-manager.js";
 import { Task } from "../src/foreman/models/task.js";
 import { Worker } from "../src/foreman/models/worker.js";
-import { resetDb } from "./helpers/task.js";
+import { resetDb, createTestTaskManager } from "./helpers/task.js";
 import { getConfig } from "../src/config.js";
 
 const mockIssues = [
@@ -31,8 +30,8 @@ describe("loadIssuesToQueue", () => {
       json: async () => mockIssues,
     } as any);
 
-    const taskManager = new TaskManager();
     resetDb();
+    const taskManager = await createTestTaskManager("owner/repo");
     vi.spyOn(Task, "fetchBlockers").mockResolvedValue([]);
 
     await loadIssuesToQueue(taskManager);
@@ -47,8 +46,8 @@ describe("loadIssuesToQueue", () => {
 
   it("throws on non-ok response", async () => {
     vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 403 } as any);
-    const taskManager = new TaskManager();
     resetDb();
+    const taskManager = await createTestTaskManager("owner/repo");
     await expect(loadIssuesToQueue(taskManager)).rejects.toThrow("403");
   });
 
@@ -61,8 +60,8 @@ describe("loadIssuesToQueue", () => {
       json: async () => [{ number: 1, title: "Updated title", body: "Updated body", labels: [{ name: "brunel:ready" }] }],
     } as any);
 
-    const taskManager = new TaskManager();
     resetDb();
+    const taskManager = await createTestTaskManager("owner/repo");
     vi.spyOn(Task, "fetchBlockers").mockResolvedValue([]);
 
     // Task #1 already exists and is assigned to a worker (simulates foreman restart)
@@ -163,8 +162,8 @@ describe("loadIssuesToQueue with blockers", () => {
         json: async () => ({ number: 99, state: "open" }),
       } as any);
 
-    const taskManager = new TaskManager();
     resetDb();
+    const taskManager = await createTestTaskManager("owner/repo");
     vi.spyOn(Task, "fetchBlockers").mockResolvedValueOnce([99]);
 
     await loadIssuesToQueue(taskManager);
@@ -189,8 +188,8 @@ describe("loadIssuesToQueue with blockers", () => {
 
     vi.spyOn(Task, "fetchBlockers").mockResolvedValueOnce([50]);
 
-    const taskManager = new TaskManager();
     resetDb();
+    const taskManager = await createTestTaskManager("owner/repo");
     await loadIssuesToQueue(taskManager);
 
     // Blocker 50 is closed, so isBlocked should be false

--- a/tests/foreman.hello-handlers.test.ts
+++ b/tests/foreman.hello-handlers.test.ts
@@ -11,7 +11,7 @@ import { Worker } from "../src/foreman/models/worker.js";
 import { Task } from "../src/foreman/models/task.js";
 import { TaskManager } from "../src/foreman/models/task-manager.js";
 import { ForemanMessage } from "../src/foreman/models/foreman-message.js";
-import { resetDb, seedTask } from "./helpers/task.js";
+import { resetDb, seedTask, createTestTaskManager } from "./helpers/task.js";
 import * as utils from "../src/utils.js";
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
@@ -23,7 +23,6 @@ function fakeWs() {
 function makeWss(taskManager: TaskManager) {
   const wss = new ForemanWss({
     config: { taskLabel: "brunel:ready", githubRepo: "owner/repo", githubToken: "token", workerSecret: undefined, pingIntervalMs: 1e9 },
-    taskManager,
     server: http.createServer(),
   });
   const sendMsg = vi.spyOn(wss, "sendMsg").mockImplementation(() => {});
@@ -40,10 +39,10 @@ function helloAck(sendMsg: ReturnType<typeof vi.spyOn>) {
 
 let taskManager: TaskManager;
 
-beforeEach(() => {
+beforeEach(async () => {
   Worker._reset();
   resetDb();
-  taskManager = new TaskManager();
+  taskManager = await createTestTaskManager();
 });
 
 afterEach(() => {
@@ -162,6 +161,7 @@ describe("handleBusyHello", () => {
       const task = await seedTask({
         task_id: "10",
         issue_number: 10,
+        repo_id: taskManager.repo.id,
         worker_id: "w1",
         assigned_at: new Date().toISOString(),
       });

--- a/tests/foreman.http.test.ts
+++ b/tests/foreman.http.test.ts
@@ -13,9 +13,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import http from "http";
 import type { AddressInfo } from "net";
 import { createHttpServer } from "../src/foreman/controllers/http-server.js";
-import { TaskManager } from "../src/foreman/models/task-manager.js";
 import { Task } from "../src/foreman/models/task.js";
-import { resetDb } from "./helpers/task.js";
+import { resetDb, createTestTaskManager } from "./helpers/task.js";
 
 vi.mock("../src/foreman/models/activity-log.js", () => ({
   queryActivityLog: vi.fn().mockResolvedValue([]),
@@ -187,14 +186,14 @@ describe("GET /api/tasks", () => {
   });
 
   it("returns active tasks with derived status and date fields, excluding complete", async () => {
-    const tm = new TaskManager();
     resetDb();
+    const tm = await createTestTaskManager();
 
     await Task.upsert("1", 1, "test/repo", "Pending bug", "Description", []);
     const t2 = await Task.upsert("2", 2, "test/repo", "Done bug", "Description", []);
     await t2.complete();
 
-    const s = createHttpServer({ webhooks: null, routeEvent: vi.fn(), taskManager: tm });
+    const s = createHttpServer({ webhooks: null, routeEvent: vi.fn() });
     const p = await startServer(s);
     try {
       const res = await request(p, "GET", "/api/tasks");
@@ -216,13 +215,13 @@ describe("GET /api/tasks", () => {
   });
 
   it("returns complete tasks when ?status=complete is requested", async () => {
-    const tm = new TaskManager();
     resetDb();
+    const tm = await createTestTaskManager();
 
     const t = await Task.upsert("42", 42, "test/repo", "Fix bug", "Description", []);
     await t.complete();
 
-    const s = createHttpServer({ webhooks: null, routeEvent: vi.fn(), taskManager: tm });
+    const s = createHttpServer({ webhooks: null, routeEvent: vi.fn() });
     const p = await startServer(s);
     try {
       const res = await request(p, "GET", "/api/tasks?status=complete");
@@ -237,14 +236,14 @@ describe("GET /api/tasks", () => {
   });
 
   it("filters tasks by status in memory", async () => {
-    const tm = new TaskManager();
     resetDb();
+    const tm = await createTestTaskManager();
 
     const t1 = await Task.upsert("1", 1, "test/repo", "T1", "b", []);
     await t1.complete();
     await Task.upsert("2", 2, "test/repo", "T2", "b", []);
 
-    const s = createHttpServer({ webhooks: null, routeEvent: vi.fn(), taskManager: tm });
+    const s = createHttpServer({ webhooks: null, routeEvent: vi.fn() });
     const p = await startServer(s);
     try {
       const res = await request(p, "GET", "/api/tasks?status=complete");

--- a/tests/foreman.reconcile.test.ts
+++ b/tests/foreman.reconcile.test.ts
@@ -4,7 +4,7 @@ import { Worker } from "../src/foreman/models/worker.js";
 import { ForemanWss } from "../src/foreman/controllers/wss.js";
 import { TaskManager } from "../src/foreman/models/task-manager.js";
 import { Task } from "../src/foreman/models/task.js";
-import { resetDb } from "./helpers/task.js";
+import { resetDb, createTestTaskManager } from "./helpers/task.js";
 import { loadDefaultConfig } from "../src/config.js";
 const defaultCfg = await loadDefaultConfig();
 import * as Wire from "../shared/wire.js";
@@ -18,12 +18,12 @@ function makeIssue(n: number): Wire.TaskIssue {
 let taskManager: TaskManager;
 let foremanWss: ForemanWss;
 
-beforeEach(() => {
+beforeEach(async () => {
   Worker._reset();
-  taskManager = new TaskManager();
   resetDb();
+  taskManager = await createTestTaskManager();
   const server = http.createServer();
-  foremanWss = new ForemanWss({ taskManager, server, config: { ...defaultCfg, taskLabel: TASK_LABEL } });
+  foremanWss = new ForemanWss({ server, config: { ...defaultCfg, taskLabel: TASK_LABEL } });
 });
 
 afterEach(() => {

--- a/tests/foreman.startup.test.ts
+++ b/tests/foreman.startup.test.ts
@@ -3,7 +3,7 @@ import { Worker } from "../src/foreman/models/worker.js";
 import { ForemanWss } from "../src/foreman/controllers/wss.js";
 import { TaskManager } from "../src/foreman/models/task-manager.js";
 import { Task } from "../src/foreman/models/task.js";
-import { resetDb } from "./helpers/task.js";
+import { resetDb, createTestTaskManager } from "./helpers/task.js";
 import { loadDefaultConfig } from "../src/config.js";
 
 const defaultCfg = await loadDefaultConfig();
@@ -81,11 +81,11 @@ function connect(msg: object): Promise<WebSocket> {
   return connectWorker(port, msg).then((ws) => { openClients.push(ws); return ws; });
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   Worker._reset();
   httpServer = http.createServer();
-  taskManager = new TaskManager();
   resetDb();
+  taskManager = await createTestTaskManager("owner/repo");
 });
 
 afterEach(() => {
@@ -121,7 +121,7 @@ describe("tryAssignWork — assign persistence", () => {
   it("task.assign is called and task status becomes assigned before task_assigned is sent", async () => {
     await registerReady(taskManager, "42", 42, "owner/repo", "Test task", "body", []);
 
-    ({ wss } = new ForemanWss({ taskManager, server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
+    ({ wss } = new ForemanWss({ server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
 
     port = await startServer();
     const ws = await connect({ type: "worker_hello", workerId: "w1", status: "idle" });
@@ -141,7 +141,7 @@ describe("tryAssignWork — assign persistence", () => {
     // Spy on the prototype so the mock applies to any Task instance returned from the DB
     vi.spyOn(Task.prototype, "assign").mockRejectedValue(new Error("db down"));
 
-    ({ wss } = new ForemanWss({ taskManager, server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
+    ({ wss } = new ForemanWss({ server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
 
     port = await startServer();
     const ws = await connect({ type: "worker_hello", workerId: "w1", status: "idle" });
@@ -152,7 +152,7 @@ describe("tryAssignWork — assign persistence", () => {
 
   it("works transparently with in-memory task store", async () => {
     await registerReady(taskManager, "42", 42, "owner/repo", "Test task", "body", []);
-    ({ wss } = new ForemanWss({ taskManager, server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
+    ({ wss } = new ForemanWss({ server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
 
     port = await startServer();
     const ws = await connect({ type: "worker_hello", workerId: "w1", status: "idle" });
@@ -174,7 +174,7 @@ describe("startup reconnect behaviour", () => {
     const fakeWs = { send: vi.fn(), close: vi.fn(), readyState: 1 } as any;
     await t!.assign(Worker.register("w1", fakeWs)); // simulate what main block does after startup restore
 
-    ({ wss } = new ForemanWss({ taskManager, server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
+    ({ wss } = new ForemanWss({ server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
 
     port = await startServer();
     const ws = await connect({ type: "worker_hello", workerId: "w1", status: "idle" });
@@ -192,7 +192,7 @@ describe("startup reconnect behaviour", () => {
     const fakeWs = { send: vi.fn(), close: vi.fn(), readyState: 1 } as any;
     await t!.assign(Worker.register("original-worker", fakeWs)); // simulate startup loading
 
-    ({ wss } = new ForemanWss({ taskManager, server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
+    ({ wss } = new ForemanWss({ server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
 
     port = await startServer();
     const ws = await connect({ type: "worker_hello", workerId: "new-worker", status: "idle" });
@@ -209,7 +209,7 @@ describe("startup reconnect behaviour", () => {
     const fakeWs = { send: vi.fn(), close: vi.fn(), readyState: 1 } as any;
     await t!.assign(Worker.register("w1", fakeWs));
 
-    ({ wss } = new ForemanWss({ taskManager, server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
+    ({ wss } = new ForemanWss({ server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
 
     port = await startServer();
     await connect({ type: "worker_hello", workerId: "w1", status: "busy", taskId: "42" });
@@ -230,7 +230,7 @@ describe("PR tracking persistence", () => {
     await t!.assign(Worker.register("w1", fakeWs));
     const spyRegisterPr = vi.spyOn(Task.prototype, "registerPr");
 
-    const result = new ForemanWss({ taskManager, server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } });
+    const result = new ForemanWss({ server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } });
     ({ wss } = result);
 
     await result.routeEvent("evt-1", "pull_request", {
@@ -252,7 +252,7 @@ describe("PR tracking persistence", () => {
     await t!.assign(Worker.register("w1", fakeWs));
     const spyRegisterPr = vi.spyOn(Task.prototype, "registerPr");
 
-    const result = new ForemanWss({ taskManager, server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } });
+    const result = new ForemanWss({ server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } });
     ({ wss } = result);
 
     await result.routeEvent("evt-1", "pull_request", {
@@ -299,7 +299,7 @@ async function restoreTasksFromDb(rows: Array<{
 
 describe("startup — restore tasks from tasks table (DB is source of truth)", () => {
   it("assigned task from store is visible in the snapshot", async () => {
-    ({ wss } = new ForemanWss({ taskManager, server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
+    ({ wss } = new ForemanWss({ server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
 
     port = await startServer();
 
@@ -317,7 +317,7 @@ describe("startup — restore tasks from tasks table (DB is source of truth)", (
   });
 
   it("pending task from store can be assigned by nextPending", async () => {
-    ({ wss } = new ForemanWss({ taskManager, server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
+    ({ wss } = new ForemanWss({ server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
 
     port = await startServer();
 
@@ -334,7 +334,7 @@ describe("startup — restore tasks from tasks table (DB is source of truth)", (
   });
 
   it("PR number and branch are restored from store", async () => {
-    ({ wss } = new ForemanWss({ taskManager, server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
+    ({ wss } = new ForemanWss({ server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
 
     port = await startServer();
 
@@ -350,7 +350,7 @@ describe("startup — restore tasks from tasks table (DB is source of truth)", (
   });
 
   it("complete tasks from store are skipped", async () => {
-    ({ wss } = new ForemanWss({ taskManager, server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
+    ({ wss } = new ForemanWss({ server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
 
     port = await startServer();
 
@@ -370,7 +370,7 @@ describe("startup — restore tasks from tasks table (DB is source of truth)", (
     // 2. GitHub data is loaded into labeledIssues (via loadIssuesToQueue)
     // 3. reconcile() is called to sync labeledIssues → taskQueue
     // 4. Worker connects and must receive the real body/labels in task_assigned
-    const localForemanWss = new ForemanWss({ taskManager, server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } });
+    const localForemanWss = new ForemanWss({ server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } });
     wss = localForemanWss.wss;
 
     port = await startServer();
@@ -404,7 +404,7 @@ describe("startup — restore tasks from tasks table (DB is source of truth)", (
     // 1. Task is restored from DB with worker_id set (loadActiveTasksFromDb)
     // 2. GitHub sync calls Task.upsert() again for the same task (loadIssuesFromGithub)
     // 3. reconcile() runs — MUST NOT assign the task to a different idle worker
-    const localForemanWss2 = new ForemanWss({ taskManager, server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } });
+    const localForemanWss2 = new ForemanWss({ server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } });
     wss = localForemanWss2.wss;
 
     port = await startServer();
@@ -486,7 +486,7 @@ describe("startup reconnect — worker reconnects to complete task", () => {
     w1.remove(); // deregister so waitUntil below detects the real reconnect
     await t!.complete(); // issue closed while worker was active
 
-    ({ wss } = new ForemanWss({ taskManager, server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
+    ({ wss } = new ForemanWss({ server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
 
     port = await startServer();
     await connect({ type: "worker_hello", workerId: "w1", status: "busy", taskId: "42" });
@@ -505,7 +505,7 @@ describe("startup reconnect — worker reconnects to complete task", () => {
     await t!.assign(Worker.register("w1", fakeWs));
     await t!.complete();
 
-    ({ wss } = new ForemanWss({ taskManager, server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
+    ({ wss } = new ForemanWss({ server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
 
     port = await startServer();
     const ws = await connect({ type: "worker_hello", workerId: "w1", status: "busy", taskId: "42" });
@@ -532,7 +532,7 @@ describe("task_complete marks task complete", () => {
     const fakeWs = { send: vi.fn(), close: vi.fn(), readyState: 1 } as any;
     await t!.assign(Worker.register("w1", fakeWs));
 
-    ({ wss } = new ForemanWss({ taskManager, server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
+    ({ wss } = new ForemanWss({ server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
 
     port = await startServer();
     const ws = await connect({ type: "worker_hello", workerId: "w1", status: "busy", taskId: "42" });

--- a/tests/foreman.task-manager.test.ts
+++ b/tests/foreman.task-manager.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { TaskManager } from "../src/foreman/models/task-manager.js";
 import { Task } from "../src/foreman/models/task.js";
 import { Worker } from "../src/foreman/models/worker.js";
-import { resetDb } from "./helpers/task.js";
+import { resetDb, createTestTaskManager } from "./helpers/task.js";
 
 const REPO = "test/repo";
 
@@ -13,8 +13,8 @@ describe("Task.complete", () => {
 
   beforeEach(async () => {
     Worker._reset();
-    manager = new TaskManager();
     resetDb();
+    manager = await createTestTaskManager();
     await Task.upsert("42", 42, REPO, "Fix the bug", "It is broken", ["brunel:ready"]);
     const t = await Task.get("42");
     const fakeWs = { send: vi.fn(), close: vi.fn(), readyState: 1 } as any;
@@ -44,8 +44,8 @@ describe("Task.revert", () => {
 
   beforeEach(async () => {
     Worker._reset();
-    manager = new TaskManager();
     resetDb();
+    manager = await createTestTaskManager();
     await Task.upsert("42", 42, REPO, "Fix the bug", "It is broken", ["brunel:ready"]);
     const t = await Task.get("42");
     const fakeWs = { send: vi.fn(), close: vi.fn(), readyState: 1 } as any;
@@ -293,10 +293,10 @@ describe("Task.status (derived)", () => {
 describe("TaskManager.assignIdleWorkers", () => {
   let manager: TaskManager;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     Worker._reset();
-    manager = new TaskManager();
     resetDb();
+    manager = await createTestTaskManager();
   });
 
   afterEach(() => {
@@ -393,10 +393,10 @@ describe("TaskManager.assignIdleWorkers", () => {
 describe("TaskManager.handleIssueLabeledEvent", () => {
   let manager: TaskManager;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     Worker._reset();
-    manager = new TaskManager();
     resetDb();
+    manager = await createTestTaskManager();
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ data: { repository: { issue: { blockedBy: { nodes: [] } } } } }),
@@ -435,10 +435,10 @@ describe("TaskManager.handleIssueLabeledEvent", () => {
 describe("TaskManager.handleIssueBodyEditedEvent", () => {
   let manager: TaskManager;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     Worker._reset();
-    manager = new TaskManager();
     resetDb();
+    manager = await createTestTaskManager();
     manager.setBlockers(42, [10]);
     manager.markBlockersLoaded(42);
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
@@ -474,8 +474,8 @@ describe("TaskManager.handlePrOpenedEvent", () => {
 
   beforeEach(async () => {
     Worker._reset();
-    manager = new TaskManager();
     resetDb();
+    manager = await createTestTaskManager();
     await Task.upsert("42", 42, REPO, "Fix the bug", "Body", ["brunel:ready"]);
   });
 
@@ -516,8 +516,8 @@ describe("TaskManager.handlePrClosedEvent", () => {
 
   beforeEach(async () => {
     Worker._reset();
-    manager = new TaskManager();
     resetDb();
+    manager = await createTestTaskManager();
     await Task.upsert("42", 42, REPO, "Fix the bug", "Body", ["brunel:ready"]);
     const t = await Task.get("42");
     await t!.registerPr(10, "fix-branch");
@@ -554,8 +554,8 @@ describe("TaskManager.getTaskForCheckEvent", () => {
 
   beforeEach(async () => {
     Worker._reset();
-    manager = new TaskManager();
     resetDb();
+    manager = await createTestTaskManager();
     await Task.upsert("42", 42, REPO, "Fix the bug", "Body", ["brunel:ready"]);
     const t = await Task.get("42");
     await t!.registerPr(10, "fix-branch");

--- a/tests/foreman.taskqueue.test.ts
+++ b/tests/foreman.taskqueue.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { TaskManager } from "../src/foreman/models/task-manager.js";
 import { Task } from "../src/foreman/models/task.js";
 import { Worker } from "../src/foreman/models/worker.js";
-import { resetDb } from "./helpers/task.js";
+import { resetDb, createTestTaskManager } from "./helpers/task.js";
 import { WebhookEvent } from "../src/foreman/models/webhook-event.js";
 
 const repoSlug = "test/repo";
@@ -18,9 +18,9 @@ async function registerBase(overrides: { taskId?: string; issueNumber?: number; 
 
 describe("TaskManager — queue operations", () => {
   let m: TaskManager;
-  beforeEach(() => {
+  beforeEach(async () => {
     Worker._reset();
-    m = new TaskManager();
+    m = await createTestTaskManager();
     resetDb();
   });
   afterEach(() => { vi.restoreAllMocks(); });
@@ -154,8 +154,8 @@ describe("TaskManager — queue operations", () => {
 
 describe("TaskManager — derived blocked status", () => {
   let m: TaskManager;
-  beforeEach(() => {
-    m = new TaskManager();
+  beforeEach(async () => {
+    m = await createTestTaskManager();
     resetDb();
   });
   afterEach(() => { vi.restoreAllMocks(); });
@@ -205,9 +205,9 @@ describe("TaskManager — derived blocked status", () => {
 
 describe("TaskManager — cancel (delete behavior)", () => {
   let m: TaskManager;
-  beforeEach(() => {
+  beforeEach(async () => {
     Worker._reset();
-    m = new TaskManager();
+    m = await createTestTaskManager();
     resetDb();
   });
   afterEach(() => { vi.restoreAllMocks(); });
@@ -241,8 +241,8 @@ describe("TaskManager — cancel (delete behavior)", () => {
 
 describe("TaskManager — nextPending with predicate", () => {
   let m: TaskManager;
-  beforeEach(() => {
-    m = new TaskManager();
+  beforeEach(async () => {
+    m = await createTestTaskManager();
     resetDb();
   });
   afterEach(() => { vi.restoreAllMocks(); });
@@ -270,9 +270,9 @@ describe("TaskManager — nextPending with predicate", () => {
 
 describe("TaskManager changed events", () => {
   let m: TaskManager;
-  beforeEach(() => {
+  beforeEach(async () => {
     Worker._reset();
-    m = new TaskManager();
+    m = await createTestTaskManager();
     resetDb();
   });
   afterEach(() => { vi.restoreAllMocks(); });

--- a/tests/foreman.timestamps.test.ts
+++ b/tests/foreman.timestamps.test.ts
@@ -9,7 +9,7 @@ import { Worker } from "../src/foreman/models/worker.js";
 import { ForemanWss } from "../src/foreman/controllers/wss.js";
 import { TaskManager } from "../src/foreman/models/task-manager.js";
 import { Task } from "../src/foreman/models/task.js";
-import { resetDb } from "./helpers/task.js";
+import { resetDb, createTestTaskManager } from "./helpers/task.js";
 import { loadDefaultConfig } from "../src/config.js";
 const defaultCfg = await loadDefaultConfig();
 import * as Wire from "../shared/wire.js";
@@ -81,7 +81,7 @@ function connect(): Promise<WebSocket> {
   return connectWorker(port).then((ws) => { openClients.push(ws); return ws; });
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   Worker._reset();
   vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
   process.env.GITHUB_REPO = "owner/repo";
@@ -92,10 +92,10 @@ beforeEach(() => {
     logLines.push(args.join(" "));
   });
 
-  taskManager = new TaskManager();
   resetDb();
+  taskManager = await createTestTaskManager("owner/repo");
   httpServer = http.createServer();
-  foremanWss = new ForemanWss({ taskManager, server: httpServer, config: defaultCfg });
+  foremanWss = new ForemanWss({ server: httpServer, config: defaultCfg });
   ({ wss } = foremanWss);
 
   return new Promise<void>((resolve) => {

--- a/tests/foreman.webhook-routing.test.ts
+++ b/tests/foreman.webhook-routing.test.ts
@@ -13,7 +13,7 @@ import { Worker } from "../src/foreman/models/worker.js";
 import { ForemanWss } from "../src/foreman/controllers/wss.js";
 import { TaskManager } from "../src/foreman/models/task-manager.js";
 import { Task } from "../src/foreman/models/task.js";
-import { resetDb } from "./helpers/task.js";
+import { resetDb, createTestTaskManager } from "./helpers/task.js";
 import { loadDefaultConfig } from "../src/config.js";
 const defaultCfg = await loadDefaultConfig();
 import * as Wire from "../shared/wire.js";
@@ -235,17 +235,17 @@ function connect(): Promise<WebSocket> {
   return connectWorker(port).then((ws) => { openClients.push(ws); return ws; });
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   Worker._reset();
   vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({ data: { repository: { issue: { blockedBy: { nodes: [] } } } } }) }));
   process.env.GITHUB_REPO = "owner/repo";
   process.env.GITHUB_TOKEN = "token";
   process.env.TASK_LABEL = "brunel:ready";
 
-  taskManager = new TaskManager();
   resetDb();
+  taskManager = await createTestTaskManager("owner/repo");
   httpServer = http.createServer();
-  foremanWss = new ForemanWss({ taskManager, server: httpServer, config: defaultCfg });
+  foremanWss = new ForemanWss({ server: httpServer, config: defaultCfg });
   ({ wss } = foremanWss);
 
   return new Promise<void>((resolve) => {

--- a/tests/foreman.websocket.test.ts
+++ b/tests/foreman.websocket.test.ts
@@ -7,7 +7,7 @@ import { Worker } from "../src/foreman/models/worker.js";
 import { ForemanWss } from "../src/foreman/controllers/wss.js";
 import { TaskManager } from "../src/foreman/models/task-manager.js";
 import { Task } from "../src/foreman/models/task.js";
-import { resetDb } from "./helpers/task.js";
+import { resetDb, createTestTaskManager } from "./helpers/task.js";
 import { loadDefaultConfig } from "../src/config.js";
 const defaultCfg = await loadDefaultConfig();
 import * as Wire from "../shared/wire.js";
@@ -84,12 +84,12 @@ function connect(): Promise<WebSocket> {
   return connectWorker(port).then((ws) => { openClients.push(ws); return ws; });
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   Worker._reset();
-  taskManager = new TaskManager();
   resetDb();
+  taskManager = await createTestTaskManager("owner/repo");
   httpServer = http.createServer();
-  foremanWss = new ForemanWss({ taskManager, server: httpServer, config: defaultCfg });
+  foremanWss = new ForemanWss({ server: httpServer, config: defaultCfg });
   ({ wss } = foremanWss);
 
   return new Promise<void>((resolve) => {
@@ -614,8 +614,8 @@ describe("dependency-aware task assignment", () => {
 describe("worker secret enforcement", () => {
   async function makeSecretServer(secret: string): Promise<{ server: http.Server; secretWss: WebSocketServer; port: number }> {
     const server = http.createServer();
-    const tm = new TaskManager();
-    const { wss: secretWss } = new ForemanWss({ taskManager: tm, server, config: { ...defaultCfg, workerSecret: secret } });
+    const tm = await createTestTaskManager();
+    const { wss: secretWss } = new ForemanWss({ server, config: { ...defaultCfg, workerSecret: secret } });
     const p = await new Promise<number>((r) => server.listen(0, () => r((server.address() as AddressInfo).port)));
     return { server, secretWss, port: p };
   }
@@ -655,8 +655,8 @@ describe("worker secret enforcement", () => {
 describe("worker WebSocket connection", () => {
   it("worker client connects to foreman successfully", async () => {
     const server = http.createServer();
-    const tm = new TaskManager();
-    const { wss } = new ForemanWss({ taskManager: tm, server, config: defaultCfg });
+    const tm = await createTestTaskManager();
+    const { wss } = new ForemanWss({ server, config: defaultCfg });
     const testPort = await new Promise<number>((resolve) => {
       server.listen(0, () => resolve((server.address() as AddressInfo).port));
     });
@@ -680,8 +680,8 @@ describe("worker WebSocket connection", () => {
 
   it("foreman rejects connections not at /worker path (regression guard)", async () => {
     const server = http.createServer();
-    const tm = new TaskManager();
-    const { wss } = new ForemanWss({ taskManager: tm, server, config: defaultCfg });
+    const tm = await createTestTaskManager();
+    const { wss } = new ForemanWss({ server, config: defaultCfg });
     const testPort = await new Promise<number>((resolve) => {
       server.listen(0, () => resolve((server.address() as AddressInfo).port));
     });
@@ -703,8 +703,8 @@ describe("worker disconnect DB logging", () => {
     const logSpy = vi.spyOn(ForemanMessage, "log").mockReturnValue(undefined);
 
     const server = http.createServer();
-    const localTm = new TaskManager();
-    const { wss: testWss } = new ForemanWss({ taskManager: localTm, server, config: defaultCfg });
+    const localTm = await createTestTaskManager();
+    const { wss: testWss } = new ForemanWss({ server, config: defaultCfg });
     const testPort = await new Promise<number>((r) => server.listen(0, () => r((server.address() as AddressInfo).port)));
 
     const ws = new WebSocket(`ws://localhost:${testPort}/worker`);
@@ -735,13 +735,13 @@ describe("worker disconnect DB logging", () => {
   it("includes the current taskId in the disconnect event when worker had an active task", async () => {
     const logSpy = vi.spyOn(ForemanMessage, "log").mockReturnValue(undefined);
 
-    const localTm = new TaskManager();
+    const localTm = await createTestTaskManager();
     await Task.upsert("42", 42, "owner/repo", "Some task", "Body", []);
     localTm.trackIssue(42);
     localTm.markBlockersLoaded(42);
 
     const server = http.createServer();
-    const { wss: testWss } = new ForemanWss({ taskManager: localTm, server, config: defaultCfg });
+    const { wss: testWss } = new ForemanWss({ server, config: defaultCfg });
     const testPort = await new Promise<number>((r) => server.listen(0, () => r((server.address() as AddressInfo).port)));
 
     const ws = new WebSocket(`ws://localhost:${testPort}/worker`);
@@ -1014,9 +1014,9 @@ describe("worker_hello — reclaim complete task for finalization work", () => {
 
 describe("keepalive ping", () => {
   it("sends WebSocket ping to connected clients on interval", async () => {
-    const tm = new TaskManager();
+    const tm = await createTestTaskManager();
     const srv = http.createServer();
-    const { wss: testWss } = new ForemanWss({ taskManager: tm, server: srv, config: { ...defaultCfg, pingIntervalMs: 50 } });
+    const { wss: testWss } = new ForemanWss({ server: srv, config: { ...defaultCfg, pingIntervalMs: 50 } });
     await new Promise<void>((resolve) => srv.listen(0, resolve));
     const testPort = (srv.address() as AddressInfo).port;
 
@@ -1087,8 +1087,8 @@ describe("graceful shutdown", () => {
   it("logs worker_disconnected with code 1001 when shutdown closes a registered worker", async () => {
     const logSpy = vi.spyOn(ForemanMessage, "log").mockReturnValue(undefined);
     const srv = http.createServer();
-    const localTm = new TaskManager();
-    const localForemanWss = new ForemanWss({ taskManager: localTm, server: srv, config: defaultCfg });
+    const localTm = await createTestTaskManager();
+    const localForemanWss = new ForemanWss({ server: srv, config: defaultCfg });
     const { wss: testWss } = localForemanWss;
     const testPort = await new Promise<number>((r) => srv.listen(0, () => r((srv.address() as AddressInfo).port)));
 

--- a/tests/helpers/task.ts
+++ b/tests/helpers/task.ts
@@ -1,16 +1,36 @@
 import { initDb, db } from "../../src/foreman/clients/db-client.js";
 import { createMemoryTaskDb } from "./memory-db.js";
 import { Task } from "../../src/foreman/models/task.js";
+import { Repo } from "../../src/foreman/models/repo.js";
+import { TaskManager } from "../../src/foreman/models/task-manager.js";
 import type { Database } from "../../src/database.types.js";
 
 type DbRow = Database["public"]["Tables"]["tasks"]["Row"];
 
 /**
- * Resets the in-memory DB to a fresh, empty state.
+ * Resets the in-memory DB and TaskManager registry to a fresh, empty state.
  * Call in beforeEach for per-test task isolation when using the DB shim.
  */
 export function resetDb(): void {
   initDb(createMemoryTaskDb());
+  TaskManager._resetRegistry();
+}
+
+/**
+ * Creates (or finds) a Repo in the in-memory DB. Useful for test setup
+ * when you need a Repo instance to create a TaskManager.
+ */
+export async function createTestRepo(fullName = "test/repo"): Promise<Repo> {
+  return Repo.findOrCreate(fullName);
+}
+
+/**
+ * Creates a per-repo TaskManager backed by a test Repo from the in-memory DB.
+ * Shorthand for `(await createTestRepo(fullName)).taskManager`.
+ */
+export async function createTestTaskManager(fullName = "test/repo"): Promise<TaskManager> {
+  const repo = await createTestRepo(fullName);
+  return repo.taskManager;
 }
 
 /**

--- a/tests/pipeline.test.ts
+++ b/tests/pipeline.test.ts
@@ -25,6 +25,7 @@ import { Task } from "../src/foreman/models/task.js";
 import { initDb } from "../src/foreman/clients/db-client.js";
 import { loadDefaultConfig } from "../src/config.js";
 import { createTestSupabase } from "./helpers/db.js";
+import { createTestTaskManager } from "./helpers/task.js";
 
 // ── One-time setup ────────────────────────────────────────────────────────────
 
@@ -201,7 +202,7 @@ function stubFetchNoBlockers() {
  * Builds a foreman + HTTP server pair.  Returns a cleanup function.
  * The caller is responsible for closing any open WebSocket clients first.
  */
-function buildForeman(): {
+async function buildForeman(): Promise<{
   taskModel: TaskManager;
   httpServer: http.Server;
   foremanWss: ForemanWss;
@@ -210,13 +211,13 @@ function buildForeman(): {
   openClients: WebSocket[];
   connect: () => Promise<WebSocket>;
   teardown: () => Promise<void>;
-} {
+}> {
   Worker._reset();
-  const taskModel = new TaskManager();
+  const taskModel = await createTestTaskManager("owner/repo");
   const httpServer = http.createServer();
   const openClients: WebSocket[] = [];
 
-  const foremanWss = new ForemanWss({ taskManager: taskModel, server: httpServer, config: {
+  const foremanWss = new ForemanWss({ server: httpServer, config: {
     ...defaultCfg,
     githubRepo: "owner/repo",
     githubToken: "token",
@@ -272,7 +273,7 @@ function buildForeman(): {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("pipeline: happy path and queued-then-assigned", () => {
-  let foreman: ReturnType<typeof buildForeman>;
+  let foreman: Awaited<ReturnType<typeof buildForeman>>;
 
   beforeEach(async () => {
     stubFetchNoBlockers();
@@ -283,7 +284,7 @@ describe("pipeline: happy path and queued-then-assigned", () => {
       supabase.from("foreman_messages").delete().in("task_id", ["42", "55"]),
       supabase.from("webhook_events").delete().in("task_id", ["42", "55"]),
     ]);
-    foreman = buildForeman();
+    foreman = await buildForeman();
     await new Promise<void>((resolve) =>
       foreman.httpServer.once("listening", resolve),
     );
@@ -372,7 +373,7 @@ describe("pipeline: happy path and queued-then-assigned", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("pipeline: worker disconnect/reclaim", () => {
-  let foreman: ReturnType<typeof buildForeman>;
+  let foreman: Awaited<ReturnType<typeof buildForeman>>;
 
   beforeEach(async () => {
     stubFetchNoBlockers();
@@ -383,7 +384,7 @@ describe("pipeline: worker disconnect/reclaim", () => {
       supabase.from("foreman_messages").delete().in("task_id", ["70"]),
       supabase.from("webhook_events").delete().in("task_id", ["70"]),
     ]);
-    foreman = buildForeman();
+    foreman = await buildForeman();
     await new Promise<void>((resolve) =>
       foreman.httpServer.once("listening", resolve),
     );
@@ -447,7 +448,7 @@ describe("pipeline: worker disconnect/reclaim", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("pipeline: dependency blocking", () => {
-  let foreman: ReturnType<typeof buildForeman>;
+  let foreman: Awaited<ReturnType<typeof buildForeman>>;
 
   beforeEach(async () => {
     // Stub fetch: native blocker query returns empty; issue-state query for #91 returns open.
@@ -476,7 +477,7 @@ describe("pipeline: dependency blocking", () => {
       supabase.from("foreman_messages").delete().in("task_id", ["91", "92"]),
       supabase.from("webhook_events").delete().in("task_id", ["91", "92"]),
     ]);
-    foreman = buildForeman();
+    foreman = await buildForeman();
     await new Promise<void>((resolve) =>
       foreman.httpServer.once("listening", resolve),
     );
@@ -532,7 +533,7 @@ describe("pipeline: dependency blocking", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("pipeline: PR events forwarded and logged to DB", () => {
-  let foreman: ReturnType<typeof buildForeman>;
+  let foreman: Awaited<ReturnType<typeof buildForeman>>;
 
   beforeEach(async () => {
     stubFetchNoBlockers();
@@ -543,7 +544,7 @@ describe("pipeline: PR events forwarded and logged to DB", () => {
       supabase.from("webhook_events").delete().in("delivery_id", ["evt-1", "evt-pr", "evt-cr"]),
       supabase.from("foreman_messages").delete().eq("worker_id", "w-pr"),
     ]);
-    foreman = buildForeman();
+    foreman = await buildForeman();
     await new Promise<void>((resolve) =>
       foreman.httpServer.once("listening", resolve),
     );


### PR DESCRIPTION
## Summary

- Replaces the singleton `TaskManager` with one instance per repo, managed via a static `Map<repoId, TaskManager>` registry and `TaskManager.forRepo(repo)` find-or-create factory
- Adds `Repo.taskManager` convenience getter; removes `taskManager` parameter from `ForemanWss` and `HttpServer` constructors
- Introduces static `TaskManager.events` emitter that aggregates instance events for cross-repo subscribers (admin broadcast, assignment)
- Updates all 20+ test files to use new `createTestTaskManager()` / `createTestRepo()` helpers

## Test plan

- [x] All 1370 non-DB unit tests pass
- [x] Type check passes (`npx tsc --noEmit`)
- [ ] CI passes (lint, tests, type check, browser tests)
- [ ] Manual smoke test: foreman starts, workers connect, tasks are assigned and completed

Closes #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)