### PR TITLE
feat: filter active repos on foreman startup

### DIFF
--- a/src/foreman/index.ts
+++ b/src/foreman/index.ts
@@ -54,7 +54,7 @@ if (isMain) {
   // Step 1: Bootstrap per-repo TaskManagers from known repos, then load active tasks.
   log("[startup] step 1: loading active tasks from DB...");
   try {
-    const repos = await Repo.list();
+    const repos = await Repo.listActive();
     for (const repo of repos) {
       await repo.taskManager.loadActiveTasksFromDb();
     }

--- a/src/foreman/models/active-record.ts
+++ b/src/foreman/models/active-record.ts
@@ -75,6 +75,16 @@ export abstract class ActiveRecord {
   }
 
   /**
+   * List all records where `col` equals `val`.
+   * Subclasses may override to narrow the return type (e.g. `Promise<Repo[]>`).
+   */
+  protected static async listBy(col: string, val: string | number): Promise<any[]> {
+    const { data, error } = await (this as any).select().eq(col, val);
+    if (error) throw error;
+    return ((data ?? []) as unknown[]).map((row) => new (this as any)(row));
+  }
+
+  /**
    * Insert a new record and return the persisted instance (including server-generated fields).
    * Subclasses may override to narrow the return type.
    * Throws on error.

--- a/src/foreman/models/repo.ts
+++ b/src/foreman/models/repo.ts
@@ -41,9 +41,7 @@ export class Repo extends ActiveRecord {
   }
 
   static async listActive(): Promise<Repo[]> {
-    const { data, error } = await (this as any).select().eq("status", "active");
-    if (error) throw error;
-    return ((data ?? []) as unknown[]).map((row) => new (this as any)(row));
+    return super.listBy("status", "active") as Promise<Repo[]>;
   }
 
   /** Convenience accessor — returns the per-repo TaskManager instance. */

--- a/src/foreman/models/repo.ts
+++ b/src/foreman/models/repo.ts
@@ -40,6 +40,12 @@ export class Repo extends ActiveRecord {
     return super.list() as Promise<Repo[]>;
   }
 
+  static async listActive(): Promise<Repo[]> {
+    const { data, error } = await (this as any).select().eq("status", "active");
+    if (error) throw error;
+    return ((data ?? []) as unknown[]).map((row) => new (this as any)(row));
+  }
+
   /** Convenience accessor — returns the per-repo TaskManager instance. */
   get taskManager(): TaskManager {
     return TaskManager.forRepo(this);

--- a/tests/db.repos.test.ts
+++ b/tests/db.repos.test.ts
@@ -59,3 +59,25 @@ describe("Repo.list", () => {
     expect(ours).toHaveLength(2);
   });
 });
+
+describe("Repo.listActive", () => {
+  it("returns only repos with status 'active'", async () => {
+    const a = await Repo.findOrCreate("dbr-owner/repo-a");
+    await Repo.findOrCreate("dbr-owner/repo-b");
+    await supabase.from("repos").update({ status: "active" }).eq("id", a.id);
+
+    const active = await Repo.listActive();
+    const ours = active.filter((r) => r.fullName.startsWith("dbr-owner/"));
+    expect(ours).toHaveLength(1);
+    expect(ours[0].fullName).toBe("dbr-owner/repo-a");
+  });
+
+  it("returns empty when no repos are active", async () => {
+    await Repo.findOrCreate("dbr-owner/repo-a");
+    await Repo.findOrCreate("dbr-owner/repo-b");
+
+    const active = await Repo.listActive();
+    const ours = active.filter((r) => r.fullName.startsWith("dbr-owner/"));
+    expect(ours).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `Repo.listActive()` which queries only repos with `status = 'active'`
- Updates foreman startup (step 1) to call `Repo.listActive()` instead of `Repo.list()`, so repos with status `'new'` are not loaded unnecessarily
- Adds two DB tests for `Repo.listActive()`: one verifying only active repos are returned, one verifying an empty result when none are active

## Test plan

- [ ] DB tests in `tests/db.repos.test.ts` pass with Supabase running
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] All non-DB unit tests pass

Closes #803