### PR TITLE
fix: pare back workspace logging (#812)

### DIFF
--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -31,6 +31,7 @@ function fmtTaskStats(inputTokens: number, outputTokens: number, costUsd: number
  * Satisfied structurally by Display; tests can pass lightweight stubs.
  */
 export interface WorkerDisplay {
+  verbose: boolean;
   print(line: string | null): void;
   printForemanMessage(msg: Wire.ForemanMessage): void;
 }

--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -31,7 +31,6 @@ function fmtTaskStats(inputTokens: number, outputTokens: number, costUsd: number
  * Satisfied structurally by Display; tests can pass lightweight stubs.
  */
 export interface WorkerDisplay {
-  verbose: boolean;
   print(line: string | null): void;
   printForemanMessage(msg: Wire.ForemanMessage): void;
 }

--- a/src/agent/controllers/workspace-controller.ts
+++ b/src/agent/controllers/workspace-controller.ts
@@ -17,6 +17,7 @@ export class WorkspaceController {
   constructor(
     readonly workspace: Workspace | undefined,
     private display: WorkerDisplay,
+    private config: { verbose: boolean },
   ) {}
 
   /**
@@ -83,7 +84,6 @@ export class WorkspaceController {
         if (removed.length === 0) {
           display.print(c.sageGreen("Nothing to prune."));
         } else {
-          for (const dir of removed) display.print(c.darkGray(`  Removed: ${dir}`));
           display.print(c.sageGreen(`Pruned ${removed.length} orphaned workspace(s).`));
         }
       },
@@ -99,29 +99,36 @@ export class WorkspaceController {
     const { workspace, display } = this;
     if (!workspace) return;
 
+    const verbose = this.config.verbose;
+
+    workspace.on("create-start", () => {
+      if (!verbose) display.print(c.sageGreen("Creating workspace..."));
+    });
     workspace.on("clone-start", ({ repoUrl: url, dir }: { repoUrl: string; dir: string }) => {
-      if (display.verbose) display.print(c.sageGreen(`Cloning ${url} → ${dir}`));
+      if (verbose) display.print(c.sageGreen(`Cloning ${url} → ${dir}`));
     });
     workspace.on("npm-install", ({ dir }: { dir: string }) => {
-      if (display.verbose) display.print(c.sageGreen(`Installing dependencies in ${dir}`));
+      if (verbose) display.print(c.sageGreen(`Installing dependencies in ${dir}`));
     });
     workspace.on("reset-start", ({ dir }: { dir: string }) => {
-      display.print(c.sageGreen(display.verbose ? `Resetting ${dir}` : "Resetting workspace..."));
+      display.print(c.sageGreen(verbose ? `Resetting ${dir}` : "Resetting workspace..."));
     });
     workspace.on("reset-retry", ({ error }: { dir: string; error: string }) => {
       display.print(c.amber(`Reset failed, retrying: ${error}`));
     });
-    workspace.on("reset-reclone", ({ error }: { dir: string; error: string; repoUrl: string }) => {
-      display.print(c.amber(`Reset failed again, re-cloning: ${error}`));
+    workspace.on("reset-reclone", ({ dir, error }: { dir: string; error: string; repoUrl: string }) => {
+      display.print(c.amber(verbose ? `Reset failed again, re-cloning ${dir}: ${error}` : `Reset failed again, re-cloning: ${error}`));
     });
     workspace.on("destroy", ({ dir }: { dir: string }) => {
-      display.print(c.sageGreen(display.verbose ? `Destroying ${dir}` : "Destroying workspace..."));
+      display.print(c.sageGreen(verbose ? `Destroying ${dir}` : "Destroying workspace..."));
     });
     workspace.on("prune-start", ({ workspaceDir: dir }: { workspaceDir: string }) => {
-      display.print(c.sageGreen(display.verbose ? `Pruning orphaned workspaces in ${dir}` : "Pruning orphaned workspaces..."));
+      display.print(c.sageGreen(verbose ? `Pruning orphaned workspaces in ${dir}` : "Pruning orphaned workspaces..."));
+    });
+    workspace.on("prune-remove", ({ dir }: { dir: string }) => {
+      display.print(c.darkGray(`  Removed: ${dir}`));
     });
 
-    display.print(c.sageGreen("Creating workspace..."));
     await workspace.create();
     process.chdir(workspace.dir);
   }

--- a/src/agent/controllers/workspace-controller.ts
+++ b/src/agent/controllers/workspace-controller.ts
@@ -100,31 +100,28 @@ export class WorkspaceController {
     if (!workspace) return;
 
     workspace.on("clone-start", ({ repoUrl: url, dir }: { repoUrl: string; dir: string }) => {
-      display.print(c.sageGreen(`[workspace] Cloning ${url} → ${dir}`));
+      if (display.verbose) display.print(c.sageGreen(`Cloning ${url} → ${dir}`));
     });
     workspace.on("npm-install", ({ dir }: { dir: string }) => {
-      display.print(c.sageGreen(`[workspace] Installing dependencies in ${dir}`));
+      if (display.verbose) display.print(c.sageGreen(`Installing dependencies in ${dir}`));
     });
     workspace.on("reset-start", ({ dir }: { dir: string }) => {
-      display.print(c.sageGreen(`[workspace] Resetting ${dir}`));
+      display.print(c.sageGreen(display.verbose ? `Resetting ${dir}` : "Resetting workspace..."));
     });
     workspace.on("reset-retry", ({ error }: { dir: string; error: string }) => {
-      display.print(c.amber(`[workspace] Reset failed, retrying: ${error}`));
+      display.print(c.amber(`Reset failed, retrying: ${error}`));
     });
-    workspace.on("reset-reclone", ({ repoUrl: url, dir, error }: { dir: string; error: string; repoUrl: string }) => {
-      display.print(c.amber(`[workspace] Reset failed again, re-cloning: ${error}`));
-      display.print(c.sageGreen(`[workspace] Re-cloning ${url} → ${dir}`));
+    workspace.on("reset-reclone", ({ error }: { dir: string; error: string; repoUrl: string }) => {
+      display.print(c.amber(`Reset failed again, re-cloning: ${error}`));
     });
     workspace.on("destroy", ({ dir }: { dir: string }) => {
-      display.print(c.sageGreen(`[workspace] Destroying ${dir}`));
+      display.print(c.sageGreen(display.verbose ? `Destroying ${dir}` : "Destroying workspace..."));
     });
     workspace.on("prune-start", ({ workspaceDir: dir }: { workspaceDir: string }) => {
-      display.print(c.sageGreen(`[workspace] Pruning orphaned workspaces in ${dir}`));
-    });
-    workspace.on("prune-remove", ({ dir }: { dir: string }) => {
-      display.print(c.sageGreen(`[workspace] Removing orphaned workspace ${dir}`));
+      display.print(c.sageGreen(display.verbose ? `Pruning orphaned workspaces in ${dir}` : "Pruning orphaned workspaces..."));
     });
 
+    display.print(c.sageGreen("Creating workspace..."));
     await workspace.create();
     process.chdir(workspace.dir);
   }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -74,7 +74,7 @@ export class BrunelAgent {
     const workspace = workspaceCfg
       ? new Workspace(workspaceCfg.workspaceDir, this.agentStatus.agentId, workspaceCfg.repoUrl, originalCwd, confirm)
       : undefined;
-    this.workspaceController = new WorkspaceController(workspace, this.display);
+    this.workspaceController = new WorkspaceController(workspace, this.display, config);
 
     this.fetchModelsFn = createFetchModelsFn(this.permConfig);
     this.settingsController = new SettingsController(this.settings, this.display);

--- a/src/agent/models/workspace.ts
+++ b/src/agent/models/workspace.ts
@@ -57,6 +57,7 @@ export class Workspace extends EventEmitter {
     fs.mkdirSync(path.dirname(this.dir), { recursive: true });
     if (!fs.existsSync(path.join(this.dir, ".git"))) {
       if (fs.existsSync(this.dir)) fs.rmSync(this.dir, { recursive: true, force: true });
+      this.emit("create-start", { dir: this.dir });
       this.emit("clone-start", { repoUrl: this.repoUrl, dir: this.dir });
       await this.exec(["clone", this.repoUrl, this.dir], undefined);
       await this._npmInstall();

--- a/tests/repl.workspace.test.ts
+++ b/tests/repl.workspace.test.ts
@@ -15,10 +15,12 @@ const SESSION_ID = "test-session-uuid";
 const REPO_URL = "https://x@github.com/owner/repo.git";
 const ORIGINAL_CWD = "/original";
 
-let testDisplay: { verbose: boolean; print: ReturnType<typeof vi.fn>; printForemanMessage: ReturnType<typeof vi.fn> };
+let testDisplay: { print: ReturnType<typeof vi.fn>; printForemanMessage: ReturnType<typeof vi.fn> };
+let testConfig: { verbose: boolean };
 
 beforeEach(() => {
-  testDisplay = { verbose: false, print: vi.fn(), printForemanMessage: vi.fn() };
+  testDisplay = { print: vi.fn(), printForemanMessage: vi.fn() };
+  testConfig = { verbose: false };
   vi.spyOn(process, "chdir").mockImplementation(() => undefined);
 });
 
@@ -42,7 +44,7 @@ function makeWorkspace(confirm = vi.fn().mockResolvedValue(true)): Workspace {
 function makeAndRegister(workspace: Workspace | undefined): void {
   const reg = new CommandRegistry();
   registry = new CommandController(reg);
-  new WorkspaceController(workspace, testDisplay).registerCommands(reg.scoped("workspace"));
+  new WorkspaceController(workspace, testDisplay, testConfig).registerCommands(reg.scoped("workspace"));
 }
 
 // ── workspace:create ──────────────────────────────────────────────────────────
@@ -153,13 +155,24 @@ describe("workspace:remove", () => {
 // ── onCreate ─────────────────────────────────────────────────────────────────
 
 describe("WorkspaceController.onCreate", () => {
-  it("prints 'Creating workspace...' and chdirs to workspace dir", async () => {
+  it("prints 'Creating workspace...' via create-start event and chdirs to workspace dir", async () => {
     const ws = makeWorkspace();
-    await new WorkspaceController(ws, testDisplay).onCreate();
+    vi.spyOn(ws, "create").mockImplementation(async () => {
+      ws.emit("create-start", { dir: ws.dir });
+      ws.isCreated = true;
+    });
+    await new WorkspaceController(ws, testDisplay, testConfig).onCreate();
     expect(ws.create).toHaveBeenCalledOnce();
     expect(process.chdir).toHaveBeenCalledWith(ws.dir);
     const printed = testDisplay.print.mock.calls.map(([l]: [string]) => stripAnsi(l)).join("\n");
     expect(printed).toContain("Creating workspace...");
+  });
+
+  it("does not print 'Creating workspace...' when create-start is not emitted (workspace already exists)", async () => {
+    const ws = makeWorkspace(); // mock does not emit create-start
+    await new WorkspaceController(ws, testDisplay, testConfig).onCreate();
+    const printed = testDisplay.print.mock.calls.map(([l]: [string]) => stripAnsi(l)).join("\n");
+    expect(printed).not.toContain("Creating workspace...");
   });
 
   it("does not print clone URL or dir in non-verbose mode", async () => {
@@ -168,7 +181,7 @@ describe("WorkspaceController.onCreate", () => {
       ws.emit("clone-start", { repoUrl: REPO_URL, dir: ws.dir });
       ws.isCreated = true;
     });
-    await new WorkspaceController(ws, testDisplay).onCreate();
+    await new WorkspaceController(ws, testDisplay, testConfig).onCreate();
     const printed = testDisplay.print.mock.calls.map(([l]: [string]) => stripAnsi(l)).join("\n");
     expect(printed).not.toContain("Cloning");
     expect(printed).not.toContain(REPO_URL);
@@ -180,8 +193,8 @@ describe("WorkspaceController.onCreate", () => {
       ws.emit("clone-start", { repoUrl: REPO_URL, dir: ws.dir });
       ws.isCreated = true;
     });
-    testDisplay.verbose = true;
-    await new WorkspaceController(ws, testDisplay).onCreate();
+    testConfig.verbose = true;
+    await new WorkspaceController(ws, testDisplay, testConfig).onCreate();
     const printed = testDisplay.print.mock.calls.map(([l]: [string]) => stripAnsi(l)).join("\n");
     expect(printed).toContain("Cloning");
     expect(printed).toContain(REPO_URL);
@@ -189,7 +202,7 @@ describe("WorkspaceController.onCreate", () => {
 
   it("prints 'Resetting workspace...' on reset-start in non-verbose", async () => {
     const ws = makeWorkspace();
-    await new WorkspaceController(ws, testDisplay).onCreate();
+    await new WorkspaceController(ws, testDisplay, testConfig).onCreate();
     testDisplay.print.mockClear();
     ws.emit("reset-start", { dir: ws.dir });
     const printed = testDisplay.print.mock.calls.map(([l]: [string]) => stripAnsi(l)).join("\n");
@@ -199,8 +212,8 @@ describe("WorkspaceController.onCreate", () => {
 
   it("prints dir path on reset-start in verbose mode", async () => {
     const ws = makeWorkspace();
-    testDisplay.verbose = true;
-    await new WorkspaceController(ws, testDisplay).onCreate();
+    testConfig.verbose = true;
+    await new WorkspaceController(ws, testDisplay, testConfig).onCreate();
     testDisplay.print.mockClear();
     ws.emit("reset-start", { dir: ws.dir });
     const printed = testDisplay.print.mock.calls.map(([l]: [string]) => stripAnsi(l)).join("\n");
@@ -210,12 +223,13 @@ describe("WorkspaceController.onCreate", () => {
   it("does not include [workspace] prefix in any message", async () => {
     const ws = makeWorkspace();
     vi.spyOn(ws, "create").mockImplementation(async () => {
+      ws.emit("create-start", { dir: ws.dir });
       ws.emit("clone-start", { repoUrl: REPO_URL, dir: ws.dir });
       ws.emit("npm-install", { dir: ws.dir });
       ws.isCreated = true;
     });
-    testDisplay.verbose = true;
-    await new WorkspaceController(ws, testDisplay).onCreate();
+    testConfig.verbose = true;
+    await new WorkspaceController(ws, testDisplay, testConfig).onCreate();
     ws.emit("reset-start", { dir: ws.dir });
     ws.emit("reset-retry", { dir: ws.dir, error: "err" });
     ws.emit("destroy", { dir: ws.dir });
@@ -242,12 +256,23 @@ describe("workspace:prune", () => {
     expect(stripAnsi(testDisplay.print.mock.calls[0][0])).toContain("Nothing to prune");
   });
 
-  it("lists removed dirs and prints summary when orphans are pruned", async () => {
+  it("lists removed dirs via prune-remove events and prints summary", async () => {
     const ws = makeWorkspace();
-    vi.mocked(ws.prune).mockResolvedValue(["/base/abc", "/base/def"]);
-    makeAndRegister(ws);
+    vi.mocked(ws.prune).mockImplementation(async () => {
+      ws.emit("prune-remove", { dir: "/base/abc" });
+      ws.emit("prune-remove", { dir: "/base/def" });
+      return ["/base/abc", "/base/def"];
+    });
+    // Register event handlers via onCreate, then commands
+    const reg = new CommandRegistry();
+    registry = new CommandController(reg);
+    const controller = new WorkspaceController(ws, testDisplay, testConfig);
+    await controller.onCreate();
+    controller.registerCommands(reg.scoped("workspace"));
+    testDisplay.print.mockClear();
+
     await registry.registry.execute("workspace:prune", "");
-    const allOutput = testDisplay.print.mock.calls.map((c: [string]) => stripAnsi(c[0])).join("\n");
+    const allOutput = testDisplay.print.mock.calls.map(([l]: [string]) => stripAnsi(l)).join("\n");
     expect(allOutput).toContain("/base/abc");
     expect(allOutput).toContain("/base/def");
     expect(allOutput).toContain("Pruned 2 orphaned workspace(s)");

--- a/tests/repl.workspace.test.ts
+++ b/tests/repl.workspace.test.ts
@@ -15,10 +15,10 @@ const SESSION_ID = "test-session-uuid";
 const REPO_URL = "https://x@github.com/owner/repo.git";
 const ORIGINAL_CWD = "/original";
 
-let testDisplay: { print: ReturnType<typeof vi.fn>; printForemanMessage: ReturnType<typeof vi.fn> };
+let testDisplay: { verbose: boolean; print: ReturnType<typeof vi.fn>; printForemanMessage: ReturnType<typeof vi.fn> };
 
 beforeEach(() => {
-  testDisplay = { print: vi.fn(), printForemanMessage: vi.fn() };
+  testDisplay = { verbose: false, print: vi.fn(), printForemanMessage: vi.fn() };
   vi.spyOn(process, "chdir").mockImplementation(() => undefined);
 });
 
@@ -147,6 +147,80 @@ describe("workspace:remove", () => {
     expect(ws.destroy).not.toHaveBeenCalled();
     expect(process.chdir).not.toHaveBeenCalled();
     expect(ws.isCreated).toBe(true);
+  });
+});
+
+// ── onCreate ─────────────────────────────────────────────────────────────────
+
+describe("WorkspaceController.onCreate", () => {
+  it("prints 'Creating workspace...' and chdirs to workspace dir", async () => {
+    const ws = makeWorkspace();
+    await new WorkspaceController(ws, testDisplay).onCreate();
+    expect(ws.create).toHaveBeenCalledOnce();
+    expect(process.chdir).toHaveBeenCalledWith(ws.dir);
+    const printed = testDisplay.print.mock.calls.map(([l]: [string]) => stripAnsi(l)).join("\n");
+    expect(printed).toContain("Creating workspace...");
+  });
+
+  it("does not print clone URL or dir in non-verbose mode", async () => {
+    const ws = makeWorkspace();
+    vi.spyOn(ws, "create").mockImplementation(async () => {
+      ws.emit("clone-start", { repoUrl: REPO_URL, dir: ws.dir });
+      ws.isCreated = true;
+    });
+    await new WorkspaceController(ws, testDisplay).onCreate();
+    const printed = testDisplay.print.mock.calls.map(([l]: [string]) => stripAnsi(l)).join("\n");
+    expect(printed).not.toContain("Cloning");
+    expect(printed).not.toContain(REPO_URL);
+  });
+
+  it("prints clone URL and dir in verbose mode", async () => {
+    const ws = makeWorkspace();
+    vi.spyOn(ws, "create").mockImplementation(async () => {
+      ws.emit("clone-start", { repoUrl: REPO_URL, dir: ws.dir });
+      ws.isCreated = true;
+    });
+    testDisplay.verbose = true;
+    await new WorkspaceController(ws, testDisplay).onCreate();
+    const printed = testDisplay.print.mock.calls.map(([l]: [string]) => stripAnsi(l)).join("\n");
+    expect(printed).toContain("Cloning");
+    expect(printed).toContain(REPO_URL);
+  });
+
+  it("prints 'Resetting workspace...' on reset-start in non-verbose", async () => {
+    const ws = makeWorkspace();
+    await new WorkspaceController(ws, testDisplay).onCreate();
+    testDisplay.print.mockClear();
+    ws.emit("reset-start", { dir: ws.dir });
+    const printed = testDisplay.print.mock.calls.map(([l]: [string]) => stripAnsi(l)).join("\n");
+    expect(printed).toContain("Resetting workspace...");
+    expect(printed).not.toContain(ws.dir);
+  });
+
+  it("prints dir path on reset-start in verbose mode", async () => {
+    const ws = makeWorkspace();
+    testDisplay.verbose = true;
+    await new WorkspaceController(ws, testDisplay).onCreate();
+    testDisplay.print.mockClear();
+    ws.emit("reset-start", { dir: ws.dir });
+    const printed = testDisplay.print.mock.calls.map(([l]: [string]) => stripAnsi(l)).join("\n");
+    expect(printed).toContain(ws.dir);
+  });
+
+  it("does not include [workspace] prefix in any message", async () => {
+    const ws = makeWorkspace();
+    vi.spyOn(ws, "create").mockImplementation(async () => {
+      ws.emit("clone-start", { repoUrl: REPO_URL, dir: ws.dir });
+      ws.emit("npm-install", { dir: ws.dir });
+      ws.isCreated = true;
+    });
+    testDisplay.verbose = true;
+    await new WorkspaceController(ws, testDisplay).onCreate();
+    ws.emit("reset-start", { dir: ws.dir });
+    ws.emit("reset-retry", { dir: ws.dir, error: "err" });
+    ws.emit("destroy", { dir: ws.dir });
+    const printed = testDisplay.print.mock.calls.map(([l]: [string]) => stripAnsi(l)).join("\n");
+    expect(printed).not.toContain("[workspace]");
   });
 });
 


### PR DESCRIPTION
## Summary

- Drop the `[workspace]` prefix from all workspace log messages
- On workspace create, only print `Creating workspace...` (non-verbose); `Cloning ... → ...` and `Installing dependencies in ...` are suppressed unless `--verbose`
- Same for reset (`Resetting workspace...`) and destroy (`Destroying workspace...`) — paths shown only in verbose mode
- Prune start prints `Pruning orphaned workspaces...` (non-verbose) or with path (verbose); the `prune-remove` event handler is removed since `/workspace:prune` already lists removed paths after the fact
- Add `verbose: boolean` to `WorkerDisplay` interface
- Add tests covering the verbose/non-verbose branching for `onCreate()`

## Test plan

- [ ] `npm test` passes (all non-DB tests green)
- [ ] `npx tsc --noEmit` passes
- [ ] Run worker manually: verify `Creating workspace...` is the only message on create (non-verbose)
- [ ] Run worker with `--verbose`: verify full clone URL and paths appear

Closes #812