### PR TITLE
docs: move BRUNEL_GITHUB_REPO to optional in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,14 @@
 # ── Required ──────────────────────────────────────────────────────────────────
 
-# GitHub repo in "owner/repo" format
-BRUNEL_GITHUB_REPO=owner/repo
-
 # GitHub personal access token with `repo` scope
 # (GH_TOKEN is forwarded automatically inside Claude Code devcontainer)
 BRUNEL_GITHUB_TOKEN=your_token_here
 
 # ── Optional ──────────────────────────────────────────────────────────────────
+
+# GitHub repo in "owner/repo" format — workers detect this from git remote automatically;
+# only needed for scripts/backfill-tasks.ts or other tooling that runs outside a git repo
+# BRUNEL_GITHUB_REPO=owner/repo
 
 # Port the foreman listens on (Railway sets PORT automatically; default: 3000)
 # BRUNEL_PORT=3000


### PR DESCRIPTION
`BRUNEL_GITHUB_REPO` was listed as Required in `.env.example`, but since #790 it is optional — workers detect it from `git remote get-url origin` automatically.

Moves it to the Optional section with a comment explaining when it is still needed (e.g. `backfill-tasks.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)