### PR TITLE
fix: erase to end of screen on resize to prevent ghost characters

### DIFF
--- a/src/agent/views/display.ts
+++ b/src/agent/views/display.ts
@@ -311,6 +311,12 @@ export class Display {
   private _handleResize(): void {
     if (!this.persistentActive && !this.active) return;
     this.clearBar();
+    // Erase from cursor (blank separator row) to end of screen. When the terminal
+    // becomes narrower, the old wider status bar wraps into extra visual rows that
+    // clearBar() (which only clears n logical rows) leaves behind as garbage.
+    if (!this.inputPrint && !this.inputStatus) {
+      process.stdout.write("\x1b[J");
+    }
     if (this._getText) this._text = this._getText();
     this._persistentText = this.renderer.fmtStatusBar(this.agentStatus, (this.getColumns() ?? W) - 1);
     this.drawBar();

--- a/tests/display.worker-status.test.ts
+++ b/tests/display.worker-status.test.ts
@@ -337,6 +337,21 @@ describe("Display persistent status bar", () => {
     expect(writes.join("")).toContain("Connected");
   });
 
+  it("emits erase-to-end-of-screen on resize to clean up wrapped content", () => {
+    // When the terminal is made narrower, the old wider status bar wraps into
+    // extra visual rows that clearBar() (which only clears n logical rows) would
+    // leave as garbage. The resize handler must emit \x1b[J (erase from cursor
+    // to end of screen) to clear those wrapped rows before redrawing.
+    agentStatus.update({ connectionStatus: "connected" });
+    display.startPersistentBar();
+    stdoutWrite.mockClear();
+
+    display.getColumns = () => 30;
+    process.stdout.emit("resize");
+    const combined = stdoutWrite.mock.calls.map(a => String(a[0])).join("");
+    expect(combined).toContain("\x1b[J");
+  });
+
   it("does not register multiple resize listeners on repeated startPersistentBar calls", () => {
     display.startPersistentBar();
     display.startPersistentBar(); // second call should not add a second listener


### PR DESCRIPTION
## Summary

- On terminal width resize, the old wider status bar content could wrap into extra visual rows below the new narrower status bar
- `clearBar()` only clears `n` logical rows (1 for persistent bar only), leaving wrapped content as garbage — appearing as orphaned 'd' characters (the last char of 'Connected') in green
- Added `\x1b[J` (erase from cursor to end of screen) in `_handleResize()` after `clearBar()` to sweep up any wrapped rows before redrawing

## Test plan
- [ ] New test: `emits erase-to-end-of-screen on resize to clean up wrapped content` verifies `\x1b[J` is written during resize
- [ ] All existing tests pass (34/34 in display.worker-status.test.ts)
- [ ] Manual: run a worker, resize terminal narrower, confirm no stray characters below status bar

Closes #821

🤖 Generated with [Claude Code](https://claude.com/claude-code)