### PR TITLE
fix: call claude-sdk-fix-libc.sh with the .sh extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
     "CLAUDE_CODE_OAUTH_TOKEN": "${localEnv:CLAUDE_CODE_OAUTH_TOKEN}"
   },
   "forwardPorts": [3000, 5173],
-  "postCreateCommand": "npm ci && claude-sdk-fix-libc",
+  "postCreateCommand": "npm ci && claude-sdk-fix-libc.sh",
   "postStartCommand": "while true; do sleep 3600; sudo /usr/local/bin/init-firewall.sh; done &",
   "waitFor": "postStartCommand"
 }


### PR DESCRIPTION
The helper installed by devcontainer-claude is `/usr/local/bin/claude-sdk-fix-libc.sh` (preserves `.sh` from the source filename). PR #808 dropped the extension and `postCreateCommand` failed at rebuild with:

```
/bin/sh: 1: claude-sdk-fix-libc: not found
```

One-char fix: add `.sh` back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)