### PR TITLE
ci: add frontend component tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,11 @@ jobs:
         env:
           CI: true
 
+      - name: Run frontend component tests
+        run: cd frontend && npm ci && npm test
+        env:
+          CI: true
+
       - run: npm run coverage
         if: always()
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,13 +74,13 @@ Config via `.env` or `brunel.config.ts` (CLI flags also accepted). See `src/conf
 ## Useful scripts
 
 - `npm test` — unit tests (vitest); excludes `frontend/**`
-- `cd frontend && npm test` — frontend component tests (vitest + jsdom); not run by CI
+- `cd frontend && npm test` — frontend component tests (vitest + jsdom)
 - `npm run smoke` — end-to-end smoke test: spawns real foreman + worker and asserts they connect
 - `npm run test:browser` — Playwright browser tests for the admin dashboard (requires `npm run build` first)
 - `npm run lint` — ESLint
 - `npx tsc --noEmit` — type check
 
-All except the frontend component tests run in CI on every PR.
+All five run in CI on every PR.
 
 ## Database
 


### PR DESCRIPTION
## Summary

- Adds a `Run frontend component tests` step to the `test` CI job that runs `cd frontend && npm ci && npm test`
- This ensures the 43 frontend React component tests (jsdom/vitest) are executed on every PR, catching regressions before merge
- Uses `npm ci` (not `npm install`) since a lockfile exists in `frontend/`

## Test plan

- [ ] CI passes on this PR with the new frontend test step
- [ ] Confirm the new step appears in the GitHub Actions run log

Closes #844