### PR TITLE
feat: show task stats (tokens/cost) in dashboard

### DIFF
--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -10,6 +10,10 @@ export default function TaskDetail() {
   const [task, setTask] = useState<Task | null>(null);
 
   useEffect(() => {
+    fetch(`/api/tasks/${id}`)
+      .then((r) => r.json() as Promise<Task>)
+      .then(setTask)
+      .catch(console.error);
     fetch(`/api/tasks/${id}/events`)
       .then((r) => r.json() as Promise<LogEntry[]>)
       .then(setEvents)
@@ -31,6 +35,13 @@ export default function TaskDetail() {
     <div>
       <h2>Task #{id}</h2>
       <p><Link to="/">← Dashboard</Link></p>
+
+      {task && (task.inputTokens != null || task.outputTokens != null) && (
+        <section style={{ marginBottom: "1rem", fontFamily: "monospace", fontSize: "0.9em", color: "#555" }}>
+          <span>Tokens: {(task.inputTokens ?? 0).toLocaleString()} in / {(task.outputTokens ?? 0).toLocaleString()} out</span>
+          {task.costUsd != null && <span style={{ marginLeft: "1rem" }}>Cost: ${task.costUsd.toFixed(4)}</span>}
+        </section>
+      )}
 
       {task?.blockers && task.blockers.length > 0 && (
         <section style={{ marginBottom: "1.5rem" }}>

--- a/frontend/src/pages/TaskList.tsx
+++ b/frontend/src/pages/TaskList.tsx
@@ -71,6 +71,7 @@ export default function TaskList() {
               <th style={th}>PR</th>
               <th style={th}>Created</th>
               <th style={th}>Completed</th>
+              <th style={th}>Tokens / Cost</th>
             </tr>
           </thead>
           <tbody>
@@ -87,6 +88,7 @@ export default function TaskList() {
                   : "—"}</td>
                 <td style={td}>{t.createdAt ? new Date(t.createdAt).toLocaleString() : "—"}</td>
                 <td style={td}>{t.completedAt ? new Date(t.completedAt).toLocaleString() : "—"}</td>
+                <td style={td}>{fmtStats(t)}</td>
               </tr>
             ))}
           </tbody>
@@ -98,3 +100,11 @@ export default function TaskList() {
 
 const th: React.CSSProperties = { textAlign: "left", borderBottom: "1px solid #ccc", padding: "4px 8px" };
 const td: React.CSSProperties = { padding: "4px 8px", borderBottom: "1px solid #eee" };
+
+function fmtStats(t: Task): string {
+  if (t.inputTokens == null && t.outputTokens == null) return "—";
+  const inK = ((t.inputTokens ?? 0) / 1000).toFixed(1);
+  const outK = ((t.outputTokens ?? 0) / 1000).toFixed(1);
+  const cost = t.costUsd != null ? ` · $${t.costUsd.toFixed(4)}` : "";
+  return `${inK}k in / ${outK}k out${cost}`;
+}

--- a/shared/wire.ts
+++ b/shared/wire.ts
@@ -26,6 +26,9 @@ export interface Task {
   createdAt?: string;
   assignedAt?: string;
   completedAt?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  costUsd?: number;
 }
 
 /** Wire representation of a connected worker — sent over the admin WebSocket. */
@@ -75,7 +78,7 @@ export interface TaskIssue {
 // Worker → Foreman messages
 export type WorkerMessage =
   | { type: "worker_hello"; workerId: string; repo: string; taskId?: string; status: "idle" | "busy"; workerSecret?: string }
-  | { type: "task_complete"; workerId: string; taskId: string }
+  | { type: "task_complete"; workerId: string; taskId: string; stats?: { inputTokens: number; outputTokens: number; costUsd?: number } }
   | { type: "worker_goodbye"; workerId: string; taskId?: string };
 
 // Foreman → Worker messages

--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -276,10 +276,13 @@ export class WorkerSession extends EventEmitter {
         this.display.print(c.amber(`afterTask failed: ${fmtError(err)}`));
       }
     }
+    const { taskInputTokens, taskOutputTokens, taskCostUsd } = this.agentStatus;
+    const hasStats = taskInputTokens > 0 || taskOutputTokens > 0 || taskCostUsd != null;
     this.sendTaskMessage({
       type: "task_complete",
       workerId: this.agentStatus.agentId,
       taskId: this.currentTaskId,
+      ...(hasStats && { stats: { inputTokens: taskInputTokens, outputTokens: taskOutputTokens, costUsd: taskCostUsd } }),
     });
     const taskNumber = this.currentIssue!.number;
     this.currentTaskId = undefined;

--- a/src/database.types.ts
+++ b/src/database.types.ts
@@ -83,6 +83,9 @@ export type Database = {
           completed_at: string | null
           issue_closed_at: string | null
           pr_merged_at: string | null
+          input_tokens: number | null
+          output_tokens: number | null
+          cost_usd: number | null
         }
         Insert: {
           task_id: string
@@ -100,6 +103,9 @@ export type Database = {
           completed_at?: string | null
           issue_closed_at?: string | null
           pr_merged_at?: string | null
+          input_tokens?: number | null
+          output_tokens?: number | null
+          cost_usd?: number | null
         }
         Update: {
           task_id?: string
@@ -117,6 +123,9 @@ export type Database = {
           completed_at?: string | null
           issue_closed_at?: string | null
           pr_merged_at?: string | null
+          input_tokens?: number | null
+          output_tokens?: number | null
+          cost_usd?: number | null
         }
         Relationships: [
           {

--- a/src/foreman/controllers/http-server.ts
+++ b/src/foreman/controllers/http-server.ts
@@ -67,6 +67,17 @@ export function createHttpServer({ webhooks, routeEvent }: HttpServerOptions): h
     }
   });
 
+  app.get("/api/tasks/:id", async (c) => {
+    try {
+      const task = await Task.get(c.req.param("id"));
+      if (!task) return c.json({ error: "not found" }, 404);
+      return c.json(task.toWire());
+    } catch (err) {
+      log(`ERROR API query failed: ${fmtError(err)}`);
+      return c.json({ error: "internal error" }, 500);
+    }
+  });
+
   app.get("/api/tasks/:id/events", async (c) => {
     try {
       const taskId = c.req.param("id");

--- a/src/foreman/controllers/wss.ts
+++ b/src/foreman/controllers/wss.ts
@@ -119,7 +119,7 @@ export class ForemanWss {
         }
         if (task) {
           try {
-            await task.complete();
+            await task.complete(msg.stats);
           } catch (err) {
             log(`ERROR Failed to mark task #${msg.taskId} complete: ${fmtError(err)}`);
             return; // don't release — keeps task assigned so the failure is visible

--- a/src/foreman/models/task.ts
+++ b/src/foreman/models/task.ts
@@ -32,6 +32,9 @@ export class Task extends ActiveRecord {
   completedAt: string | null;
   issueClosedAt: string | null;
   prMergedAt: string | null;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  costUsd: number | null;
 
   // ── In-memory blocker state (not persisted to DB) ─────────────────────────
   /** Merged set of blockers with their current open/closed state — set by TaskManager.hydrateBlockers(). */
@@ -60,6 +63,9 @@ export class Task extends ActiveRecord {
     this.completedAt = row.completed_at;
     this.issueClosedAt = row.issue_closed_at;
     this.prMergedAt = row.pr_merged_at;
+    this.inputTokens = row.input_tokens;
+    this.outputTokens = row.output_tokens;
+    this.costUsd = row.cost_usd;
   }
 
   get status(): TaskStatus {
@@ -91,6 +97,9 @@ export class Task extends ActiveRecord {
       createdAt: this.createdAt,
       assignedAt: this.assignedAt ?? undefined,
       completedAt: this.completedAt ?? undefined,
+      inputTokens: this.inputTokens ?? undefined,
+      outputTokens: this.outputTokens ?? undefined,
+      costUsd: this.costUsd ?? undefined,
     };
   }
 
@@ -134,6 +143,9 @@ export class Task extends ActiveRecord {
       completed_at: null,
       issue_closed_at: null,
       pr_merged_at: null,
+      input_tokens: null,
+      output_tokens: null,
+      cost_usd: null,
       ...fields,
     };
     return new Task(row);
@@ -174,6 +186,9 @@ export class Task extends ActiveRecord {
     if ("title" in changes) this.title = changes.title!;
     if ("body" in changes) this.body = changes.body!;
     if ("labels" in changes) this.labels = changes.labels!;
+    if ("input_tokens" in changes) this.inputTokens = changes.input_tokens ?? null;
+    if ("output_tokens" in changes) this.outputTokens = changes.output_tokens ?? null;
+    if ("cost_usd" in changes) this.costUsd = changes.cost_usd ?? null;
     await this.update(changes as Record<string, unknown>);
     // "changed" event is emitted by the base update() above.
   }
@@ -233,8 +248,15 @@ export class Task extends ActiveRecord {
     await this.save({ worker_id: worker.workerId, assigned_at: new Date().toISOString() });
   }
 
-  async complete(): Promise<void> {
-    await this.save({ completed_at: new Date().toISOString() });
+  async complete(stats?: { inputTokens: number; outputTokens: number; costUsd?: number }): Promise<void> {
+    await this.save({
+      completed_at: new Date().toISOString(),
+      ...(stats && {
+        input_tokens: stats.inputTokens,
+        output_tokens: stats.outputTokens,
+        cost_usd: stats.costUsd ?? null,
+      }),
+    });
   }
 
   async revert(): Promise<void> {

--- a/supabase/migrations/20260423000000_task_stats.sql
+++ b/supabase/migrations/20260423000000_task_stats.sql
@@ -1,0 +1,4 @@
+ALTER TABLE tasks
+  ADD COLUMN IF NOT EXISTS input_tokens  integer,
+  ADD COLUMN IF NOT EXISTS output_tokens integer,
+  ADD COLUMN IF NOT EXISTS cost_usd      numeric(12, 6);

--- a/tests/foreman.http.test.ts
+++ b/tests/foreman.http.test.ts
@@ -144,6 +144,46 @@ describe("GET /api/log", () => {
   });
 });
 
+describe("GET /api/tasks/:id", () => {
+  it("returns 404 when task does not exist", async () => {
+    resetDb();
+    const s = createHttpServer({ webhooks: null, routeEvent: vi.fn() });
+    const p = await startServer(s);
+    try {
+      const res = await request(p, "GET", "/api/tasks/nonexistent");
+      expect(res.status).toBe(404);
+    } finally {
+      await stopServer(s);
+    }
+  });
+
+  it("returns 200 with task data including stats for a completed task", async () => {
+    resetDb();
+    await createTestTaskManager();
+
+    const t = await Task.upsert("http-t1", 9901, "test/repo", "Fix bug", "body", []);
+    await t.complete({ inputTokens: 1000, outputTokens: 500, costUsd: 0.05 });
+
+    const s = createHttpServer({ webhooks: null, routeEvent: vi.fn() });
+    const p = await startServer(s);
+    try {
+      const res = await request(p, "GET", "/api/tasks/http-t1");
+      expect(res.status).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body).toMatchObject({
+        taskId: "http-t1",
+        status: "complete",
+        inputTokens: 1000,
+        outputTokens: 500,
+        costUsd: 0.05,
+      });
+    } finally {
+      vi.restoreAllMocks();
+      await stopServer(s);
+    }
+  });
+});
+
 describe("GET /api/tasks/:id/events", () => {
   it("returns 200 with an empty JSON array when queryActivityLog returns empty", async () => {
     const res = await request(port, "GET", "/api/tasks/42/events");

--- a/tests/foreman.websocket.test.ts
+++ b/tests/foreman.websocket.test.ts
@@ -247,6 +247,23 @@ describe("foreman WebSocket protocol", () => {
     expect(raceResult).toBe("timeout");
   });
 
+  it("task_complete with stats persists token counts and cost on the task", async () => {
+    await makeTask(taskManager, 3001);
+    const ws = await connect();
+    const q = makeQueue(ws);
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    await q.next(); // hello_ack
+    await q.next(); // task_assigned
+
+    send(ws, { type: "task_complete", workerId: "w1", taskId: "3001", stats: { inputTokens: 1000, outputTokens: 500, costUsd: 0.05 } });
+    await waitUntil(() => Worker.get("w1")?.status === "idle");
+
+    const task = await Task.get("3001");
+    expect(task?.inputTokens).toBe(1000);
+    expect(task?.outputTokens).toBe(500);
+    expect(task?.costUsd).toBe(0.05);
+  });
+
   it("worker reconnects as busy and reclaims its own task (no task_assigned sent)", async () => {
     await makeTask(taskManager, 1);
     const ws1 = await connect();

--- a/tests/helpers/memory-db.ts
+++ b/tests/helpers/memory-db.ts
@@ -164,6 +164,9 @@ export function createMemoryTaskDb(): SupabaseClient<Database> {
             completed_at: null,
             issue_closed_at: null,
             pr_merged_at: null,
+            input_tokens: null,
+            output_tokens: null,
+            cost_usd: null,
             created_at: now,
             // Preserve all existing field values (mirrors ON CONFLICT DO UPDATE
             // which only updates the columns listed in the UPDATE SET — all other

--- a/tests/helpers/task.ts
+++ b/tests/helpers/task.ts
@@ -64,6 +64,9 @@ export async function seedTask(
     completed_at: null,
     issue_closed_at: null,
     pr_merged_at: null,
+    input_tokens: null,
+    output_tokens: null,
+    cost_usd: null,
     ...fields,
   } as any, { onConflict: "task_id" }).select().maybeSingle();
   Task.events.emit("changed");

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -244,6 +244,25 @@ describe("completeCurrentTask", () => {
     await session.completeCurrentTask();
     expect(fakeWs.send).not.toHaveBeenCalled();
   });
+
+  it("includes accumulated token stats in task_complete message", async () => {
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue: makeIssue() });
+    session.takeNextPrompt();
+    sb.addQueryStats(1000, 500, 0.05); // add stats after assignment (task_assigned resets stats)
+    await session.completeCurrentTask();
+    const sent = JSON.parse(fakeWs.send.mock.calls[0][0]);
+    expect(sent.type).toBe("task_complete");
+    expect(sent.stats).toEqual({ inputTokens: 1000, outputTokens: 500, costUsd: 0.05 });
+  });
+
+  it("omits stats from task_complete when no tokens were used", async () => {
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue: makeIssue() });
+    session.takeNextPrompt();
+    await session.completeCurrentTask();
+    const sent = JSON.parse(fakeWs.send.mock.calls[0][0]);
+    expect(sent.type).toBe("task_complete");
+    expect(sent.stats).toBeUndefined();
+  });
 });
 
 // ── State isolation ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Worker reports input/output token counts and cost in the `task_complete` message (only when non-zero)
- Foreman stores these in three new nullable DB columns: `input_tokens`, `output_tokens`, `cost_usd`
- Task list page gains a "Tokens / Cost" column (e.g. `1.2k in / 3.4k out · $0.0500`)
- Task detail page shows token counts and cost under the task title
- New `GET /api/tasks/:id` REST endpoint so the detail page can load stats for completed tasks (which are excluded from the WebSocket snapshot)

## Test plan

- [ ] 5 new tests cover the end-to-end stats flow: worker sends stats in `task_complete`, foreman stores them on the task, REST endpoint returns them
- [ ] Run `npm test` — 1408 passing, same 4 DB tests skip (require Supabase)
- [ ] Run `npx tsc --noEmit` — clean
- [ ] Run `npm run lint` — clean
- [ ] Manual: complete a task, check task list for Tokens/Cost column, check task detail for stats section

Closes #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)