### PR TITLE
docs: document frontend component test command and CI gap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,13 +73,14 @@ Config via `.env` or `brunel.config.ts` (CLI flags also accepted). See `src/conf
 
 ## Useful scripts
 
-- `npm test` — unit tests (vitest)
+- `npm test` — unit tests (vitest); excludes `frontend/**`
+- `cd frontend && npm test` — frontend component tests (vitest + jsdom); not run by CI
 - `npm run smoke` — end-to-end smoke test: spawns real foreman + worker and asserts they connect
 - `npm run test:browser` — Playwright browser tests for the admin dashboard (requires `npm run build` first)
 - `npm run lint` — ESLint
 - `npx tsc --noEmit` — type check
 
-All five run in CI on every PR.
+All except the frontend component tests run in CI on every PR.
 
 ## Database
 


### PR DESCRIPTION
## Summary

- Documents `cd frontend && npm test` in CLAUDE.md (it was missing entirely)
- Notes that frontend component tests are not run by CI (see #844 for the fix)

Surfaced during #841, where fixing `frontend/vitest.config.ts` revealed the frontend tests weren't actually running anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)