### PR TITLE
fix: classify pull_request/opened as actionable so doc-reminder prompt fires

### DIFF
--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -73,7 +73,7 @@ export function classifyEvent(event: Wire.WebhookEvent): "actionable" | "log_onl
     }
 
     case "pull_request":
-      return (action === "closed" || action === "auto_merge_enabled") ? "actionable" : "log_only";
+      return (action === "closed" || action === "auto_merge_enabled" || action === "opened") ? "actionable" : "log_only";
 
     case "pull_request_review":
     case "pull_request_review_comment":

--- a/tests/worker.classify-event.test.ts
+++ b/tests/worker.classify-event.test.ts
@@ -64,8 +64,8 @@ describe("classifyEvent", () => {
       expect(classifyEvent(makeEvent("pull_request", { action: "auto_merge_enabled" }))).toBe("actionable");
     });
 
-    it("is log_only when action is opened", () => {
-      expect(classifyEvent(makeEvent("pull_request", { action: "opened" }))).toBe("log_only");
+    it("is actionable when action is opened", () => {
+      expect(classifyEvent(makeEvent("pull_request", { action: "opened" }))).toBe("actionable");
     });
 
     it("is log_only when action is synchronize", () => {


### PR DESCRIPTION
## Summary

- `classifyEvent()` in `worker-controller.ts` was returning `"log_only"` for `pull_request/opened`, causing the event to be silently dropped before the documentation-reminder prompt could fire
- Added `"opened"` to the actionable action list alongside `"closed"` and `"auto_merge_enabled"`
- Updated the corresponding test to assert `"actionable"` for the `opened` action

Closes #849

🤖 Generated with [Claude Code](https://claude.com/claude-code)