### PR TITLE
docs: document repo-scoped assignment gate and DB test isolation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,8 @@ Status is **derived from timestamps**, not stored: `completedAt` → complete, `
 
 `Task.upsert()` intentionally does not overwrite status fields on conflict, so re-syncing at startup never clobbers existing assignments.
 
+Task assignment is **repo-scoped**: `TaskManager.tryAssignWork()` only assigns a task to a worker if (a) the worker's repo status is `"active"` and (b) the task's `repoId` matches the worker's repo. Workers from inactive or mismatched repos are silently skipped.
+
 ## Worker/Foreman handshake
 
 Every `worker_hello` includes a `repo` field (owner/name parsed from `git remote get-url origin`). The foreman resolves this to a `Repo` via `Repo.findOrCreate()` and stores it on the `Worker` — every registered Worker always has a `Repo`. Missing or unresolvable repo is a fatal error.
@@ -99,5 +101,6 @@ See **`docs/type-system.md`** for the full design. In brief: one server model cl
 - **Real-time UIs**: prefer event-based designs — a model holds state and emits on change; the UI subscribes once rather than scattering manual refresh calls.
 - **Pass model objects, not IDs**: controllers look up model objects from wire message IDs first, then pass the objects to helpers.
 - **Wire types**: all live in `shared/wire.ts`, imported as `import * as Wire from "../../shared/wire.js"`.
-- **Tests**: the DB is initialised globally with an in-memory shim via `tests/setup.ts`. See test helper files in `tests/helpers/` for utilities like `seedTask()`, `resetDb()`, `createTestRepo()`, `createTestTaskManager()`, and `registerTestCommands()`. `resetDb()` also clears the TaskManager registry.
+- **Tests**: the DB is initialised globally with an in-memory shim via `tests/setup.ts`. See test helper files in `tests/helpers/` for utilities like `seedTask()`, `resetDb()`, `createTestRepo()`, `createTestTaskManager()`, and `registerTestCommands()`. `resetDb()` also clears the TaskManager registry. Any test that expects task assignment must call `await taskModel.repo.activate()` after `createTestTaskManager()`, since repos start as `"new"`.
 - **Browser tests**: the server is shared across all tests — use unique issue numbers per test rather than resetting server state.
+- **DB test isolation**: `db.*.test.ts` and `pipeline.test.ts` run in parallel against the same Supabase instance. `pipeline.test.ts` uses `task_id` values `"42"` and `"55"` — avoid those in other DB tests to prevent row-count contamination.


### PR DESCRIPTION
## Summary

- Documents the repo-scoped task assignment invariant in the Task lifecycle section: `tryAssignWork()` only assigns if the worker's repo is `"active"` and the task's `repoId` matches
- Adds a note to Key conventions that tests expecting assignment must call `await taskModel.repo.activate()` after `createTestTaskManager()`
- Warns that `db.*.test.ts` and `pipeline.test.ts` run in parallel and `pipeline.test.ts` reserves `task_id` values `"42"` and `"55"` — avoid those in other DB tests

Follows up on #835 (repo-scoped task assignment implementation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)