### PR TITLE
refactor: simplify settings data flow

### DIFF
--- a/src/agent/controllers/agent-controller.ts
+++ b/src/agent/controllers/agent-controller.ts
@@ -1,12 +1,12 @@
 import fs from "fs";
 import { query } from "@anthropic-ai/claude-agent-sdk";
-import type { CanUseTool, PermissionMode, PermissionResult } from "@anthropic-ai/claude-agent-sdk";
+import type { CanUseTool, PermissionResult } from "@anthropic-ai/claude-agent-sdk";
 import { c } from "../views/style.js";
 import type { Display } from "../views/display.js";
 import { Picker } from "../views/picker.js";
 import type { PickQuestionResult } from "../views/picker.js";
 import { Settings } from "../models/settings.js";
-import type { ModelInfo, FetchModelsFn, EffortValue } from "../models/settings.js";
+import type { ModelInfo, FetchModelsFn } from "../models/settings.js";
 import { QueryStats } from "../models/query-stats.js";
 
 // ── Log file ──────────────────────────────────────────────────────────────────
@@ -28,11 +28,6 @@ export function logFull(label: string, data: unknown) {
 type QuestionOption = { label: string; description: string };
 type Question = { question: string; header: string; options: QuestionOption[]; multiSelect: boolean };
 
-export type AgentPermConfig = {
-  permissionMode: PermissionMode;
-  allowDangerouslySkipPermissions: boolean;
-};
-
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 /** The SDK query object exposes supportedModels() as an undocumented extension. */
@@ -42,9 +37,9 @@ type QueryWithModels = { supportedModels?: () => Promise<ModelInfo[]> };
  * Returns a function that fetches available Claude models from the SDK.
  * Used by the /model command to populate the model picker.
  */
-export function createFetchModelsFn(permConfig: AgentPermConfig): FetchModelsFn {
+export function createFetchModelsFn(settings: Settings): FetchModelsFn {
   return async () => {
-    const q = query({ prompt: "", options: { cwd: process.cwd(), systemPrompt: { type: "preset", preset: "claude_code" }, permissionMode: permConfig.permissionMode } });
+    const q = query({ prompt: "", options: { cwd: process.cwd(), systemPrompt: { type: "preset", preset: "claude_code" }, permissionMode: settings.permissionMode } });
     const qm = q as unknown as QueryWithModels;
     if (typeof qm.supportedModels === "function") return qm.supportedModels();
     return [];
@@ -65,7 +60,6 @@ export class AgentController {
   constructor(
     private display: Display,
     private picker: Picker,
-    private permConfig: AgentPermConfig,
     private settings: Settings,
   ) {}
 
@@ -78,11 +72,9 @@ export class AgentController {
     prompt: string,
     sessionId: string | undefined,
     abortController?: AbortController,
-    model?: string,
-    effort?: EffortValue,
   ): Promise<{ sessionId: string | undefined; stats: QueryStats }> {
     logFull("QUERY", { prompt, sessionId });
-    const { display, permConfig } = this;
+    const { display } = this;
     // Save and clear the input callbacks while the query runs. In worker
     // mode, ask() registers drawFresh() as the callback so the prompt redraws
     // after background WebSocket messages — but during a query run the callback
@@ -106,19 +98,18 @@ export class AgentController {
     const getStatusText = () => c.darkGray(stats.getStatusText());
     display.startBar(getStatusText);
 
+    const allowDangerouslySkipPerms = this.settings.permissionMode === "bypassPermissions";
+
     const canUseTool: CanUseTool = async (toolName, input) => {
       if (toolName === "AskUserQuestion") {
         return this.handleAskUserQuestion(input, getStatusText);
       }
-      if (permConfig.allowDangerouslySkipPermissions) return { behavior: "allow", updatedInput: input };
+      if (allowDangerouslySkipPerms) return { behavior: "allow", updatedInput: input };
       return this.handleToolPermission(toolName, input, getStatusText);
     };
 
     // Use caller-provided AbortController (worker mode) or create our own (REPL mode).
     const ac = abortController ?? new AbortController();
-
-    // Use settings as source of truth for permissionMode (initialized from config)
-    const allowDangerouslySkipPerms = this.settings.permissionMode === "bypassPermissions";
 
     const iterable = query({
       prompt,
@@ -132,8 +123,8 @@ export class AgentController {
         abortController: ac,
         ...(allowDangerouslySkipPerms ? { allowDangerouslySkipPermissions: true } : {}),
         ...(sessionId ? { resume: sessionId } : {}),
-        ...(model ? { model } : {}),
-        ...(effort ? { effort } : {}),
+        ...(this.settings.model ? { model: this.settings.model } : {}),
+        ...(this.settings.effort ? { effort: this.settings.effort } : {}),
       },
     });
 

--- a/src/agent/controllers/agent-controller.ts
+++ b/src/agent/controllers/agent-controller.ts
@@ -6,7 +6,7 @@ import type { Display } from "../views/display.js";
 import { Picker } from "../views/picker.js";
 import type { PickQuestionResult } from "../views/picker.js";
 import { Settings } from "../models/settings.js";
-import type { ModelInfo, FetchModelsFn } from "../models/settings.js";
+import type { ModelInfo } from "../models/settings.js";
 import { QueryStats } from "../models/query-stats.js";
 
 // ── Log file ──────────────────────────────────────────────────────────────────
@@ -33,19 +33,6 @@ type Question = { question: string; header: string; options: QuestionOption[]; m
 /** The SDK query object exposes supportedModels() as an undocumented extension. */
 type QueryWithModels = { supportedModels?: () => Promise<ModelInfo[]> };
 
-/**
- * Returns a function that fetches available Claude models from the SDK.
- * Used by the /model command to populate the model picker.
- */
-export function createFetchModelsFn(settings: Settings): FetchModelsFn {
-  return async () => {
-    const q = query({ prompt: "", options: { cwd: process.cwd(), systemPrompt: { type: "preset", preset: "claude_code" }, permissionMode: settings.permissionMode } });
-    const qm = q as unknown as QueryWithModels;
-    if (typeof qm.supportedModels === "function") return qm.supportedModels();
-    return [];
-  };
-}
-
 // ── AgentController ───────────────────────────────────────────────────────────
 
 /**
@@ -62,6 +49,14 @@ export class AgentController {
     private picker: Picker,
     private settings: Settings,
   ) {}
+
+  /** Fetches available Claude models from the SDK. Used by the /model command. */
+  async fetchModels(): Promise<ModelInfo[]> {
+    const q = query({ prompt: "", options: { cwd: process.cwd(), systemPrompt: { type: "preset", preset: "claude_code" }, permissionMode: this.settings.permissionMode } });
+    const qm = q as unknown as QueryWithModels;
+    if (typeof qm.supportedModels === "function") return qm.supportedModels();
+    return [];
+  }
 
   /**
    * Run a single prompt through the Claude SDK. Manages the status bar,

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -12,11 +12,10 @@ import { loadConfig, getConfig, type BrunelConfig } from "../config.js";
 import { Workspace } from "./models/workspace.js";
 import { fmtError } from "../utils.js";
 import { Settings } from "./models/settings.js";
-import type { FetchModelsFn } from "./models/settings.js";
 import { CommandRegistry, CommandController } from "./controllers/command-controller.js";
 import { SettingsController } from "./controllers/settings-controller.js";
 import { WorkspaceController } from "./controllers/workspace-controller.js";
-import { AgentController, logFull, createFetchModelsFn } from "./controllers/agent-controller.js";
+import { AgentController, logFull } from "./controllers/agent-controller.js";
 
 // ── BrunelAgent ───────────────────────────────────────────────────────────────
 
@@ -34,7 +33,6 @@ export class BrunelAgent {
   private readonly picker: Picker;
   private readonly agentController: AgentController;
   private readonly workspaceController: WorkspaceController;
-  private readonly fetchModelsFn: FetchModelsFn;
   private readonly settingsController: SettingsController;
   private readonly controller: CommandController;
 
@@ -70,7 +68,6 @@ export class BrunelAgent {
       : undefined;
     this.workspaceController = new WorkspaceController(workspace, this.display, config);
 
-    this.fetchModelsFn = createFetchModelsFn(this.settings);
     this.settingsController = new SettingsController(this.settings, this.display);
     const registry = new CommandRegistry();
     this.controller = new CommandController(registry);
@@ -149,7 +146,7 @@ export class BrunelAgent {
         await this.settingsController.pickModel(
           args,
           (opts, idx) => this.picker.pick(opts, { currentIdx: idx, escapable: true }),
-          this.fetchModelsFn,
+          () => this.agentController.fetchModels(),
         );
       },
     });

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -17,7 +17,6 @@ import { CommandRegistry, CommandController } from "./controllers/command-contro
 import { SettingsController } from "./controllers/settings-controller.js";
 import { WorkspaceController } from "./controllers/workspace-controller.js";
 import { AgentController, logFull, createFetchModelsFn } from "./controllers/agent-controller.js";
-import type { AgentPermConfig } from "./controllers/agent-controller.js";
 
 // ── BrunelAgent ───────────────────────────────────────────────────────────────
 
@@ -30,7 +29,6 @@ import type { AgentPermConfig } from "./controllers/agent-controller.js";
 export class BrunelAgent {
   readonly display: Display;
   private readonly settings: Settings;
-  private readonly permConfig: AgentPermConfig;
   private readonly agentStatus: AgentStatus;
   private readonly input: Input;
   private readonly picker: Picker;
@@ -41,16 +39,12 @@ export class BrunelAgent {
   private readonly controller: CommandController;
 
   constructor(config: BrunelConfig) {
-    this.settings = new Settings({ model: config.model, effort: config.effort, permissionMode: config.permissionMode });
+    this.settings = new Settings(config);
     this.agentStatus = new AgentStatus({ agentId: WorkerSession.generateAgentId(), settings: this.settings });
     this.display = new Display(config, this.agentStatus);
-    this.permConfig = {
-      permissionMode: config.permissionMode,
-      allowDangerouslySkipPermissions: config.allowDangerouslySkipPermissions,
-    };
     this.input = new Input(this.display);
     this.picker = new Picker();
-    this.agentController = new AgentController(this.display, this.picker, this.permConfig, this.settings);
+    this.agentController = new AgentController(this.display, this.picker, this.settings);
 
     const originalCwd = process.cwd();
     const confirm = async (msg: string): Promise<boolean> => {
@@ -76,7 +70,7 @@ export class BrunelAgent {
       : undefined;
     this.workspaceController = new WorkspaceController(workspace, this.display, config);
 
-    this.fetchModelsFn = createFetchModelsFn(this.permConfig);
+    this.fetchModelsFn = createFetchModelsFn(this.settings);
     this.settingsController = new SettingsController(this.settings, this.display);
     const registry = new CommandRegistry();
     this.controller = new CommandController(registry);
@@ -112,7 +106,7 @@ export class BrunelAgent {
     // Print the startup banner.
     this.display.print(c.sageGreen(hr("═")));
     this.display.print(c.skyBlue(this.display.s.bold("  Brunel Agent")));
-    this.display.print(c.lavender(`  Permissions: ${this.permConfig.permissionMode} | Model: ${this.settings.model ?? "default"} | Effort: ${this.settings.effort ?? "auto"} | Output: ${getConfig().verbose ? "verbose" : "quiet"} | Log: repl.log`));
+    this.display.print(c.lavender(`  Permissions: ${this.settings.permissionMode ?? "default"} | Model: ${this.settings.model ?? "default"} | Effort: ${this.settings.effort ?? "auto"} | Output: ${getConfig().verbose ? "verbose" : "quiet"} | Log: repl.log`));
     this.display.print(c.sageGreen(hr("═")));
 
     process.stdout.write("\x1b[?2004h"); // enable bracketed paste mode
@@ -188,7 +182,7 @@ export class BrunelAgent {
       const ac = new AbortController();
       session?.notifyQueryStart(ac);
       try {
-        const { sessionId: newId, stats } = await this.agentController.runQuery(prompt, sessionId, ac, this.settings.model, this.settings.effort);
+        const { sessionId: newId, stats } = await this.agentController.runQuery(prompt, sessionId, ac);
         sessionId = newId ?? sessionId;
         if (session) {
           this.agentStatus.addQueryStats(stats.inputTokens, stats.outputTokens, stats.costUsd);

--- a/tests/repl.query.test.ts
+++ b/tests/repl.query.test.ts
@@ -32,11 +32,6 @@ let mockPicker: {
   pickQuestion: ReturnType<typeof vi.fn>;
 };
 
-const defaultPermConfig = {
-  permissionMode: "default" as const,
-  allowDangerouslySkipPermissions: false,
-};
-
 const FAKE_MODELS = [
   { value: "sonnet", displayName: "Sonnet 4.6", description: "Best for everyday tasks" },
   { value: "opus", displayName: "Opus 4.6", description: "Most capable for complex work" },
@@ -78,7 +73,7 @@ beforeEach(() => {
     pickQuestion: vi.fn().mockResolvedValue({ type: "answer", value: "Fast" }),
   };
   testSettings = new Settings({});
-  testController = new AgentController(testDisplay, mockPicker as unknown as Picker, defaultPermConfig, testSettings);
+  testController = new AgentController(testDisplay, mockPicker as unknown as Picker, testSettings);
   getConfig().verbose = false;
   vi.clearAllMocks();
 });
@@ -640,13 +635,14 @@ describe("runQuery - interrupt via ^C on stdin", () => {
 
 describe("runQuery - model option", () => {
 
-  it("passes model to SDK query options when provided", async () => {
+  it("passes model to SDK query options when set on settings", async () => {
+    testSettings._setModel("opus");
     mockQueryMessages([
       { type: "result", duration_ms: 100, num_turns: 1, usage: { input_tokens: 10, output_tokens: 5 } },
     ]);
     const cap = captureConsole();
     try {
-      await testController.runQuery("test", undefined, undefined, "opus");
+      await testController.runQuery("test", undefined);
     } finally {
       cap.restore();
     }


### PR DESCRIPTION
## Summary

- `Settings` constructor now accepts the whole config object and picks what it needs, instead of receiving `model`, `effort`, and `permissionMode` as three separate values
- `AgentController.runQuery()` no longer takes `model`/`effort` parameters — it reads them directly from `this.settings` (it already had the settings object)
- Removed the redundant `permConfig` object: `permissionMode` and `allowDangerouslySkipPermissions` were duplicates of values already in `settings`; `AgentController` and `createFetchModelsFn` now use `settings` directly
- Updated tests accordingly (model is set via `settings._setModel()` instead of a parameter)

## Test plan

- [ ] All 1408 unit tests pass (`npm test`)
- [ ] TypeScript type-check clean (`npx tsc --noEmit`)
- [ ] ESLint clean (`npm run lint`)

Closes #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)