### PR TITLE
fix: /model sonnet pins Sonnet instead of falling back to SDK default

### DIFF
--- a/src/agent/controllers/settings-controller.ts
+++ b/src/agent/controllers/settings-controller.ts
@@ -36,7 +36,7 @@ export class SettingsController {
 
     // Direct set: /model <alias-or-id>
     if (args) {
-      if (args === "default" || args === "sonnet") {
+      if (args === "default") {
         this.display.print(c.darkGray("Model set to default."));
         this.settings._setModel(undefined);
         return;
@@ -76,23 +76,13 @@ export class SettingsController {
       options.push(`${m.displayName}${desc}`);
       if (m.value === this.settings.model) currentIdx = i;
     }
-    // If model is undefined (default), mark the first entry as current
-    if (this.settings.model === undefined) currentIdx = 0;
 
     this.display.print(c.yellow("\nSelect model:"));
     const result = await pickFn(options, currentIdx);
 
     if (result.type !== "selected") return;
 
-    // Selected a model from the list
     const chosen = models[result.index];
-    if (result.index === 0 && this.settings.model === undefined) return; // already on default, no-op
-    // Selecting the first (default/recommended) entry resets to undefined
-    if (result.index === 0) {
-      this.display.print(c.darkGray(`Model set to ${chosen.displayName}.`));
-      this.settings._setModel(undefined);
-      return;
-    }
     this.display.print(c.darkGray(`Model set to ${chosen.displayName}.`));
     this.settings._setModel(chosen.value);
   }

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -201,12 +201,14 @@ describe("pickModel <arg> (direct set)", () => {
     expect(printed.join("")).toContain("default");
   });
 
-  it("'sonnet' maps to default", async () => {
+  it("'sonnet' is stored as-is, not silently mapped to default", async () => {
     const s = new Settings({ model: "opus" });
     s.setCachedModels(MODELS);
     await makeCtrl(s).pickModel("sonnet", noopPick, undefined);
-    expect(s.model).toBeUndefined();
-    expect(printed.join("")).toContain("default");
+    expect(s.model).toBe("sonnet");
+    const output = printed.join("");
+    expect(output).toMatch(/warning|unknown/i);
+    expect(output).toContain("sonnet");
   });
 
   it("accepts value as-is when no cache", async () => {
@@ -234,13 +236,13 @@ describe("pickModel (interactive picker)", () => {
     expect(printed.join("")).toContain("No model list available");
   });
 
-  it("selecting first entry resets to undefined (default)", async () => {
+  it("selecting first entry stores that entry's literal value", async () => {
     const pickFn = vi.fn<(options: string[], currentIdx: number) => Promise<PickResult>>()
       .mockResolvedValue({ type: "selected", index: 0 });
     const s = new Settings({ model: "opus" });
     s.setCachedModels(MODELS);
     await makeCtrl(s).pickModel("", pickFn, undefined);
-    expect(s.model).toBeUndefined();
+    expect(s.model).toBe(MODELS[0].value); // "default" stored literally, not undefined
   });
 
   it("selecting a named model sets the model", async () => {
@@ -262,13 +264,13 @@ describe("pickModel (interactive picker)", () => {
     expect(pickFn.mock.calls[0][1]).toBe(1);
   });
 
-  it("passes currentIdx 0 when no model set (default)", async () => {
+  it("passes currentIdx -1 when no model set (nothing pre-selected)", async () => {
     const pickFn = vi.fn<(options: string[], currentIdx: number) => Promise<PickResult>>()
       .mockResolvedValue({ type: "cancelled" });
     const s = new Settings();
     s.setCachedModels(MODELS);
     await makeCtrl(s).pickModel("", pickFn, undefined);
-    expect(pickFn.mock.calls[0][1]).toBe(0);
+    expect(pickFn.mock.calls[0][1]).toBe(-1);
   });
 
   it("shows model descriptions in options", async () => {


### PR DESCRIPTION
## Summary

- Removes `"sonnet"` from the `"default" || "sonnet"` special case in `SettingsController.pickModel`. `/model sonnet` now stores `"sonnet"` like any other alias, rather than `undefined` which fell through to the SDK's current default.
- Removes the `result.index === 0` special case in the interactive picker that assumed position 0 always meant "reset to undefined". All picker entries now store their literal `value`, so the user gets exactly what they selected.
- Updates the `currentIdx` logic: when no model is set (`undefined`), the picker shows nothing pre-selected (`-1`) instead of incorrectly highlighting the first entry.

## Test plan

- [x] New test: `'sonnet' is stored as-is, not silently mapped to default` — fails before fix, passes after
- [x] New test: `selecting first entry stores that entry's literal value` — fails before fix, passes after
- [x] New test: `passes currentIdx -1 when no model set (nothing pre-selected)` — fails before fix, passes after
- [x] All 1386 existing tests still pass
- [x] TypeScript type check clean

Closes #817

🤖 Generated with [Claude Code](https://claude.com/claude-code)