### PR TITLE
Fix MaxListenersExceededWarning from TaskManager constructor

### DIFF
--- a/src/foreman/models/task-manager.ts
+++ b/src/foreman/models/task-manager.ts
@@ -58,6 +58,9 @@ export class TaskManager extends EventEmitter {
 
   /** Reset the registry — for tests only. */
   static _resetRegistry(): void {
+    for (const tm of TaskManager.registry.values()) {
+      Task.events.off("changed", tm._onTaskChanged);
+    }
     TaskManager.registry.clear();
     TaskManager.events.removeAllListeners();
   }
@@ -80,13 +83,15 @@ export class TaskManager extends EventEmitter {
   private _blockers: Map<number, number[]>;
   private _blockersLoaded: Set<number>;
 
+  private _onTaskChanged = () => this.emit("changed");
+
   constructor(repo: Repo) {
     super();
     this.repo = repo;
     this._openIssues = new Set();
     this._blockers = new Map();
     this._blockersLoaded = new Set();
-    Task.events.on("changed", () => this.emit("changed"));
+    Task.events.on("changed", this._onTaskChanged);
     // Forward instance events to static aggregator
     this.on("changed", () => TaskManager.events.emit("changed"));
     this.on("deps_loaded", () => TaskManager.events.emit("deps_loaded", this));

--- a/tests/dependencies.test.ts
+++ b/tests/dependencies.test.ts
@@ -62,8 +62,8 @@ describe("TaskManager — setBlockers / isBlocked", () => {
   let tm: TaskManager;
 
   beforeEach(async () => {
-    tm = await createTestTaskManager();
     resetDb();
+    tm = await createTestTaskManager();
   });
 
   afterEach(() => {

--- a/tests/foreman.task-manager.test.ts
+++ b/tests/foreman.task-manager.test.ts
@@ -615,3 +615,21 @@ describe("Task.toAssignmentPayload", () => {
     });
   });
 });
+
+describe("TaskManager listener cleanup", () => {
+  beforeEach(() => {
+    resetDb();
+  });
+
+  it("removes Task.events listeners when registry is reset", async () => {
+    const before = Task.events.listenerCount("changed");
+    // Create several TaskManagers to add listeners
+    for (let i = 0; i < 15; i++) {
+      await createTestTaskManager(`test/repo-${i}`);
+    }
+    expect(Task.events.listenerCount("changed")).toBe(before + 15);
+
+    resetDb();
+    expect(Task.events.listenerCount("changed")).toBe(0);
+  });
+});

--- a/tests/foreman.taskqueue.test.ts
+++ b/tests/foreman.taskqueue.test.ts
@@ -20,8 +20,8 @@ describe("TaskManager — queue operations", () => {
   let m: TaskManager;
   beforeEach(async () => {
     Worker._reset();
-    m = await createTestTaskManager();
     resetDb();
+    m = await createTestTaskManager();
   });
   afterEach(() => { vi.restoreAllMocks(); });
 
@@ -155,8 +155,8 @@ describe("TaskManager — queue operations", () => {
 describe("TaskManager — derived blocked status", () => {
   let m: TaskManager;
   beforeEach(async () => {
-    m = await createTestTaskManager();
     resetDb();
+    m = await createTestTaskManager();
   });
   afterEach(() => { vi.restoreAllMocks(); });
 
@@ -207,8 +207,8 @@ describe("TaskManager — cancel (delete behavior)", () => {
   let m: TaskManager;
   beforeEach(async () => {
     Worker._reset();
-    m = await createTestTaskManager();
     resetDb();
+    m = await createTestTaskManager();
   });
   afterEach(() => { vi.restoreAllMocks(); });
 
@@ -242,8 +242,8 @@ describe("TaskManager — cancel (delete behavior)", () => {
 describe("TaskManager — nextPending with predicate", () => {
   let m: TaskManager;
   beforeEach(async () => {
-    m = await createTestTaskManager();
     resetDb();
+    m = await createTestTaskManager();
   });
   afterEach(() => { vi.restoreAllMocks(); });
 
@@ -272,8 +272,8 @@ describe("TaskManager changed events", () => {
   let m: TaskManager;
   beforeEach(async () => {
     Worker._reset();
-    m = await createTestTaskManager();
     resetDb();
+    m = await createTestTaskManager();
   });
   afterEach(() => { vi.restoreAllMocks(); });
 


### PR DESCRIPTION
## Summary

- Store the per-instance `Task.events` listener as a named property (`_onTaskChanged`) so `_resetRegistry()` can remove it before clearing the registry
- Fix `beforeEach` ordering in tests that called `createTestTaskManager()` before `resetDb()` — the old order worked by accident when `_resetRegistry()` didn't clean up `Task.events` listeners

## Test plan

- [x] New test verifies listener count returns to 0 after `resetDb()` even when 15+ TaskManagers were created
- [x] All existing tests pass (1371/1371)
- [x] TypeScript compiles clean
- [x] ESLint passes

Closes #806

🤖 Generated with [Claude Code](https://claude.com/claude-code)