### PR TITLE
feat: make githubRepo optional; derive from git remote on worker side

### DIFF
--- a/scripts/backfill-tasks.ts
+++ b/scripts/backfill-tasks.ts
@@ -24,6 +24,11 @@ const dryRun = process.argv.includes("--dry-run");
 const config = await loadConfig(process.argv.slice(2).filter(a => a !== "--dry-run"));
 const { githubRepo: repo, githubToken: token, supabaseUrl, supabaseSecretKey } = config;
 
+if (!repo) {
+  console.error("ERROR: githubRepo is required for this script. Set BRUNEL_GITHUB_REPO or pass --github-repo.");
+  process.exit(1);
+}
+
 if (!supabaseUrl || !supabaseSecretKey) {
   console.error("ERROR: supabaseUrl and supabaseSecretKey are required.");
   process.exit(1);

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -27,46 +27,32 @@ import { AgentController, logFull } from "./controllers/agent-controller.js";
  */
 export class BrunelAgent {
   readonly display: Display;
+  private readonly config: BrunelConfig;
   private readonly settings: Settings;
   private readonly agentStatus: AgentStatus;
   private readonly input: Input;
   private readonly picker: Picker;
   private readonly agentController: AgentController;
-  private readonly workspaceController: WorkspaceController;
   private readonly settingsController: SettingsController;
   private readonly controller: CommandController;
+  private readonly originalCwd: string;
+  private readonly confirm: (msg: string) => Promise<boolean>;
 
   constructor(config: BrunelConfig) {
+    this.config = config;
     this.settings = new Settings(config);
     this.agentStatus = new AgentStatus({ agentId: WorkerSession.generateAgentId(), settings: this.settings });
     this.display = new Display(config, this.agentStatus);
     this.input = new Input(this.display);
     this.picker = new Picker(this.display, () => this.input.cancel());
     this.agentController = new AgentController(this.display, this.picker, this.settings);
-
-    const originalCwd = process.cwd();
-    const confirm = async (msg: string): Promise<boolean> => {
+    this.originalCwd = process.cwd();
+    this.confirm = async (msg: string): Promise<boolean> => {
       this.display.stopBar();
       this.display.print(c.amber(`\n⚠ Potential data loss:\n${msg}`));
       const idx = await this.picker.pick(["Yes, proceed", "No, cancel"]);
       return idx === 0;
     };
-
-    const workspaceCfg = (config.githubRepo && config.githubToken)
-      ? {
-          workspaceDir: config.workspaceDir ?? path.join(os.homedir(), ".brunel", "workers"),
-          repoUrl: config.repoUrl ?? `https://${config.githubToken}@github.com/${config.githubRepo}.git`,
-        }
-      : undefined;
-
-    // Construct workspace and controller once for both REPL and worker modes.
-    // In worker mode, WorkspaceController.onCreate() (called via startWorkerMode)
-    // clones the repo and changes the working directory. In REPL mode it is
-    // available for manual /workspace:* commands but not auto-cloned.
-    const workspace = workspaceCfg
-      ? new Workspace(workspaceCfg.workspaceDir, this.agentStatus.agentId, workspaceCfg.repoUrl, originalCwd, confirm)
-      : undefined;
-    this.workspaceController = new WorkspaceController(workspace, this.display, config);
 
     this.settingsController = new SettingsController(this.settings, this.display);
     const registry = new CommandRegistry();
@@ -85,8 +71,26 @@ export class BrunelAgent {
     // workspace events, create the clone, configure the WorkerSession, and
     // install signal handlers.
     const repo = runWorkerMode ? await WorkerSession.getRemoteRepo() : "";
+
+    // Build workspace config after repo detection. repoUrl can be set explicitly
+    // in config; otherwise it's derived from the detected git remote + token.
+    const { config } = this;
+    const repoUrl = config.repoUrl ?? (repo && config.githubToken
+      ? `https://${config.githubToken}@github.com/${repo}.git`
+      : undefined);
+    const workspaceCfg = repoUrl
+      ? {
+          workspaceDir: config.workspaceDir ?? path.join(os.homedir(), ".brunel", "workers"),
+          repoUrl,
+        }
+      : undefined;
+    const workspace = workspaceCfg
+      ? new Workspace(workspaceCfg.workspaceDir, this.agentStatus.agentId, workspaceCfg.repoUrl, this.originalCwd, this.confirm)
+      : undefined;
+    const workspaceController = new WorkspaceController(workspace, this.display, config);
+
     const workerCtx = runWorkerMode
-      ? await startWorkerMode(this.display, this.picker, this.workspaceController, repo)
+      ? await startWorkerMode(this.display, this.picker, workspaceController, repo)
       : undefined;
     const session = workerCtx?.session;
     const workerCleanup = workerCtx?.cleanup;
@@ -94,7 +98,7 @@ export class BrunelAgent {
     // doExit handles REPL workspace cleanup and stdin/stdout teardown.
     // Only called in REPL mode (worker mode cleanup goes through workerCleanup()).
     const doExit = async () => {
-      await this.workspaceController.onDestroy();
+      await workspaceController.onDestroy();
       process.stdout.write("\x1b[?2004l\r\n");
       if (process.stdin.isTTY) process.stdin.setRawMode(false);
       process.stdin.pause();
@@ -118,7 +122,7 @@ export class BrunelAgent {
     // Registration happens here rather than the constructor because some
     // handlers close over start()-local state (sessionId, doExit, session).
     const registry = this.controller.registry;
-    this.workspaceController.registerCommands(registry.scoped("workspace"));
+    workspaceController.registerCommands(registry.scoped("workspace"));
     registerWorkerCommands(session, registry.scoped("worker"), this.display);
     registry.register("exit", {
       description: "Exit",

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,8 +25,8 @@ const boolPreprocess = (v: unknown) => {
 const BrunelConfigSchema = z.object({
   // ── Shared (foreman + worker) ───────────────────────────────────────────────
 
-  /** GitHub repo in "owner/repo" format. Required. */
-  githubRepo:     z.string().min(1),
+  /** GitHub repo in "owner/repo" format. Optional; workers detect it from git remote automatically. */
+  githubRepo:     z.string().min(1).optional(),
   /** GitHub personal access token with `repo` scope. Required. Prefer env var over config file. */
   githubToken:    z.string().min(1),
   /** Issue label that triggers work (foreman picks up issues with this label). */
@@ -292,5 +292,5 @@ export async function loadConfig(
  * that need default values (e.g. taskLabel) without a real GitHub repo or token.
  */
 export function loadDefaultConfig(): Promise<BrunelConfig> {
-  return loadConfig([], { githubRepo: "owner/repo", githubToken: "tok" });
+  return loadConfig([], { githubToken: "tok" });
 }

--- a/src/foreman/controllers/wss.ts
+++ b/src/foreman/controllers/wss.ts
@@ -46,14 +46,14 @@ function routeResult(task: { taskId: string; workerId: string | null } | null | 
 // ── ForemanWss class ──────────────────────────────────────────────────────────
 
 type ForemanWssOptions = {
-  config: Pick<BrunelConfig, "taskLabel" | "githubRepo" | "githubToken" | "githubApiUrl" | "workerSecret" | "pingIntervalMs">;
+  config: Pick<BrunelConfig, "taskLabel" | "githubToken" | "githubApiUrl" | "workerSecret" | "pingIntervalMs">;
   server: http.Server;
   adminWss?: AdminWss;
 };
 
 export class ForemanWss {
   readonly wss: WebSocketServer;
-  private readonly config: Pick<BrunelConfig, "taskLabel" | "githubRepo" | "githubToken" | "githubApiUrl" | "workerSecret" | "pingIntervalMs">;
+  private readonly config: Pick<BrunelConfig, "taskLabel" | "githubToken" | "githubApiUrl" | "workerSecret" | "pingIntervalMs">;
   private readonly adminWss?: AdminWss;
   private nextBroadcastId = 1;
 
@@ -533,7 +533,8 @@ export class ForemanWss {
 
   /** Resolve the Repo from a webhook payload's repository.full_name, creating it if needed. */
   private async resolveRepo(p: R): Promise<Repo> {
-    const repoFullName = strProp(p.repository, "full_name") ?? this.config.githubRepo;
+    const repoFullName = strProp(p.repository, "full_name");
+    if (!repoFullName) throw new Error("Webhook payload missing repository.full_name");
     return Repo.findOrCreate(repoFullName);
   }
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -79,16 +79,16 @@ describe("defaults", () => {
 // ── Required fields ───────────────────────────────────────────────────────────
 
 describe("required field validation", () => {
-  it("exits 1 when githubRepo is missing", async () => {
-    process.env.BRUNEL_GITHUB_TOKEN = "tok";
+  it("exits 1 when githubToken is missing", async () => {
     await loadConfig(["node", "repl.js"]);
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
-  it("exits 1 when githubToken is missing", async () => {
-    process.env.BRUNEL_GITHUB_REPO = "owner/repo";
-    await loadConfig(["node", "repl.js"]);
-    expect(exitSpy).toHaveBeenCalledWith(1);
+  it("succeeds when githubRepo is omitted (it is optional)", async () => {
+    process.env.BRUNEL_GITHUB_TOKEN = "tok";
+    const cfg = await loadConfig(["node", "repl.js"]);
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(cfg.githubRepo).toBeUndefined();
   });
 });
 

--- a/tests/foreman.admin-broadcast.test.ts
+++ b/tests/foreman.admin-broadcast.test.ts
@@ -145,7 +145,7 @@ describe("foreman admin broadcast — snapshot on PR registration", () => {
         body: "Closes #42",
         head: { ref: "fix-the-bug" },
       },
-      repository: { html_url: "https://github.com/owner/repo" },
+      repository: { full_name: "owner/repo", html_url: "https://github.com/owner/repo" },
     });
 
     await waitUntil(() => snapshots.length > 0);

--- a/tests/foreman.blockers.test.ts
+++ b/tests/foreman.blockers.test.ts
@@ -61,6 +61,7 @@ describe("foreman — blocker transitions via routeEvent", () => {
     await foremanWss.routeEvent("evt-1", "issues", {
       action: "closed",
       issue: { number: 5, title: "Blocker", labels: [] },
+      repository: { full_name: "owner/repo" },
     });
 
     // Now pending
@@ -91,6 +92,7 @@ describe("foreman — blocker transitions via routeEvent", () => {
     await foremanWss.routeEvent("evt-1", "issues", {
       action: "closed",
       issue: { number: 5, title: "Blocker 5", labels: [] },
+      repository: { full_name: "owner/repo" },
     });
 
     // Task remains blocked (6 is still open)

--- a/tests/foreman.event-router.handlers.test.ts
+++ b/tests/foreman.event-router.handlers.test.ts
@@ -44,7 +44,7 @@ async function makeDeps(): Promise<TestDeps> {
   vi.spyOn(taskManager, "handlePrClosedEvent").mockResolvedValue(null);
   vi.spyOn(taskManager, "getTaskForCheckEvent").mockResolvedValue(null);
   const wss = new ForemanWss({
-    config: { taskLabel: "brunel:ready", githubRepo: "owner/repo", githubToken: "token", workerSecret: undefined, pingIntervalMs: 1e9 },
+    config: { taskLabel: "brunel:ready", githubToken: "token", workerSecret: undefined, pingIntervalMs: 1e9 },
     server: http.createServer(),
   });
   const sendMsg = vi.spyOn(wss, "sendMsg").mockImplementation(() => {});
@@ -83,7 +83,7 @@ describe("routePrEvent — synchronize", () => {
     await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, repo_id: testRepoId });
     const { wss, sendMsg, forwardEvent } = await makeDeps();
     const result = await wss.routePrEvent(
-      { action: "synchronize", pull_request: { number: 99 } },
+      { action: "synchronize", pull_request: { number: 99 }, repository: { full_name: "owner/repo" } },
       makeEvent(),
     );
     expect(result.taskId).toBe("42");
@@ -107,6 +107,7 @@ describe("routePrEvent — opened", () => {
           body: "Closes #42",
           head: { ref: "feature-branch" },
         },
+        repository: { full_name: "owner/repo" },
       },
       makeEvent(),
     );
@@ -120,7 +121,7 @@ describe("routePrEvent — opened", () => {
     const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
     taskManager.handlePrOpenedEvent.mockResolvedValue(null);
     const result = await wss.routePrEvent(
-      { action: "opened", pull_request: { number: 99, body: "no link here", head: { ref: "branch" } } },
+      { action: "opened", pull_request: { number: 99, body: "no link here", head: { ref: "branch" } }, repository: { full_name: "owner/repo" } },
       makeEvent(),
     );
     expect(result).toEqual({ taskId: null, workerId: null });
@@ -137,7 +138,7 @@ describe("routePrEvent — closed without merge", () => {
     const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
     taskManager.handlePrClosedEvent.mockResolvedValue(task);
     const result = await wss.routePrEvent(
-      { action: "closed", pull_request: { number: 99, merged: false } },
+      { action: "closed", pull_request: { number: 99, merged: false }, repository: { full_name: "owner/repo" } },
       makeEvent(),
     );
     expect(taskManager.handlePrClosedEvent).toHaveBeenCalledWith(99, false);
@@ -150,7 +151,7 @@ describe("routePrEvent — closed without merge", () => {
     const { wss, forwardEvent, taskManager } = await makeDeps();
     taskManager.handlePrClosedEvent.mockResolvedValue(null);
     const result = await wss.routePrEvent(
-      { action: "closed", pull_request: { number: 99, merged: false } },
+      { action: "closed", pull_request: { number: 99, merged: false }, repository: { full_name: "owner/repo" } },
       makeEvent(),
     );
     expect(result).toEqual({ taskId: null, workerId: null });
@@ -166,7 +167,7 @@ describe("routePrEvent — closed with merge", () => {
     const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
     taskManager.handlePrClosedEvent.mockResolvedValue(task);
     const result = await wss.routePrEvent(
-      { action: "closed", pull_request: { number: 99, merged: true } },
+      { action: "closed", pull_request: { number: 99, merged: true }, repository: { full_name: "owner/repo" } },
       makeEvent(),
     );
     expect(taskManager.handlePrClosedEvent).toHaveBeenCalledWith(99, true);
@@ -178,7 +179,7 @@ describe("routePrEvent — closed with merge", () => {
   it("returns null when no task owns the PR", async () => {
     const { wss, forwardEvent } = await makeDeps();
     const result = await wss.routePrEvent(
-      { action: "closed", pull_request: { number: 99, merged: true } },
+      { action: "closed", pull_request: { number: 99, merged: true }, repository: { full_name: "owner/repo" } },
       makeEvent(),
     );
     expect(result).toEqual({ taskId: null, workerId: null });
@@ -193,7 +194,7 @@ describe("routePrEvent — passthrough", () => {
     w.assign(task);
     const { wss, sendMsg, forwardEvent } = await makeDeps();
     const result = await wss.routePrEvent(
-      { action: "labeled", pull_request: { number: 99 } },
+      { action: "labeled", pull_request: { number: 99 }, repository: { full_name: "owner/repo" } },
       makeEvent(),
     );
     expect(forwardEvent).toHaveBeenCalledOnce();
@@ -204,7 +205,7 @@ describe("routePrEvent — passthrough", () => {
   it("returns null task when no task owns the PR", async () => {
     const { wss, forwardEvent } = await makeDeps();
     const result = await wss.routePrEvent(
-      { action: "labeled", pull_request: { number: 99 } },
+      { action: "labeled", pull_request: { number: 99 }, repository: { full_name: "owner/repo" } },
       makeEvent(),
     );
     expect(result).toEqual({ taskId: null, workerId: null });
@@ -228,7 +229,7 @@ describe("routePrReviewEvent", () => {
     w.assign(task);
     const { wss, sendMsg, forwardEvent } = await makeDeps();
     const result = await wss.routePrReviewEvent(
-      { pull_request: { number: 99 } },
+      { pull_request: { number: 99 }, repository: { full_name: "owner/repo" } },
       makeEvent("pull_request_review"),
     );
     expect(forwardEvent).toHaveBeenCalledOnce();
@@ -239,7 +240,7 @@ describe("routePrReviewEvent", () => {
   it("returns null when no task owns the reviewed PR", async () => {
     const { wss, forwardEvent } = await makeDeps();
     const result = await wss.routePrReviewEvent(
-      { pull_request: { number: 99 } },
+      { pull_request: { number: 99 }, repository: { full_name: "owner/repo" } },
       makeEvent("pull_request_review"),
     );
     expect(result).toEqual({ taskId: null, workerId: null });
@@ -257,7 +258,7 @@ describe("routeCheckEvent — via PR number", () => {
     const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
     taskManager.getTaskForCheckEvent.mockResolvedValue({ task, ref: "PR #99" });
     const result = await wss.routeCheckEvent(
-      { check_run: { pull_requests: [{ number: 99 }] } },
+      { check_run: { pull_requests: [{ number: 99 }] }, repository: { full_name: "owner/repo" } },
       makeEvent("check_run"),
       "check_run",
     );
@@ -274,7 +275,7 @@ describe("routeCheckEvent — via PR number", () => {
     const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
     taskManager.getTaskForCheckEvent.mockResolvedValue({ task, ref: "PR #99" });
     const result = await wss.routeCheckEvent(
-      { check_suite: { pull_requests: [{ number: 99 }] } },
+      { check_suite: { pull_requests: [{ number: 99 }] }, repository: { full_name: "owner/repo" } },
       makeEvent("check_suite"),
       "check_suite",
     );
@@ -293,7 +294,7 @@ describe("routeCheckEvent — via branch name", () => {
     const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
     taskManager.getTaskForCheckEvent.mockResolvedValue({ task, ref: "branch feature-branch" });
     const result = await wss.routeCheckEvent(
-      { check_run: { pull_requests: [], check_suite: { head_branch: "feature-branch" } } },
+      { check_run: { pull_requests: [], check_suite: { head_branch: "feature-branch" } }, repository: { full_name: "owner/repo" } },
       makeEvent("check_run"),
       "check_run",
     );
@@ -310,7 +311,7 @@ describe("routeCheckEvent — via branch name", () => {
     const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
     taskManager.getTaskForCheckEvent.mockResolvedValue({ task, ref: "branch feature-branch" });
     const result = await wss.routeCheckEvent(
-      { check_suite: { pull_requests: [], head_branch: "feature-branch" } },
+      { check_suite: { pull_requests: [], head_branch: "feature-branch" }, repository: { full_name: "owner/repo" } },
       makeEvent("check_suite"),
       "check_suite",
     );
@@ -323,7 +324,7 @@ describe("routeCheckEvent — via branch name", () => {
   it("returns null when getTaskForCheckEvent finds nothing", async () => {
     const { wss, forwardEvent } = await makeDeps();
     const result = await wss.routeCheckEvent(
-      { check_run: { pull_requests: [], check_suite: { head_branch: "unknown-branch" } } },
+      { check_run: { pull_requests: [], check_suite: { head_branch: "unknown-branch" } }, repository: { full_name: "owner/repo" } },
       makeEvent("check_run"),
       "check_run",
     );
@@ -361,7 +362,7 @@ describe("routeIssueEvent — enqueue on labeled", () => {
     taskManager.handleIssueLabeledEvent.mockResolvedValue(null);
     const issue = { number: 42, title: "Do something", body: "", state: "closed", labels: [{ name: "brunel:ready" }] };
     const result = await wss.routeIssueEvent(
-      { action: "labeled", label: { name: "brunel:ready" } },
+      { action: "labeled", label: { name: "brunel:ready" }, repository: { full_name: "owner/repo" } },
       makeEvent("issues"),
       issue,
       42,
@@ -375,7 +376,7 @@ describe("routeIssueEvent — enqueue on labeled", () => {
     const { wss, forwardEvent, taskManager } = await makeDeps();
     const issue = { number: 42, title: "Do something", body: "", state: "open", labels: [] };
     const result = await wss.routeIssueEvent(
-      { action: "labeled", label: { name: "other-label" } },
+      { action: "labeled", label: { name: "other-label" }, repository: { full_name: "owner/repo" } },
       makeEvent("issues"),
       issue,
       42,
@@ -407,7 +408,7 @@ describe("routeIssueEvent — enqueue on opened", () => {
     const { wss, forwardEvent, taskManager } = await makeDeps();
     const issue = { number: 42, title: "Do something", body: "", state: "open", labels: [] };
     const result = await wss.routeIssueEvent(
-      { action: "opened" },
+      { action: "opened", repository: { full_name: "owner/repo" } },
       makeEvent("issues"),
       issue,
       42,
@@ -424,7 +425,7 @@ describe("routeIssueEvent — unlabeled (dequeue)", () => {
     const { wss, forwardEvent, taskManager } = await makeDeps();
     const issue = { number: 42 };
     await wss.routeIssueEvent(
-      { action: "unlabeled", label: { name: "brunel:ready" } },
+      { action: "unlabeled", label: { name: "brunel:ready" }, repository: { full_name: "owner/repo" } },
       makeEvent("issues"),
       issue,
       42,
@@ -440,7 +441,7 @@ describe("routeIssueEvent — unlabeled (dequeue)", () => {
     const { wss, forwardEvent, taskManager } = await makeDeps();
     const issue = { number: 42 };
     await wss.routeIssueEvent(
-      { action: "unlabeled", label: { name: "other-label" } },
+      { action: "unlabeled", label: { name: "other-label" }, repository: { full_name: "owner/repo" } },
       makeEvent("issues"),
       issue,
       42,
@@ -456,7 +457,7 @@ describe("routeIssueEvent — closed", () => {
     const { wss, forwardEvent, taskManager } = await makeDeps();
     const issue = { number: 42 };
     await wss.routeIssueEvent(
-      { action: "closed" },
+      { action: "closed", repository: { full_name: "owner/repo" } },
       makeEvent("issues"),
       issue,
       42,
@@ -471,7 +472,7 @@ describe("routeIssueEvent — closed", () => {
     const { wss, forwardEvent, taskManager } = await makeDeps();
     const issue = { number: 42 };
     await wss.routeIssueEvent(
-      { action: "closed" },
+      { action: "closed", repository: { full_name: "owner/repo" } },
       makeEvent("issues"),
       issue,
       42,
@@ -486,7 +487,7 @@ describe("routeIssueEvent — reopened", () => {
     const { wss, forwardEvent, taskManager } = await makeDeps();
     const issue = { number: 42 };
     await wss.routeIssueEvent(
-      { action: "reopened" },
+      { action: "reopened", repository: { full_name: "owner/repo" } },
       makeEvent("issues"),
       issue,
       42,
@@ -501,7 +502,7 @@ describe("routeIssueEvent — reopened", () => {
     const { wss, forwardEvent, taskManager } = await makeDeps();
     const issue = { number: 42 };
     await wss.routeIssueEvent(
-      { action: "reopened" },
+      { action: "reopened", repository: { full_name: "owner/repo" } },
       makeEvent("issues"),
       issue,
       42,
@@ -517,7 +518,7 @@ describe("routeIssueEvent — edited", () => {
     const { wss, forwardEvent, taskManager } = await makeDeps();
     const issue = { number: 42, body: "updated body" };
     await wss.routeIssueEvent(
-      { action: "edited", changes: { body: { from: "old body" } } },
+      { action: "edited", changes: { body: { from: "old body" } }, repository: { full_name: "owner/repo" } },
       makeEvent("issues"),
       issue,
       42,
@@ -533,7 +534,7 @@ describe("routeIssueEvent — edited", () => {
     const { wss, forwardEvent, taskManager } = await makeDeps();
     const issue = { number: 42, title: "updated title" };
     await wss.routeIssueEvent(
-      { action: "edited", changes: { title: { from: "old title" } } },
+      { action: "edited", changes: { title: { from: "old title" } }, repository: { full_name: "owner/repo" } },
       makeEvent("issues"),
       issue,
       42,
@@ -547,7 +548,7 @@ describe("routeIssueEvent — edited", () => {
     const { wss, forwardEvent, taskManager } = await makeDeps();
     const issue = { number: 42, body: "updated body" };
     await wss.routeIssueEvent(
-      { action: "edited", changes: { body: { from: "old body" } } },
+      { action: "edited", changes: { body: { from: "old body" } }, repository: { full_name: "owner/repo" } },
       makeEvent("issues"),
       issue,
       42,
@@ -560,7 +561,7 @@ describe("routeIssueEvent — edited", () => {
     await seedTask({ task_id: "42", issue_number: 42, repo_id: testRepoId, body: "original body" });
     const { wss } = await makeDeps();
     await wss.routeIssueEvent(
-      { action: "edited", changes: { body: { from: "original body" } } },
+      { action: "edited", changes: { body: { from: "original body" } }, repository: { full_name: "owner/repo" } },
       makeEvent("issues"),
       { number: 42, body: "updated body" },
       42,
@@ -573,7 +574,7 @@ describe("routeIssueEvent — edited", () => {
     await seedTask({ task_id: "42", issue_number: 42, repo_id: testRepoId, title: "original title" });
     const { wss } = await makeDeps();
     await wss.routeIssueEvent(
-      { action: "edited", changes: { title: { from: "original title" } } },
+      { action: "edited", changes: { title: { from: "original title" } }, repository: { full_name: "owner/repo" } },
       makeEvent("issues"),
       { number: 42, title: "updated title" },
       42,
@@ -591,7 +592,7 @@ describe("routeIssueEvent — passthrough forwarding", () => {
     const { wss, sendMsg, forwardEvent } = await makeDeps();
     const issue = { number: 42 };
     const result = await wss.routeIssueEvent(
-      { action: "assigned" },
+      { action: "assigned", repository: { full_name: "owner/repo" } },
       makeEvent("issues"),
       issue,
       42,
@@ -608,7 +609,7 @@ describe("routeIssueEvent — passthrough forwarding", () => {
     const { wss, sendMsg, forwardEvent } = await makeDeps();
     const issue = { number: 99 }; // PR number in issue.number
     const result = await wss.routeIssueEvent(
-      { action: "created" },
+      { action: "created", repository: { full_name: "owner/repo" } },
       makeEvent("issue_comment"),
       issue,
       99,

--- a/tests/foreman.event-router.test.ts
+++ b/tests/foreman.event-router.test.ts
@@ -30,7 +30,7 @@ function makeEvent(name = "issue_comment"): WebhookEvent {
 
 function makeWss(_taskManager?: any): { wss: ForemanWss; sendMsg: ReturnType<typeof vi.fn> } {
   const wss = new ForemanWss({
-    config: { taskLabel: "brunel:ready", githubRepo: "owner/repo", githubToken: "token", workerSecret: undefined, pingIntervalMs: 1e9 },
+    config: { taskLabel: "brunel:ready", githubToken: "token", workerSecret: undefined, pingIntervalMs: 1e9 },
     server: http.createServer(),
   });
   const sendMsg = vi.spyOn(wss, "sendMsg").mockImplementation(() => {});

--- a/tests/foreman.github.test.ts
+++ b/tests/foreman.github.test.ts
@@ -13,7 +13,6 @@ const mockIssues = [
 beforeEach(() => {
   Worker._reset();
   vi.stubGlobal("fetch", vi.fn());
-  getConfig().githubRepo = "owner/repo";
   getConfig().githubToken = "token123";
   getConfig().taskLabel = "brunel:ready";
 });

--- a/tests/foreman.hello-handlers.test.ts
+++ b/tests/foreman.hello-handlers.test.ts
@@ -24,7 +24,7 @@ function fakeWs() {
 
 function makeWss(taskManager: TaskManager) {
   const wss = new ForemanWss({
-    config: { taskLabel: "brunel:ready", githubRepo: "owner/repo", githubToken: "token", workerSecret: undefined, pingIntervalMs: 1e9 },
+    config: { taskLabel: "brunel:ready", githubToken: "token", workerSecret: undefined, pingIntervalMs: 1e9 },
     server: http.createServer(),
   });
   const sendMsg = vi.spyOn(wss, "sendMsg").mockImplementation(() => {});
@@ -497,7 +497,7 @@ describe("repoStatus in hello_ack", () => {
 describe("activate_repo", () => {
   function makeWssForActivate() {
     const wss = new ForemanWss({
-      config: { taskLabel: "brunel:ready", githubRepo: "owner/repo", githubToken: "token", workerSecret: undefined, pingIntervalMs: 1e9 },
+      config: { taskLabel: "brunel:ready", githubToken: "token", workerSecret: undefined, pingIntervalMs: 1e9 },
       server: http.createServer(),
     });
     const sendMsg = vi.spyOn(wss, "sendMsg").mockImplementation(() => {});

--- a/tests/foreman.reconcile.test.ts
+++ b/tests/foreman.reconcile.test.ts
@@ -97,6 +97,7 @@ describe("issues/closed — task lifecycle", () => {
     await foremanWss.routeEvent("evt-1", "issues", {
       action: "closed",
       issue: { number: 142, title: "T", body: "", labels: [] },
+      repository: { full_name: "owner/repo" },
     });
 
     expect((await Task.get("142"))?.status).toBe("closed");
@@ -112,6 +113,7 @@ describe("issues/closed — task lifecycle", () => {
     await foremanWss.routeEvent("evt-1", "issues", {
       action: "closed",
       issue: { number: 143, title: "T", body: "", labels: [] },
+      repository: { full_name: "owner/repo" },
     });
 
     expect((await Task.get("143"))?.status).toBe("complete");
@@ -125,6 +127,7 @@ describe("issues/closed — task lifecycle", () => {
     await foremanWss.routeEvent("evt-1", "issues", {
       action: "closed",
       issue: { number: 144, title: "T", body: "", labels: [] },
+      repository: { full_name: "owner/repo" },
     });
 
     expect(await Task.get("144")).toBeNull();
@@ -141,6 +144,7 @@ describe("issues/closed — task lifecycle", () => {
     await foremanWss.routeEvent("evt-1", "issues", {
       action: "closed",
       issue: { number: 145, title: "T", body: "", labels: [] },
+      repository: { full_name: "owner/repo" },
     });
 
     expect((await Task.get("145"))?.status).toBe("closed");
@@ -156,6 +160,7 @@ describe("issues/closed — task lifecycle", () => {
     await foremanWss.routeEvent("evt-1", "issues", {
       action: "closed",
       issue: { number: 42, title: "T", body: "", labels: [] },
+      repository: { full_name: "owner/repo" },
     });
 
     await new Promise((r) => setImmediate(r));
@@ -180,7 +185,7 @@ describe("startDepsLoad() error handling", () => {
         body: "body",
         labels: [{ name: TASK_LABEL }],
       },
-      repository: { html_url: "https://github.com/o/r" },
+      repository: { full_name: "owner/repo", html_url: "https://github.com/o/r" },
     });
 
     expect(taskManager.isBlockersLoaded(42)).toBe(false);

--- a/tests/foreman.repo-filter.test.ts
+++ b/tests/foreman.repo-filter.test.ts
@@ -38,7 +38,7 @@ function makeTaskManager() {
 
 function makeWss(taskManager: ReturnType<typeof makeTaskManager>) {
   const wss = new ForemanWss({
-    config: { taskLabel: "brunel:ready", githubRepo: "owner/repo", githubToken: "token", workerSecret: undefined, pingIntervalMs: 1e9 },
+    config: { taskLabel: "brunel:ready", githubToken: "token", workerSecret: undefined, pingIntervalMs: 1e9 },
     taskManager: taskManager as any,
     server: http.createServer(),
   });

--- a/tests/foreman.startup.test.ts
+++ b/tests/foreman.startup.test.ts
@@ -241,6 +241,7 @@ describe("PR tracking persistence", () => {
         body: "Fixes #42\n\nSome work.",
         head: { ref: "fix-issue-42" },
       },
+      repository: { full_name: "owner/repo" },
     });
 
     expect(spyRegisterPr).toHaveBeenCalledWith(10, "fix-issue-42");
@@ -263,6 +264,7 @@ describe("PR tracking persistence", () => {
         body: "Fixes #42",
         head: {}, // no ref
       },
+      repository: { full_name: "owner/repo" },
     });
 
     expect(spyRegisterPr).toHaveBeenCalledWith(10, null);

--- a/tests/foreman.timestamps.test.ts
+++ b/tests/foreman.timestamps.test.ts
@@ -171,7 +171,7 @@ describe("foreman log timestamps", () => {
 
     logLines.length = 0;
     const reply = nextMsg(ws);
-    foremanWss.routeEvent("evt-1", "issue_comment", { issue: { number: 1 }, comment: { body: "hi" } });
+    foremanWss.routeEvent("evt-1", "issue_comment", { issue: { number: 1 }, comment: { body: "hi" }, repository: { full_name: "owner/repo" } });
     await reply;
 
     for (const line of logLines) {
@@ -189,7 +189,7 @@ describe("foreman log timestamps", () => {
       action: "labeled",
       label: { name: "brunel:ready" },
       issue: { number: 5, title: "Do something", body: "", labels: [{ name: "brunel:ready" }] },
-      repository: { html_url: "https://github.com/owner/repo" },
+      repository: { full_name: "owner/repo", html_url: "https://github.com/owner/repo" },
     });
     // give a tick for async processing
     await new Promise((r) => setTimeout(r, 10));

--- a/tests/foreman.webhook-routing.test.ts
+++ b/tests/foreman.webhook-routing.test.ts
@@ -86,7 +86,7 @@ function labeledPayload(issueNumber: number, labelName: string) {
       body: `Body of issue ${issueNumber}`,
       labels: [{ name: labelName }],
     },
-    repository: { html_url: "https://github.com/owner/repo" },
+    repository: { full_name: "owner/repo", html_url: "https://github.com/owner/repo" },
   };
 }
 
@@ -99,7 +99,7 @@ function openedPayload(issueNumber: number, labels: string[]) {
       body: `Body of issue ${issueNumber}`,
       labels: labels.map((name) => ({ name })),
     },
-    repository: { html_url: "https://github.com/owner/repo" },
+    repository: { full_name: "owner/repo", html_url: "https://github.com/owner/repo" },
   };
 }
 
@@ -112,7 +112,7 @@ function prOpenedPayload(prNumber: number, body: string, headBranch = `branch-fo
       body,
       head: { ref: headBranch },
     },
-    repository: { html_url: "https://github.com/owner/repo" },
+    repository: { full_name: "owner/repo", html_url: "https://github.com/owner/repo" },
   };
 }
 
@@ -127,7 +127,7 @@ function checkRunPayloadByBranch(headBranch: string, conclusion: string) {
       pull_requests: [],
       check_suite: { head_branch: headBranch },
     },
-    repository: { html_url: "https://github.com/owner/repo" },
+    repository: { full_name: "owner/repo", html_url: "https://github.com/owner/repo" },
   };
 }
 
@@ -139,7 +139,7 @@ function checkSuitePayloadByBranch(headBranch: string, conclusion: string) {
       pull_requests: [],
       head_branch: headBranch,
     },
-    repository: { html_url: "https://github.com/owner/repo" },
+    repository: { full_name: "owner/repo", html_url: "https://github.com/owner/repo" },
   };
 }
 
@@ -152,7 +152,7 @@ function checkRunPayload(prNumber: number, conclusion: string) {
       output: { summary: "Test output" },
       pull_requests: [{ number: prNumber }],
     },
-    repository: { html_url: "https://github.com/owner/repo" },
+    repository: { full_name: "owner/repo", html_url: "https://github.com/owner/repo" },
   };
 }
 
@@ -165,7 +165,7 @@ function prClosedPayload(prNumber: number, merged: boolean) {
       merged,
       head: { ref: `branch-for-pr-${prNumber}` },
     },
-    repository: { html_url: "https://github.com/owner/repo" },
+    repository: { full_name: "owner/repo", html_url: "https://github.com/owner/repo" },
   };
 }
 
@@ -179,7 +179,7 @@ function prEditedPayload(prNumber: number, newBody: string, headBranch = `branch
       head: { ref: headBranch },
     },
     changes: { body: { from: "old body without closing keyword" } },
-    repository: { html_url: "https://github.com/owner/repo" },
+    repository: { full_name: "owner/repo", html_url: "https://github.com/owner/repo" },
   };
 }
 
@@ -188,7 +188,7 @@ function prReviewPayload(prNumber: number) {
     action: "submitted",
     pull_request: { number: prNumber, title: "PR title" },
     review: { state: "changes_requested", body: "Please fix this." },
-    repository: { html_url: "https://github.com/owner/repo" },
+    repository: { full_name: "owner/repo", html_url: "https://github.com/owner/repo" },
   };
 }
 
@@ -197,7 +197,7 @@ function prReviewCommentPayload(prNumber: number) {
     action: "created",
     pull_request: { number: prNumber, title: "PR title" },
     comment: { body: "Nit: rename this", path: "src/foo.ts" },
-    repository: { html_url: "https://github.com/owner/repo" },
+    repository: { full_name: "owner/repo", html_url: "https://github.com/owner/repo" },
   };
 }
 
@@ -206,7 +206,7 @@ function issueCommentPayload(prOrIssueNumber: number, body = "LGTM") {
     action: "created",
     issue: { number: prOrIssueNumber, title: `Issue/PR ${prOrIssueNumber}`, pull_request: {} },
     comment: { body, user: { login: "reviewer" } },
-    repository: { html_url: "https://github.com/owner/repo" },
+    repository: { full_name: "owner/repo", html_url: "https://github.com/owner/repo" },
   };
 }
 
@@ -217,7 +217,7 @@ function checkSuitePayload(prNumber: number, conclusion: string) {
       conclusion,
       pull_requests: [{ number: prNumber }],
     },
-    repository: { html_url: "https://github.com/owner/repo" },
+    repository: { full_name: "owner/repo", html_url: "https://github.com/owner/repo" },
   };
 }
 
@@ -568,7 +568,7 @@ describe("PR event forwarding to workers", () => {
       action: "edited",
       pull_request: { number: 10, title: "PR 10 (updated title)", body: "Closes #42", head: { ref: "branch-for-pr-10" } },
       changes: { title: { from: "PR 10" } }, // no body change
-      repository: { html_url: "https://github.com/owner/repo" },
+      repository: { full_name: "owner/repo", html_url: "https://github.com/owner/repo" },
     });
     const msg = await reply;
     expect(msg.type).toBe("event_notification");
@@ -760,7 +760,7 @@ describe("foreman event filtering", () => {
     foremanWss.routeEvent("evt-sync", "pull_request", {
       action: "synchronize",
       pull_request: { number: 10, title: "PR 10", body: "Closes #42", head: { ref: "branch" } },
-      repository: { html_url: "https://github.com/owner/repo" },
+      repository: { full_name: "owner/repo", html_url: "https://github.com/owner/repo" },
     });
 
     const raceResult = await Promise.race([
@@ -782,7 +782,7 @@ describe("foreman event filtering", () => {
       action: "unlabeled",
       label: { name: "brunel:ready" },
       issue: { number: 42, title: "Issue 42", body: "Body", labels: [] },
-      repository: { html_url: "https://github.com/owner/repo" },
+      repository: { full_name: "owner/repo", html_url: "https://github.com/owner/repo" },
     });
     // Allow async processing to complete
     await new Promise((r) => setTimeout(r, 50));
@@ -806,7 +806,7 @@ describe("foreman event filtering", () => {
       action: "unlabeled",
       label: { name: "brunel:ready" },
       issue: { number: 42, title: "Issue 42", body: "Body", labels: [] },
-      repository: { html_url: "https://github.com/owner/repo" },
+      repository: { full_name: "owner/repo", html_url: "https://github.com/owner/repo" },
     });
     // Allow async processing
     await new Promise((r) => setTimeout(r, 50));
@@ -824,7 +824,7 @@ describe("foreman event filtering", () => {
       action: "unlabeled",
       label: { name: "some-other-label" },
       issue: { number: 42, title: "Issue 42", body: "Body", labels: [{ name: "brunel:ready" }] },
-      repository: { html_url: "https://github.com/owner/repo" },
+      repository: { full_name: "owner/repo", html_url: "https://github.com/owner/repo" },
     });
     // Allow async processing
     await new Promise((r) => setTimeout(r, 50));
@@ -846,7 +846,7 @@ describe("foreman event filtering", () => {
         state: "closed",
         labels: [{ name: "brunel:ready" }],
       },
-      repository: { html_url: "https://github.com/owner/repo" },
+      repository: { full_name: "owner/repo", html_url: "https://github.com/owner/repo" },
     });
     // Allow async processing
     await new Promise((r) => setTimeout(r, 50));
@@ -865,7 +865,7 @@ describe("foreman event filtering", () => {
     foremanWss.routeEvent("evt-closed", "issues", {
       action: "closed",
       issue: { number: 42, title: "Issue 42", body: "Body", labels: [{ name: "brunel:ready" }] },
-      repository: { html_url: "https://github.com/owner/repo" },
+      repository: { full_name: "owner/repo", html_url: "https://github.com/owner/repo" },
     });
     const msg = await reply;
     expect((msg as any).event.payload.action).toBe("closed");
@@ -882,7 +882,7 @@ describe("foreman event filtering", () => {
     foremanWss.routeEvent("evt-reopened", "issues", {
       action: "reopened",
       issue: { number: 42, title: "Issue 42", body: "Body", labels: [{ name: "brunel:ready" }] },
-      repository: { html_url: "https://github.com/owner/repo" },
+      repository: { full_name: "owner/repo", html_url: "https://github.com/owner/repo" },
     });
     const msg = await reply;
     expect((msg as any).event.payload.action).toBe("reopened");

--- a/tests/foreman.websocket.test.ts
+++ b/tests/foreman.websocket.test.ts
@@ -296,7 +296,7 @@ describe("foreman WebSocket protocol", () => {
     await nextMsg(ws); // task_assigned
 
     const reply = nextMsg(ws);
-    foremanWss.routeEvent("evt-1", "issue_comment", { issue: { number: 1 }, comment: { body: "hi" } });
+    foremanWss.routeEvent("evt-1", "issue_comment", { issue: { number: 1 }, comment: { body: "hi" }, repository: { full_name: "owner/repo" } });
     const msg = await reply;
     assert(msg.type === "event_notification");
     expect(msg.taskId).toBe("1");
@@ -305,7 +305,7 @@ describe("foreman WebSocket protocol", () => {
 
   it("routeEvent queues event when no worker is assigned", async () => {
     await makeTask(taskManager, 1);
-    await foremanWss.routeEvent("evt-1", "issue_comment", { issue: { number: 1 } });
+    await foremanWss.routeEvent("evt-1", "issue_comment", { issue: { number: 1 }, repository: { full_name: "owner/repo" } });
     const t = await Task.get("1");
     const events = taskManager.drainEvents(t!);
     expect(events).toHaveLength(1);
@@ -411,7 +411,7 @@ describe("foreman WebSocket protocol", () => {
       nextMsg(wsB).then(() => "message" as const),
       new Promise<"timeout">((r) => setTimeout(() => r("timeout"), 50)),
     ]);
-    foremanWss.routeEvent("evt-1", "issue_comment", { issue: { number: taskA }, comment: { body: "update" } });
+    foremanWss.routeEvent("evt-1", "issue_comment", { issue: { number: taskA }, comment: { body: "update" }, repository: { full_name: "owner/repo" } });
     expect(await replyA).toMatchObject({ type: "event_notification", taskId: String(taskA) });
     expect(await noMsgB).toBe("timeout");
 
@@ -420,7 +420,7 @@ describe("foreman WebSocket protocol", () => {
       nextMsg(wsA).then(() => "message" as const),
       new Promise<"timeout">((r) => setTimeout(() => r("timeout"), 50)),
     ]);
-    foremanWss.routeEvent("evt-2", "issue_comment", { issue: { number: taskB }, comment: { body: "update" } });
+    foremanWss.routeEvent("evt-2", "issue_comment", { issue: { number: taskB }, comment: { body: "update" }, repository: { full_name: "owner/repo" } });
     expect(await replyB).toMatchObject({ type: "event_notification", taskId: String(taskB) });
     expect(await noMsgA).toBe("timeout");
   });
@@ -514,7 +514,7 @@ describe("hello_ack handshake", () => {
     const t = await Task.get("1");
     const fakeWs = { send: vi.fn(), close: vi.fn(), readyState: 1 } as any;
     { const w = Worker.register("w1", fakeWs, fakeRepo()); await t!.assign(w); w.assign(t!); w.markDisconnected(); }
-    await foremanWss.routeEvent("evt-1", "issue_comment", { issue: { number: 1 } });
+    await foremanWss.routeEvent("evt-1", "issue_comment", { issue: { number: 1 }, repository: { full_name: "owner/repo" } });
 
     const ws = await connect();
     const messages: Wire.ForemanMessage[] = [];
@@ -589,6 +589,7 @@ describe("dependency-aware task assignment", () => {
     foremanWss.routeEvent("evt-1", "issues", {
       action: "closed",
       issue: { number: 10, title: "Blocker", body: "", labels: [] },
+      repository: { full_name: "owner/repo" },
     });
     expect(await reply).toMatchObject({ type: "task_assigned", taskId: "42" });
   });
@@ -600,6 +601,7 @@ describe("dependency-aware task assignment", () => {
     foremanWss.routeEvent("evt-1", "issues", {
       action: "reopened",
       issue: { number: 10, title: "Blocker", body: "", labels: [] },
+      repository: { full_name: "owner/repo" },
     });
 
     const ws = await connect();
@@ -837,7 +839,7 @@ describe("disconnected worker state", () => {
     await closeClient(ws);
     await waitUntil(() => Worker.get("w1")?.status === "disconnected");
 
-    await foremanWss.routeEvent("evt-1", "issue_comment", { issue: { number: 1 }, comment: { body: "hi" } });
+    await foremanWss.routeEvent("evt-1", "issue_comment", { issue: { number: 1 }, comment: { body: "hi" }, repository: { full_name: "owner/repo" } });
 
     const t = await Task.get("1");
     const queued = taskManager.drainEvents(t!);
@@ -854,7 +856,7 @@ describe("disconnected worker state", () => {
     await closeClient(ws1);
     await waitUntil(() => Worker.get("w1")?.status === "disconnected");
 
-    await foremanWss.routeEvent("evt-1", "issue_comment", { issue: { number: 1 }, comment: { body: "hi" } });
+    await foremanWss.routeEvent("evt-1", "issue_comment", { issue: { number: 1 }, comment: { body: "hi" }, repository: { full_name: "owner/repo" } });
 
     const ws2 = await connect();
     const q2 = makeQueue(ws2);
@@ -1019,7 +1021,7 @@ describe("issues/closed — close persistence", () => {
     taskManager.trackIssue(1);
     taskManager.markBlockersLoaded(1);
 
-    await foremanWss.routeEvent("evt-1", "issues", { action: "closed", issue: { number: 1, title: "T", body: "", labels: [] } });
+    await foremanWss.routeEvent("evt-1", "issues", { action: "closed", issue: { number: 1, title: "T", body: "", labels: [] }, repository: { full_name: "owner/repo" } });
 
     await waitUntil(() => spyClose.mock.calls.length > 0);
     expect(spyClose).toHaveBeenCalled();

--- a/tests/pipeline.test.ts
+++ b/tests/pipeline.test.ts
@@ -103,7 +103,7 @@ function labeledPayload(issueNumber: number, body = "") {
       body,
       labels: [{ name: "brunel:ready" }],
     },
-    repository: { html_url: "https://github.com/owner/repo" },
+    repository: { full_name: "owner/repo", html_url: "https://github.com/owner/repo" },
   };
 }
 
@@ -116,7 +116,7 @@ function closedPayload(issueNumber: number) {
       body: "",
       labels: [],
     },
-    repository: { html_url: "https://github.com/owner/repo" },
+    repository: { full_name: "owner/repo", html_url: "https://github.com/owner/repo" },
   };
 }
 
@@ -133,7 +133,7 @@ function prOpenedPayload(
       body,
       head: { ref: headBranch },
     },
-    repository: { html_url: "https://github.com/owner/repo" },
+    repository: { full_name: "owner/repo", html_url: "https://github.com/owner/repo" },
   };
 }
 
@@ -146,7 +146,7 @@ function checkRunPayload(prNumber: number) {
       output: { summary: "" },
       pull_requests: [{ number: prNumber }],
     },
-    repository: { html_url: "https://github.com/owner/repo" },
+    repository: { full_name: "owner/repo", html_url: "https://github.com/owner/repo" },
   };
 }
 
@@ -220,7 +220,6 @@ async function buildForeman(): Promise<{
 
   const foremanWss = new ForemanWss({ server: httpServer, config: {
     ...defaultCfg,
-    githubRepo: "owner/repo",
     githubToken: "token",
   } });
   const { wss } = foremanWss;


### PR DESCRIPTION
## Summary

- Makes `githubRepo` optional in the Zod config schema (was required)
- Removes foreman's `config.githubRepo` fallback in `resolveRepo()` — real webhooks always include `repository.full_name`; throws an error if it's missing instead
- Moves workspace construction from constructor to `start()` in `src/agent/index.ts` so it can use the async-detected repo from `WorkerSession.getRemoteRepo()`
- Updates test payloads that were relying on the config fallback to include explicit `repository: { full_name: "owner/repo" }`

## Test plan

- [ ] `npm test` passes (1439 tests, 0 failures excluding DB tests requiring Supabase)
- [ ] `npm run lint` passes
- [ ] `npx tsc --noEmit` passes
- [ ] Existing `config.test.ts` updated: removed "exits 1 when githubRepo is missing", added "succeeds when githubRepo is omitted"

Closes #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)