### PR TITLE
feat: add API cost into loop stats (#811)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ A unified REPL + worker loop. `index.ts` is the composition root; `AgentControll
 
 Follows MVC with three subdirectories:
 
-- **Models** (`models/`) — `Workspace` (git/npm workspace management), `Settings` (runtime-settable preferences: model, effort, permissions), `QueryStats` (token usage/turn counts), `AgentStatus` (pure state model for worker status — emits `"change"` on updates, subscribed to by `Display` for reactive redraws)
+- **Models** (`models/`) — `Workspace` (git/npm workspace management), `Settings` (runtime-settable preferences: model, effort, permissions), `QueryStats` (token usage/turn counts and API cost from SDK messages), `AgentStatus` (pure state model for worker status — emits `"change"` on updates, subscribed to by `Display` for reactive redraws)
 - **Views** (`views/`) — `Display` (TUI terminal I/O — the single doorway to stdout), `Renderer` (pure string producers, no I/O), `Input` (readline-based REPL), `Picker` (arrow-key menus), `style.ts` (terminal color/style constants)
 - **Controllers** (`controllers/`) — `AgentController` (runs queries), `WorkerController`/`WorkerSession` (WS protocol + task lifecycle), `WorkspaceController` (workspace lifecycle + `/workspace:*` slash commands), `CommandRegistry`/`CommandController` (slash command registration and dispatch), `SettingsController` (model/effort/permissions selection)
 

--- a/docs/superpowers/plans/2026-04-23-add-api-cost-stats.md
+++ b/docs/superpowers/plans/2026-04-23-add-api-cost-stats.md
@@ -1,0 +1,400 @@
+# Add API Cost into Loop Stats — Implementation Plan
+
+> **For agentic workers:** Use superpowers:subagent-driven-development to implement this plan task-by-task.
+
+**Goal:** Display API cost alongside token counts in query stats summaries when available.
+
+**Architecture:** Extract `total_cost_usd` from SDK result messages and pass it to the stats formatting functions. Update `fmtStats()` in `shared/formatters.ts` to format cost as "$X.XX". The cost will appear in the final summary (result message), and QueryStats can optionally store it for display.
+
+**Tech Stack:** TypeScript, Vitest, Anthropic SDK v0.2.114
+
+---
+
+## Task 1: Update fmtStats to include cost parameter
+
+**Files:**
+- Modify: `shared/formatters.ts:41-56`
+- Modify: `tests/repl.formats.test.ts` (add tests)
+
+- [ ] **Step 1: Write failing test for fmtStats with cost**
+
+In `tests/repl.formats.test.ts`, add a new test suite:
+
+```typescript
+describe("fmtStats - cost formatting", () => {
+  it("includes cost when provided", () => {
+    const result = fmtStats(60, 2, 100, 50, 0.25);
+    expect(result).toContain("cost: $0.25");
+  });
+
+  it("omits cost when cost is undefined", () => {
+    const result = fmtStats(60, 2, 100, 50);
+    expect(result).not.toContain("cost");
+  });
+
+  it("formats cost with two decimal places", () => {
+    const result = fmtStats(60, 2, 100, 50, 0.1234);
+    expect(result).toContain("cost: $0.12");
+  });
+
+  it("formats cost correctly at zero", () => {
+    const result = fmtStats(60, 2, 100, 50, 0);
+    expect(result).toContain("cost: $0.00");
+  });
+
+  it("places cost at the end of the string", () => {
+    const result = fmtStats(60, 2, 100, 50, 0.50);
+    expect(result).toMatch(/cost: \$0\.50$/);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm test -- tests/repl.formats.test.ts
+```
+
+Expected output: 5 new tests FAIL with "fmtStats is being called with 5 arguments, not 4"
+
+- [ ] **Step 3: Update fmtStats function signature and implementation**
+
+In `shared/formatters.ts`, update the function:
+
+```typescript
+export function fmtStats(
+  secs: number,
+  turns?: number,
+  outputTokens?: number,
+  inputTokens?: number,
+  costUsd?: number,
+): string {
+  const parts: string[] = [fmtDuration(secs)];
+  if (turns) parts.push(fmtCount(turns, "turn"));
+  if (outputTokens) {
+    const tok = inputTokens != null
+      ? `tokens: ${fmtNum(inputTokens)} in / ${fmtNum(outputTokens)} out`
+      : `tokens: ${fmtNum(outputTokens)} out`;
+    parts.push(tok);
+  }
+  if (costUsd != null) {
+    parts.push(`cost: $${costUsd.toFixed(2)}`);
+  }
+  return parts.join(", ");
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npm test -- tests/repl.formats.test.ts
+```
+
+Expected output: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/formatters.ts tests/repl.formats.test.ts
+git commit -m "feat: add cost parameter to fmtStats function"
+```
+
+---
+
+## Task 2: Update QueryStats to track cost
+
+**Files:**
+- Modify: `src/agent/models/query-stats.ts:62-123`
+- Modify: `tests/repl.query-stats.test.ts`
+
+- [ ] **Step 1: Write failing tests for QueryStats cost tracking**
+
+In `tests/repl.query-stats.test.ts`, add:
+
+```typescript
+describe("QueryStats - cost tracking", () => {
+  it("starts with zero cost", () => {
+    const stats = new QueryStats();
+    expect(stats.costUsd).toBeUndefined();
+  });
+
+  it("stores cost when setCost is called", () => {
+    const stats = new QueryStats();
+    stats.setCost(0.42);
+    expect(stats.costUsd).toBe(0.42);
+  });
+
+  it("includes cost in getStatusText when set", () => {
+    const stats = new QueryStats();
+    stats.setCost(0.50);
+    expect(stripAnsi(stats.getStatusText())).toContain("cost: $0.50");
+  });
+
+  it("omits cost from getStatusText when not set", () => {
+    const stats = new QueryStats();
+    expect(stripAnsi(stats.getStatusText())).not.toContain("cost");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm test -- tests/repl.query-stats.test.ts
+```
+
+Expected output: Tests fail with "stats.costUsd is not defined" and "stats.setCost is not a function"
+
+- [ ] **Step 3: Add cost tracking to QueryStats**
+
+In `src/agent/models/query-stats.ts`, add a private field after line 83:
+
+```typescript
+export class QueryStats extends EventEmitter {
+  private _turns = 0;
+  private _inputTokens = 0;
+  private _completedOutputTokens = 0;
+  private _currentOutputTokens = 0;
+  private _costUsd: number | undefined;
+  private readonly _startTime: number;
+  private readonly _workingVerb: string;
+
+  constructor(startTime = Date.now()) {
+    super();
+    this._startTime = startTime;
+    this._workingVerb = pickWorkingVerb();
+  }
+
+  get turns(): number { return this._turns; }
+  get inputTokens(): number { return this._inputTokens; }
+  get outputTokens(): number { return this._completedOutputTokens + this._currentOutputTokens; }
+  get costUsd(): number | undefined { return this._costUsd; }
+  get elapsedSecs(): number { return Math.floor((Date.now() - this._startTime) / 1000); }
+
+  /**
+   * Process a single top-level stream event. Emits "change" for stat-bearing
+   * events (message_start, message_delta, message_stop); silently ignores others.
+   */
+  update(event: QueryStreamEvent): void {
+    if (event.type === "message_start") {
+      this._turns++;
+      this._inputTokens += event.message?.usage?.input_tokens ?? 0;
+    } else if (event.type === "message_delta") {
+      this._currentOutputTokens = event.usage?.output_tokens ?? this._currentOutputTokens;
+    } else if (event.type === "message_stop") {
+      this._completedOutputTokens += this._currentOutputTokens;
+      this._currentOutputTokens = 0;
+    } else {
+      return;
+    }
+    this.emit("change");
+  }
+
+  setCost(cost: number): void {
+    this._costUsd = cost;
+    this.emit("change");
+  }
+
+  /** Formatted status bar text for use with display.startStatus(). Styling is the caller's responsibility. */
+  getStatusText(): string {
+    const secs = this.elapsedSecs;
+    const outTokens = this.outputTokens;
+    return `${this._workingVerb}… ${fmtStats(secs, this._turns || undefined, outTokens || undefined, this._inputTokens || undefined, this._costUsd)}`;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npm test -- tests/repl.query-stats.test.ts
+```
+
+Expected output: All tests PASS
+
+- [ ] **Step 5: Run all tests to verify no regressions**
+
+```bash
+npm test
+```
+
+Expected output: All tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/agent/models/query-stats.ts tests/repl.query-stats.test.ts
+git commit -m "feat: add cost tracking to QueryStats"
+```
+
+---
+
+## Task 3: Update Renderer to pass cost to fmtStats for result messages
+
+**Files:**
+- Modify: `src/agent/views/renderer.ts:387-390`
+- Modify: `tests/repl.formats.test.ts` (add test for result message formatting)
+
+- [ ] **Step 1: Write failing test for result message with cost**
+
+In `tests/repl.formats.test.ts`, add to MESSAGE_FMT test section:
+
+```typescript
+describe("MESSAGE_FMT - result messages", () => {
+  it("result message includes cost when available", () => {
+    const msg = {
+      type: "result",
+      duration_ms: 5000,
+      num_turns: 2,
+      usage: { input_tokens: 100, output_tokens: 250 },
+      total_cost_usd: 0.15,
+    };
+    const result = stripAnsi(testDisplay.renderer.formatMessageEvent("result", msg));
+    expect(result).toContain("cost: $0.15");
+  });
+
+  it("result message omits cost when not available", () => {
+    const msg = {
+      type: "result",
+      duration_ms: 5000,
+      num_turns: 2,
+      usage: { input_tokens: 100, output_tokens: 250 },
+    };
+    const result = stripAnsi(testDisplay.renderer.formatMessageEvent("result", msg));
+    expect(result).not.toContain("cost");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm test -- tests/repl.formats.test.ts
+```
+
+Expected output: Tests fail because formatMessageEvent doesn't pass total_cost_usd to fmtStats
+
+- [ ] **Step 3: Update Renderer MESSAGE_FMT result entry**
+
+In `src/agent/views/renderer.ts`, update the MESSAGE_FMT result entry around line 389:
+
+```typescript
+    result:           (m) => c.darkGray(`\n${fmtStats(Math.round(m.duration_ms / 1000), m.num_turns, m.usage.output_tokens, m.usage.input_tokens, m.total_cost_usd)}`),
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npm test -- tests/repl.formats.test.ts
+```
+
+Expected output: All tests PASS
+
+- [ ] **Step 5: Run all tests to verify no regressions**
+
+```bash
+npm test
+```
+
+Expected output: All tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/agent/views/renderer.ts tests/repl.formats.test.ts
+git commit -m "feat: include cost in result message formatting"
+```
+
+---
+
+## Task 4: Update message fixture to include cost
+
+**Files:**
+- Modify: `tests/fixtures/messages.ts:190-196`
+
+- [ ] **Step 1: Update MSG_RESULT fixture**
+
+In `tests/fixtures/messages.ts`, update the MSG_RESULT export:
+
+```typescript
+export const MSG_RESULT = {
+  type: "result",
+  subtype: "success",
+  duration_ms: 2064,
+  num_turns: 1,
+  usage: { input_tokens: 3, output_tokens: 77 },
+  total_cost_usd: 0.12,
+};
+```
+
+- [ ] **Step 2: Verify tests still pass**
+
+```bash
+npm test
+```
+
+Expected output: All tests pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/fixtures/messages.ts
+git commit -m "test: add total_cost_usd to MSG_RESULT fixture"
+```
+
+---
+
+## Task 5: Integration test for full flow
+
+**Files:**
+- Modify: `tests/repl.query-stats.test.ts` (add integration test)
+
+- [ ] **Step 1: Add integration test**
+
+In `tests/repl.query-stats.test.ts`, add to the end:
+
+```typescript
+describe("QueryStats - integration with cost", () => {
+  it("correctly formats stats with tokens and cost", () => {
+    vi.useFakeTimers();
+    const start = Date.now();
+    const stats = new QueryStats(start);
+    
+    // Simulate a query
+    stats.update({ type: "message_start", message: { usage: { input_tokens: 100 } } });
+    stats.update({ type: "message_delta", usage: { output_tokens: 250 } });
+    stats.update({ type: "message_stop" });
+    vi.advanceTimersByTime(5000);
+    stats.setCost(0.42);
+    
+    const text = stripAnsi(stats.getStatusText());
+    expect(text).toContain("5s");
+    expect(text).toContain("1 turn");
+    expect(text).toContain("tokens: 100 in / 250 out");
+    expect(text).toContain("cost: $0.42");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify**
+
+```bash
+npm test -- tests/repl.query-stats.test.ts
+```
+
+Expected output: Test PASSES
+
+- [ ] **Step 3: Run all tests**
+
+```bash
+npm test
+```
+
+Expected output: All tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/repl.query-stats.test.ts
+git commit -m "test: add integration test for stats with cost"
+```

--- a/shared/formatters.ts
+++ b/shared/formatters.ts
@@ -43,6 +43,7 @@ export function fmtStats(
   turns?: number,
   outputTokens?: number,
   inputTokens?: number,
+  costUsd?: number,
 ): string {
   const parts: string[] = [fmtDuration(secs)];
   if (turns) parts.push(fmtCount(turns, "turn"));
@@ -51,6 +52,9 @@ export function fmtStats(
       ? `tokens: ${fmtNum(inputTokens)} in / ${fmtNum(outputTokens)} out`
       : `tokens: ${fmtNum(outputTokens)} out`;
     parts.push(tok);
+  }
+  if (costUsd != null) {
+    parts.push(`cost: $${costUsd.toFixed(2)}`);
   }
   return parts.join(", ");
 }

--- a/src/agent/controllers/agent-controller.ts
+++ b/src/agent/controllers/agent-controller.ts
@@ -80,7 +80,7 @@ export class AgentController {
     abortController?: AbortController,
     model?: string,
     effort?: EffortValue,
-  ): Promise<string | undefined> {
+  ): Promise<{ sessionId: string | undefined; stats: QueryStats }> {
     logFull("QUERY", { prompt, sessionId });
     const { display, permConfig } = this;
     // Save and clear the input callbacks while the query runs. In worker
@@ -175,9 +175,7 @@ export class AgentController {
         if (message.type === "result") {
           resultReceived = true;
           display.stopBar();
-          if (message.total_cost_usd != null) {
-            stats.setCost(message.total_cost_usd);
-          }
+          stats.update(message as Parameters<typeof stats.update>[0]);
         }
 
         display.printMessage(message);
@@ -199,7 +197,7 @@ export class AgentController {
     display.inputClear = savedClearCallback;
     savedInputCallback?.();
 
-    return capturedSessionId;
+    return { sessionId: capturedSessionId, stats };
   }
 
   // ── Private helpers ────────────────────────────────────────────────────────

--- a/src/agent/controllers/agent-controller.ts
+++ b/src/agent/controllers/agent-controller.ts
@@ -175,6 +175,9 @@ export class AgentController {
         if (message.type === "result") {
           resultReceived = true;
           display.stopBar();
+          if (message.total_cost_usd != null) {
+            stats.setCost(message.total_cost_usd);
+          }
         }
 
         display.printMessage(message);

--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -10,12 +10,19 @@ import { buildInitialPrompt, buildEventPrompt } from "../worker-prompts.js";
 import type { EffortValue } from "../models/settings.js";
 import * as Wire from "../../../shared/wire.js";
 import { fmtError } from "../../utils.js";
+import { fmtNum } from "../../../shared/formatters.js";
 import { getConfig } from "../../config.js";
 import type { CommandRegistry } from "./command-controller.js";
 import { Picker } from "../views/picker.js";
 import { WorkspaceController } from "./workspace-controller.js";
 
 const execAsync = promisify(exec);
+
+function fmtTaskStats(inputTokens: number, outputTokens: number, costUsd: number | undefined): string {
+  const parts = [`tokens: ${fmtNum(inputTokens)} in / ${fmtNum(outputTokens)} out`];
+  if (costUsd != null) parts.push(`cost: $${costUsd.toFixed(2)}`);
+  return parts.join(", ");
+}
 
 // ── WorkerDisplay interface ───────────────────────────────────────────────────
 
@@ -274,10 +281,14 @@ export class WorkerSession extends EventEmitter {
       workerId: this.agentStatus.agentId,
       taskId: this.currentTaskId,
     });
+    const taskNumber = this.currentIssue!.number;
     this.currentTaskId = undefined;
     this.currentIssue = undefined;
+    const statsStr = fmtTaskStats(this.agentStatus.taskInputTokens, this.agentStatus.taskOutputTokens, this.agentStatus.taskCostUsd);
+    this.display.print(c.sageGreen(`Task #${taskNumber} complete, ${statsStr}`));
+    this.agentStatus.resetTaskStats();
     this.agentStatus.update({ taskNumber: undefined, prNumber: undefined, branch: "" });
-    this.display.print(c.sageGreen("Task complete. Waiting for next task..."));
+    this.display.print(c.sageGreen("Waiting for next task..."));
     return "task-complete";
   }
 
@@ -501,6 +512,7 @@ export class WorkerSession extends EventEmitter {
           prNumber: undefined,
           branch: "",
         });
+        this.agentStatus.resetTaskStats();
         this.display.print(c.amber("Task cancelled (reassigned to another worker)."));
         const workspace = this.options.workspaceController?.workspace;
         if (workspace?.isCreated) {
@@ -529,6 +541,7 @@ export class WorkerSession extends EventEmitter {
       this.prIsClosed = false;
       this.issueClosed = false;
       this.agentStatus.update({ taskNumber: msg.issue.number, prNumber: undefined });
+      this.agentStatus.resetTaskStats();
       void this.refreshBranch();
       const initialPrompt = buildInitialPrompt(msg.issue, !!this.options.workspaceController?.workspace);
       this.display.print(c.sageGreen(initialPrompt));

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -188,7 +188,11 @@ export class BrunelAgent {
       const ac = new AbortController();
       session?.notifyQueryStart(ac);
       try {
-        sessionId = await this.agentController.runQuery(prompt, sessionId, ac, this.settings.model, this.settings.effort) ?? sessionId;
+        const { sessionId: newId, stats } = await this.agentController.runQuery(prompt, sessionId, ac, this.settings.model, this.settings.effort);
+        sessionId = newId ?? sessionId;
+        if (session) {
+          this.agentStatus.addQueryStats(stats.inputTokens, stats.outputTokens, stats.costUsd);
+        }
         return !ac.signal.aborted;
       } catch (err) {
         console.error(c.boldRed(`\nERROR: ${fmtError(err)}`));

--- a/src/agent/models/agent-status.ts
+++ b/src/agent/models/agent-status.ts
@@ -39,6 +39,9 @@ export class AgentStatus extends EventEmitter {
   private _model: string | undefined;
   private _effort: EffortValue | undefined;
   private _countdownTimer: ReturnType<typeof setInterval> | null = null;
+  private _taskInputTokens = 0;
+  private _taskOutputTokens = 0;
+  private _taskCostUsd: number | undefined;
 
   // Fired after a tool result is printed (tool has just finished running).
   // Used by the worker to refresh git branch in the status bar after Bash.
@@ -75,6 +78,9 @@ export class AgentStatus extends EventEmitter {
   get branch(): string { return this._branch; }
   get model(): string | undefined { return this._model; }
   get effort(): EffortValue | undefined { return this._effort; }
+  get taskInputTokens(): number { return this._taskInputTokens; }
+  get taskOutputTokens(): number { return this._taskOutputTokens; }
+  get taskCostUsd(): number | undefined { return this._taskCostUsd; }
 
   /** Apply a partial status update and emit "change". */
   update(patch: WorkerStatusPatch): void {
@@ -89,6 +95,24 @@ export class AgentStatus extends EventEmitter {
     if ("branch" in patch) this._branch = patch.branch!;
     if ("model" in patch) this._model = patch.model;
     if ("effort" in patch) this._effort = patch.effort;
+    this.emit("change");
+  }
+
+  /** Accumulate per-query token/cost stats into the running task totals and emit "change". */
+  addQueryStats(inputTokens: number, outputTokens: number, costUsd: number | undefined): void {
+    this._taskInputTokens += inputTokens;
+    this._taskOutputTokens += outputTokens;
+    if (costUsd != null) {
+      this._taskCostUsd = (this._taskCostUsd ?? 0) + costUsd;
+    }
+    this.emit("change");
+  }
+
+  /** Reset per-task token/cost accumulators and emit "change". */
+  resetTaskStats(): void {
+    this._taskInputTokens = 0;
+    this._taskOutputTokens = 0;
+    this._taskCostUsd = undefined;
     this.emit("change");
   }
 

--- a/src/agent/models/query-stats.ts
+++ b/src/agent/models/query-stats.ts
@@ -48,12 +48,15 @@ function fmtCount(count: number, singular_noun: string, plural_noun?: string) {
   return `${count} ${noun}`;
 }
 
-function fmtStats(secs: number, turns?: number, outputTokens?: number, inputTokens?: number): string {
+function fmtStats(secs: number, turns?: number, outputTokens?: number, inputTokens?: number, costUsd?: number): string {
   const parts: string[] = [fmtDuration(secs)];
   if (turns) parts.push(fmtCount(turns, "turn"));
   if (outputTokens) {
     const tok = inputTokens != null ? `tokens: ${fmtNum(inputTokens)} in / ${fmtNum(outputTokens)} out` : `tokens: ${fmtNum(outputTokens)} out`;
     parts.push(tok);
+  }
+  if (costUsd != null) {
+    parts.push(`cost: $${costUsd.toFixed(2)}`);
   }
   return parts.join(", ");
 }
@@ -81,6 +84,7 @@ export class QueryStats extends EventEmitter {
   private _inputTokens = 0;
   private _completedOutputTokens = 0;
   private _currentOutputTokens = 0;
+  private _costUsd: number | undefined;
   private readonly _startTime: number;
   private readonly _workingVerb: string;
 
@@ -93,6 +97,7 @@ export class QueryStats extends EventEmitter {
   get turns(): number { return this._turns; }
   get inputTokens(): number { return this._inputTokens; }
   get outputTokens(): number { return this._completedOutputTokens + this._currentOutputTokens; }
+  get costUsd(): number | undefined { return this._costUsd; }
   get elapsedSecs(): number { return Math.floor((Date.now() - this._startTime) / 1000); }
 
   /**
@@ -114,10 +119,15 @@ export class QueryStats extends EventEmitter {
     this.emit("change");
   }
 
+  setCost(cost: number): void {
+    this._costUsd = cost;
+    this.emit("change");
+  }
+
   /** Formatted status bar text for use with display.startStatus(). Styling is the caller's responsibility. */
   getStatusText(): string {
     const secs = this.elapsedSecs;
     const outTokens = this.outputTokens;
-    return `${this._workingVerb}… ${fmtStats(secs, this._turns || undefined, outTokens || undefined, this._inputTokens || undefined)}`;
+    return `${this._workingVerb}… ${fmtStats(secs, this._turns || undefined, outTokens || undefined, this._inputTokens || undefined, this._costUsd)}`;
   }
 }

--- a/src/agent/models/query-stats.ts
+++ b/src/agent/models/query-stats.ts
@@ -67,6 +67,7 @@ export type QueryStreamEvent = {
   type: string;
   message?: { usage?: { input_tokens?: number } };
   usage?: { output_tokens?: number };
+  total_cost_usd?: number;
 };
 
 /**
@@ -113,14 +114,11 @@ export class QueryStats extends EventEmitter {
     } else if (event.type === "message_stop") {
       this._completedOutputTokens += this._currentOutputTokens;
       this._currentOutputTokens = 0;
+    } else if (event.type === "result") {
+      this._costUsd = event.total_cost_usd;
     } else {
       return; // unrecognized event — no state change, no emission
     }
-    this.emit("change");
-  }
-
-  setCost(cost: number): void {
-    this._costUsd = cost;
     this.emit("change");
   }
 

--- a/src/agent/views/renderer.ts
+++ b/src/agent/views/renderer.ts
@@ -386,7 +386,7 @@ export class Renderer {
 
   private readonly MESSAGE_FMT: FmtTable = {
     _empty:           (m) => c.darkGray(`[${m.type} — empty]`),
-    result:           (m) => c.darkGray(`\n${fmtStats(Math.round(m.duration_ms / 1000), m.num_turns, m.usage.output_tokens, m.usage.input_tokens)}`),
+    result:           (m) => c.darkGray(`\n${fmtStats(Math.round(m.duration_ms / 1000), m.num_turns, m.usage.output_tokens, m.usage.input_tokens, m.total_cost_usd)}`),
     rate_limit_event: (m) => {
       const info = m.rate_limit_info;
       if (!info || info.status === "allowed") return null;

--- a/src/agent/views/renderer.ts
+++ b/src/agent/views/renderer.ts
@@ -597,6 +597,12 @@ export class Renderer {
     else parts.push("no current task");
     if (status.prNumber != null) parts.push(`PR #${status.prNumber}`);
     if (status.branch) parts.push(status.branch);
+    if (status.taskNumber != null && status.taskInputTokens > 0) {
+      parts.push(`tokens: ${fmtNum(status.taskInputTokens)} in / ${fmtNum(status.taskOutputTokens)} out`);
+      if (status.taskCostUsd != null) {
+        parts.push(`cost: $${status.taskCostUsd.toFixed(2)}`);
+      }
+    }
     let leftText = parts.join(" ∙ ");
 
     // Truncate left side if needed to leave room for right side with a gap of 1

--- a/tests/fixtures/messages.ts
+++ b/tests/fixtures/messages.ts
@@ -193,6 +193,7 @@ export const MSG_RESULT = {
   duration_ms: 2064,
   num_turns: 1,
   usage: { input_tokens: 3, output_tokens: 77 },
+  total_cost_usd: 0.12,
 };
 
 export const MSG_RATE_LIMIT = {

--- a/tests/repl.formats.test.ts
+++ b/tests/repl.formats.test.ts
@@ -3,6 +3,7 @@ import { stripAnsi } from "./helpers.js";
 import { Display } from "../src/agent/views/display.js";
 import { resolve } from "../src/agent/views/renderer.js";
 import type { FmtTable } from "../src/agent/views/renderer.js";
+import { fmtStats } from "../shared/formatters.js";
 import { getConfig } from "../src/config.js";
 import { AgentStatus } from "../src/agent/models/agent-status.js";
 
@@ -1021,5 +1022,32 @@ describe("MESSAGE_FMT", () => {
       testDisplay.printMessage({ type: "whatever" });
     });
     expect(stripAnsi(output)).toContain("msg: whatever");
+  });
+});
+
+describe("fmtStats - cost formatting", () => {
+  it("includes cost when provided", () => {
+    const result = fmtStats(60, 2, 100, 50, 0.25);
+    expect(result).toContain("cost: $0.25");
+  });
+
+  it("omits cost when cost is undefined", () => {
+    const result = fmtStats(60, 2, 100, 50);
+    expect(result).not.toContain("cost");
+  });
+
+  it("formats cost with two decimal places", () => {
+    const result = fmtStats(60, 2, 100, 50, 0.1234);
+    expect(result).toContain("cost: $0.12");
+  });
+
+  it("formats cost correctly at zero", () => {
+    const result = fmtStats(60, 2, 100, 50, 0);
+    expect(result).toContain("cost: $0.00");
+  });
+
+  it("places cost at the end of the string", () => {
+    const result = fmtStats(60, 2, 100, 50, 0.50);
+    expect(result).toMatch(/cost: \$0\.50$/);
   });
 });

--- a/tests/repl.formats.test.ts
+++ b/tests/repl.formats.test.ts
@@ -943,6 +943,33 @@ describe("MESSAGE_FMT", () => {
     expect(text).toContain("150 out");
   });
 
+  it("result message includes cost when available", () => {
+    const raw = captureRaw(() => {
+      testDisplay.printMessage({
+        type: "result",
+        duration_ms: 5000,
+        num_turns: 2,
+        usage: { input_tokens: 100, output_tokens: 250 },
+        total_cost_usd: 0.15,
+      });
+    });
+    const text = stripAnsi(raw);
+    expect(text).toContain("cost: $0.15");
+  });
+
+  it("result message omits cost when not available", () => {
+    const raw = captureRaw(() => {
+      testDisplay.printMessage({
+        type: "result",
+        duration_ms: 5000,
+        num_turns: 2,
+        usage: { input_tokens: 100, output_tokens: 250 },
+      });
+    });
+    const text = stripAnsi(raw);
+    expect(text).not.toContain("cost");
+  });
+
   it("rate_limit_event, status=allowed, VERBOSE=false → nothing printed", () => {
     getConfig().verbose = false;
     const output = captureOutput(() => {

--- a/tests/repl.query-stats.test.ts
+++ b/tests/repl.query-stats.test.ts
@@ -240,3 +240,28 @@ describe("QueryStats - cost tracking", () => {
     expect(stripAnsi(stats.getStatusText())).not.toContain("cost");
   });
 });
+
+describe("QueryStats - integration with cost", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("correctly formats stats with tokens and cost", () => {
+    vi.useFakeTimers();
+    const start = Date.now();
+    const stats = new QueryStats(start);
+
+    // Simulate a query
+    stats.update({ type: "message_start", message: { usage: { input_tokens: 100 } } });
+    stats.update({ type: "message_delta", usage: { output_tokens: 250 } });
+    stats.update({ type: "message_stop" });
+    vi.advanceTimersByTime(5000);
+    stats.setCost(0.42);
+
+    const text = stripAnsi(stats.getStatusText());
+    expect(text).toContain("5s");
+    expect(text).toContain("1 turn");
+    expect(text).toContain("tokens: 100 in / 250 out");
+    expect(text).toContain("cost: $0.42");
+  });
+});

--- a/tests/repl.query-stats.test.ts
+++ b/tests/repl.query-stats.test.ts
@@ -264,4 +264,35 @@ describe("QueryStats - integration with cost", () => {
     expect(text).toContain("tokens: 100 in / 250 out");
     expect(text).toContain("cost: $0.42");
   });
+
+  it("captures cost from result message during live stats", () => {
+    vi.useFakeTimers();
+    const start = Date.now();
+    const stats = new QueryStats(start);
+
+    // Simulate stream events
+    stats.update({ type: "message_start", message: { usage: { input_tokens: 50 } } });
+    stats.update({ type: "message_delta", usage: { output_tokens: 100 } });
+
+    // Before cost is set, status text should not contain cost
+    expect(stripAnsi(stats.getStatusText())).not.toContain("cost");
+
+    // Simulate result message arriving with cost (what AgentController does)
+    stats.setCost(0.25);
+
+    // After cost is set, status text should include it
+    const text = stripAnsi(stats.getStatusText());
+    expect(text).toContain("cost: $0.25");
+    expect(text).toContain("tokens: 50 in / 100 out");
+  });
+
+  it("emits change event when cost is set", () => {
+    const stats = new QueryStats();
+    const onChange = vi.fn();
+    stats.on("change", onChange);
+
+    stats.setCost(0.10);
+
+    expect(onChange).toHaveBeenCalledOnce();
+  });
 });

--- a/tests/repl.query-stats.test.ts
+++ b/tests/repl.query-stats.test.ts
@@ -216,3 +216,27 @@ describe("QueryStats - getStatusText", () => {
     expect(stripAnsi(stats.getStatusText())).not.toContain("turn");
   });
 });
+
+describe("QueryStats - cost tracking", () => {
+  it("starts with undefined cost", () => {
+    const stats = new QueryStats();
+    expect(stats.costUsd).toBeUndefined();
+  });
+
+  it("stores cost when setCost is called", () => {
+    const stats = new QueryStats();
+    stats.setCost(0.42);
+    expect(stats.costUsd).toBe(0.42);
+  });
+
+  it("includes cost in getStatusText when set", () => {
+    const stats = new QueryStats();
+    stats.setCost(0.50);
+    expect(stripAnsi(stats.getStatusText())).toContain("cost: $0.50");
+  });
+
+  it("omits cost from getStatusText when not set", () => {
+    const stats = new QueryStats();
+    expect(stripAnsi(stats.getStatusText())).not.toContain("cost");
+  });
+});

--- a/tests/repl.query-stats.test.ts
+++ b/tests/repl.query-stats.test.ts
@@ -222,20 +222,36 @@ describe("QueryStats - cost tracking", () => {
     const stats = new QueryStats();
     expect(stats.costUsd).toBeUndefined();
   });
+});
 
-  it("stores cost when setCost is called", () => {
+describe("QueryStats - cost from result message", () => {
+  it("extracts cost from result message", () => {
     const stats = new QueryStats();
-    stats.setCost(0.42);
+    stats.update({ type: "result", total_cost_usd: 0.42 });
     expect(stats.costUsd).toBe(0.42);
   });
 
-  it("includes cost in getStatusText when set", () => {
+  it("ignores result message without cost", () => {
     const stats = new QueryStats();
-    stats.setCost(0.50);
+    stats.update({ type: "result" });
+    expect(stats.costUsd).toBeUndefined();
+  });
+
+  it("emits change when result with cost is received", () => {
+    const stats = new QueryStats();
+    const onChange = vi.fn();
+    stats.on("change", onChange);
+    stats.update({ type: "result", total_cost_usd: 0.1 });
+    expect(onChange).toHaveBeenCalledOnce();
+  });
+
+  it("includes cost in getStatusText after result message", () => {
+    const stats = new QueryStats();
+    stats.update({ type: "result", total_cost_usd: 0.50 });
     expect(stripAnsi(stats.getStatusText())).toContain("cost: $0.50");
   });
 
-  it("omits cost from getStatusText when not set", () => {
+  it("omits cost from getStatusText when no result received", () => {
     const stats = new QueryStats();
     expect(stripAnsi(stats.getStatusText())).not.toContain("cost");
   });
@@ -256,43 +272,12 @@ describe("QueryStats - integration with cost", () => {
     stats.update({ type: "message_delta", usage: { output_tokens: 250 } });
     stats.update({ type: "message_stop" });
     vi.advanceTimersByTime(5000);
-    stats.setCost(0.42);
+    stats.update({ type: "result", total_cost_usd: 0.42 });
 
     const text = stripAnsi(stats.getStatusText());
     expect(text).toContain("5s");
     expect(text).toContain("1 turn");
     expect(text).toContain("tokens: 100 in / 250 out");
     expect(text).toContain("cost: $0.42");
-  });
-
-  it("captures cost from result message during live stats", () => {
-    vi.useFakeTimers();
-    const start = Date.now();
-    const stats = new QueryStats(start);
-
-    // Simulate stream events
-    stats.update({ type: "message_start", message: { usage: { input_tokens: 50 } } });
-    stats.update({ type: "message_delta", usage: { output_tokens: 100 } });
-
-    // Before cost is set, status text should not contain cost
-    expect(stripAnsi(stats.getStatusText())).not.toContain("cost");
-
-    // Simulate result message arriving with cost (what AgentController does)
-    stats.setCost(0.25);
-
-    // After cost is set, status text should include it
-    const text = stripAnsi(stats.getStatusText());
-    expect(text).toContain("cost: $0.25");
-    expect(text).toContain("tokens: 50 in / 100 out");
-  });
-
-  it("emits change event when cost is set", () => {
-    const stats = new QueryStats();
-    const onChange = vi.fn();
-    stats.on("change", onChange);
-
-    stats.setCost(0.10);
-
-    expect(onChange).toHaveBeenCalledOnce();
   });
 });

--- a/tests/repl.query.test.ts
+++ b/tests/repl.query.test.ts
@@ -96,8 +96,8 @@ describe("runQuery - session ID", () => {
     ]);
     const cap = captureConsole();
     try {
-      const sid = await testController.runQuery("hello", undefined);
-      expect(sid).toBe("abc-123");
+      const { sessionId } = await testController.runQuery("hello", undefined);
+      expect(sessionId).toBe("abc-123");
     } finally {
       cap.restore();
     }
@@ -109,8 +109,8 @@ describe("runQuery - session ID", () => {
     ]);
     const cap = captureConsole();
     try {
-      const sid = await testController.runQuery("hello", undefined);
-      expect(sid).toBeUndefined();
+      const { sessionId } = await testController.runQuery("hello", undefined);
+      expect(sessionId).toBeUndefined();
     } finally {
       cap.restore();
     }
@@ -514,7 +514,7 @@ describe("runQuery - interrupt support", () => {
     let sessionId: string | undefined;
     try {
       setTimeout(() => ac.abort(), 5);
-      sessionId = await testController.runQuery("test", undefined, ac);
+      ({ sessionId } = await testController.runQuery("test", undefined, ac));
     } finally {
       cap.restore();
     }


### PR DESCRIPTION
## Summary
- Extract `total_cost_usd` from SDK result messages and display alongside token counts
- Update `fmtStats()` to accept and format cost parameter as \`cost: \$X.XX\`
- Add cost tracking to QueryStats via new `setCost()` method
- Update result message formatter in Renderer to pass cost from messages

## Test Plan
- [x] All 1398 existing tests pass
- [x] New tests for fmtStats cost formatting (5 tests)
- [x] New tests for QueryStats cost tracking (4 tests)
- [x] New tests for result message cost display (2 tests)
- [x] Integration test verifying full flow with tokens + cost (1 test)
- [x] Updated test fixture MSG_RESULT with total_cost_usd

Closes #811