### PR TITLE
feat(foreman): repo-scoped task assignment in TaskManager

### DIFF
--- a/src/foreman/models/task-manager.ts
+++ b/src/foreman/models/task-manager.ts
@@ -133,7 +133,10 @@ export class TaskManager extends EventEmitter {
   }
 
   private async tryAssignWork(worker: Worker): Promise<AssignOutcome | null> {
-    const task = await this.nextPending(t => t.blockersLoaded && t.status === "pending");
+    if (worker.repo.status !== "active") return null;
+    const task = await this.nextPending(
+      t => t.blockersLoaded && t.status === "pending" && t.repoId === worker.repo.id,
+    );
     if (!task) return null;
     worker.assign(task);
     try {

--- a/tests/browser/server.ts
+++ b/tests/browser/server.ts
@@ -55,6 +55,7 @@ const cfg = await loadDefaultConfig();
 
 initDb(createMemoryTaskDb());
 const taskModel = await createTestTaskManager("owner/repo");
+await taskModel.repo.activate();
 
 // Mock workers managed by /test/connect-worker and /test/workers/:id
 const mockWorkers = new Map<string, WebSocket>();

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -212,23 +212,26 @@ describe("WebhookEvent.format (richer summaries)", () => {
 
 describe("queryActivityLog", () => {
   it("returns entries sorted by timestamp descending", async () => {
+    // Use a task_id not shared with pipeline.test.ts (which uses "42" and "55")
+    // to avoid DB contamination when both test files run in parallel.
+    const SORT_TASK_ID = "db-sort-999";
     await supabase.from("webhook_events").insert({
-      event_name: "issues", action: "labeled", issue_number: 42,
-      task_id: "42", worker_id: null, payload: {},
+      event_name: "issues", action: "labeled", issue_number: 999,
+      task_id: SORT_TASK_ID, worker_id: null, payload: {},
       received_at: "2026-03-27T01:00:00Z",
     });
     await supabase.from("foreman_messages").insert({
-      direction: "sent", worker_id: "w1", task_id: "42",
+      direction: "sent", worker_id: "w1", task_id: SORT_TASK_ID,
       msg_type: "task_assigned", payload: {},
       created_at: "2026-03-27T02:00:00Z",
     });
     await supabase.from("webhook_events").insert({
-      event_name: "issues", action: "unlabeled", issue_number: 42,
-      task_id: "42", worker_id: null, payload: {},
+      event_name: "issues", action: "unlabeled", issue_number: 999,
+      task_id: SORT_TASK_ID, worker_id: null, payload: {},
       received_at: "2026-03-27T03:00:00Z",
     });
 
-    const entries = await queryActivityLog({ taskId: "42" });
+    const entries = await queryActivityLog({ taskId: SORT_TASK_ID });
     expect(entries).toHaveLength(3);
     expect(entries[0].timestamp).toBe("2026-03-27T03:00:00+00:00");
     expect(entries[1].timestamp).toBe("2026-03-27T02:00:00+00:00");

--- a/tests/foreman.reconcile.test.ts
+++ b/tests/foreman.reconcile.test.ts
@@ -22,6 +22,7 @@ beforeEach(async () => {
   Worker._reset();
   resetDb();
   taskManager = await createTestTaskManager("owner/repo");
+  await taskManager.repo.activate();
   const server = http.createServer();
   foremanWss = new ForemanWss({ server, config: { ...defaultCfg, taskLabel: TASK_LABEL } });
 });
@@ -50,7 +51,7 @@ describe("reconcile()", () => {
 
   it("assigns a pending task to an idle worker when blockersLoaded is true", async () => {
     const fakeWs = { send: vi.fn(), close: vi.fn(), readyState: 1 } as any;
-    Worker.register("w1", fakeWs, fakeRepo());
+    Worker.register("w1", fakeWs, fakeRepo("owner/repo", taskManager.repo.id, "active"));
 
     await Task.upsert("42", 42, "owner/repo", "T", "b", []);
     taskManager.trackIssue(42);

--- a/tests/foreman.startup.test.ts
+++ b/tests/foreman.startup.test.ts
@@ -86,6 +86,7 @@ beforeEach(async () => {
   httpServer = http.createServer();
   resetDb();
   taskManager = await createTestTaskManager("owner/repo");
+  await taskManager.repo.activate();
 });
 
 afterEach(() => {

--- a/tests/foreman.task-manager.test.ts
+++ b/tests/foreman.task-manager.test.ts
@@ -325,7 +325,7 @@ describe("TaskManager.assignIdleWorkers", () => {
     await Task.upsert("42", 42, REPO, "Fix the bug", "Body", ["brunel:ready"]);
     manager.markBlockersLoaded(42);
     const fakeWs = { send: vi.fn(), close: vi.fn(), readyState: 1 } as any;
-    Worker.register("worker-1", fakeWs, fakeRepo());
+    Worker.register("worker-1", fakeWs, fakeRepo(REPO, manager.repo.id, "active"));
 
     const outcomes = await manager.assignIdleWorkers();
 
@@ -342,7 +342,7 @@ describe("TaskManager.assignIdleWorkers", () => {
     await Task.upsert("42", 42, REPO, "Fix the bug", "Body", ["brunel:ready"]);
     manager.markBlockersLoaded(42);
     const fakeWs = { send: vi.fn(), close: vi.fn(), readyState: 1 } as any;
-    const worker = Worker.register("worker-1", fakeWs, fakeRepo());
+    const worker = Worker.register("worker-1", fakeWs, fakeRepo(REPO, manager.repo.id, "active"));
 
     await manager.assignIdleWorkers();
     expect(worker.currentTaskId).toBe("42");
@@ -352,8 +352,8 @@ describe("TaskManager.assignIdleWorkers", () => {
     await Task.upsert("42", 42, REPO, "Fix the bug", "Body", ["brunel:ready"]);
     manager.markBlockersLoaded(42);
     const fakeWs = { send: vi.fn(), close: vi.fn(), readyState: 1 } as any;
-    Worker.register("worker-1", fakeWs, fakeRepo());
-    Worker.register("worker-2", fakeWs, fakeRepo());
+    Worker.register("worker-1", fakeWs, fakeRepo(REPO, manager.repo.id, "active"));
+    Worker.register("worker-2", fakeWs, fakeRepo(REPO, manager.repo.id, "active"));
 
     // Fire both concurrently — only one worker should win the task.
     const [r1, r2] = await Promise.all([manager.assignIdleWorkers(), manager.assignIdleWorkers()]);
@@ -364,7 +364,7 @@ describe("TaskManager.assignIdleWorkers", () => {
     await Task.upsert("42", 42, REPO, "Fix the bug", "Body", ["brunel:ready"]);
     manager.markBlockersLoaded(42);
     const fakeWs = { send: vi.fn(), close: vi.fn(), readyState: 1 } as any;
-    Worker.register("worker-1", fakeWs, fakeRepo());
+    Worker.register("worker-1", fakeWs, fakeRepo(REPO, manager.repo.id, "active"));
 
     vi.spyOn(Task.prototype, "assign").mockRejectedValue(new Error("DB down"));
 
@@ -382,13 +382,34 @@ describe("TaskManager.assignIdleWorkers", () => {
     await Task.upsert("42", 42, REPO, "Fix the bug", "Body", ["brunel:ready"]);
     manager.markBlockersLoaded(42);
     const fakeWs = { send: vi.fn(), close: vi.fn(), readyState: 1 } as any;
-    Worker.register("worker-1", fakeWs, fakeRepo());
+    Worker.register("worker-1", fakeWs, fakeRepo(REPO, manager.repo.id, "active"));
 
     vi.spyOn(Task.prototype, "assign").mockRejectedValue(new Error("DB down"));
 
     // Both calls should resolve (not hang), even though assignment fails.
     await manager.assignIdleWorkers();
     await manager.assignIdleWorkers();
+  });
+
+  it("skips assignment when worker's repo is not active", async () => {
+    await Task.upsert("42", 42, REPO, "Fix the bug", "Body", ["brunel:ready"]);
+    manager.markBlockersLoaded(42);
+    const fakeWs = { send: vi.fn(), close: vi.fn(), readyState: 1 } as any;
+    Worker.register("worker-1", fakeWs, fakeRepo(REPO, manager.repo.id, "new"));
+
+    const outcomes = await manager.assignIdleWorkers();
+    expect(outcomes).toHaveLength(0);
+  });
+
+  it("skips assignment when worker's repo id does not match task's repo id", async () => {
+    await Task.upsert("42", 42, REPO, "Fix the bug", "Body", ["brunel:ready"]);
+    manager.markBlockersLoaded(42);
+    const fakeWs = { send: vi.fn(), close: vi.fn(), readyState: 1 } as any;
+    // Worker belongs to a different repo (id 999)
+    Worker.register("worker-1", fakeWs, fakeRepo("other/repo", 999, "active"));
+
+    const outcomes = await manager.assignIdleWorkers();
+    expect(outcomes).toHaveLength(0);
   });
 });
 

--- a/tests/foreman.timestamps.test.ts
+++ b/tests/foreman.timestamps.test.ts
@@ -94,6 +94,7 @@ beforeEach(async () => {
 
   resetDb();
   taskManager = await createTestTaskManager("owner/repo");
+  await taskManager.repo.activate();
   httpServer = http.createServer();
   foremanWss = new ForemanWss({ server: httpServer, config: defaultCfg });
   ({ wss } = foremanWss);

--- a/tests/foreman.webhook-routing.test.ts
+++ b/tests/foreman.webhook-routing.test.ts
@@ -244,6 +244,7 @@ beforeEach(async () => {
 
   resetDb();
   taskManager = await createTestTaskManager("owner/repo");
+  await taskManager.repo.activate();
   httpServer = http.createServer();
   foremanWss = new ForemanWss({ server: httpServer, config: defaultCfg });
   ({ wss } = foremanWss);

--- a/tests/foreman.websocket.test.ts
+++ b/tests/foreman.websocket.test.ts
@@ -88,6 +88,7 @@ beforeEach(async () => {
   Worker._reset();
   resetDb();
   taskManager = await createTestTaskManager("owner/repo");
+  await taskManager.repo.activate();
   httpServer = http.createServer();
   foremanWss = new ForemanWss({ server: httpServer, config: defaultCfg });
   ({ wss } = foremanWss);

--- a/tests/pipeline.test.ts
+++ b/tests/pipeline.test.ts
@@ -214,6 +214,7 @@ async function buildForeman(): Promise<{
 }> {
   Worker._reset();
   const taskModel = await createTestTaskManager("owner/repo");
+  await taskModel.repo.activate();
   const httpServer = http.createServer();
   const openClients: WebSocket[] = [];
 

--- a/tests/smoke.ts
+++ b/tests/smoke.ts
@@ -246,12 +246,24 @@ async function run(): Promise<void> {
   }
 
   // Send worker_hello and wait for hello_ack (status: "idle").
-  ws.send(JSON.stringify({ type: "worker_hello", repo: "owner/repo", workerId, status: "idle" }));
+  // The repo must match the webhook's repository so the task and worker are scoped to the same repo.
+  const FAKE_WORKER_REPO = "test/test";
+  ws.send(JSON.stringify({ type: "worker_hello", repo: FAKE_WORKER_REPO, workerId, status: "idle" }));
   const ack = await withTimeout(nextWsMsg(), TIMEOUT_MS, "hello_ack");
   if (ack.type !== "hello_ack" || ack.status !== "idle") {
     throw new Error(`Expected hello_ack idle, got: ${JSON.stringify(ack)}`);
   }
   process.stderr.write("[fake-worker] hello_ack received — worker is idle\n");
+
+  // If the repo is new, activate it so the foreman will assign tasks to this worker.
+  if (ack.repoStatus === "new") {
+    ws.send(JSON.stringify({ type: "activate_repo", workerId }));
+    const activated = await withTimeout(nextWsMsg(), TIMEOUT_MS, "repo_activated");
+    if (activated.type !== "repo_activated") {
+      throw new Error(`Expected repo_activated, got: ${JSON.stringify(activated)}`);
+    }
+    process.stderr.write("[fake-worker] repo activated\n");
+  }
 
   // POST a fake issues/labeled webhook to the foreman.
   const webhookPayload = JSON.stringify({


### PR DESCRIPTION
## Summary

- In `TaskManager.tryAssignWork(worker)`, skip assignment entirely when `worker.repo.status !== 'active'` — enforces the activation gate at assignment time
- Filter candidate tasks to those whose `repoId` matches `worker.repo.id` — prevents cross-repo task assignment
- Add tests for both new guards: inactive-repo skip and cross-repo mismatch skip
- Update all integration test setups (`foreman.websocket`, `foreman.startup`, `foreman.webhook-routing`, `foreman.timestamps`, `foreman.reconcile`) to activate repos before expecting task assignment, reflecting the real production flow

## Test plan

- [ ] New tests: "skips assignment when worker's repo is not active" and "skips assignment when worker's repo id does not match task's repo id" pass
- [ ] All existing 1437 tests pass (DB tests require `supabase start` and are excluded as per project convention)
- [ ] `npx tsc --noEmit` clean
- [ ] `npm run lint` clean

Closes #788

🤖 Generated with [Claude Code](https://claude.com/claude-code)