### PR TITLE
test: replace internal flag assertions with behavioral stdout assertions

### DIFF
--- a/tests/display.worker-status.test.ts
+++ b/tests/display.worker-status.test.ts
@@ -306,13 +306,14 @@ describe("Display persistent status bar", () => {
   });
 
   it("stopBar leaves persistent status active", () => {
+    agentStatus.update({ connectionStatus: "connected" });
     display.startPersistentBar();
     display.startBar(() => "Working…");
     stdoutWrite.mockClear();
     display.stopBar();
-    // persistent status is still active
-    expect(display.persistentActive).toBe(true);
-    expect(display.active).toBe(false);
+    const combined = stdoutWrite.mock.calls.map(a => String(a[0])).join("");
+    expect(combined).toContain("Connected");
+    expect(combined).not.toContain("Working…");
   });
 
   it("agentStatus change triggers persistent bar redraw", () => {


### PR DESCRIPTION
## Summary

- Replaces `display.persistentActive` and `display.active` flag checks in the "stopBar leaves persistent status active" test with behavioral stdout assertions
- Sets a known connection status (`"connected"`) so the persistent bar renders "Connected"
- After `stopBar()`, asserts stdout contains "Connected" (persistent bar still visible) and does not contain "Working…" (animated bar is gone)

Closes #852

## Test plan
- [x] `npm test` passes (all 1438 tests pass)
- [x] The modified test "stopBar leaves persistent status active" passes and exercises user-visible behavior rather than internal state

🤖 Generated with [Claude Code](https://claude.com/claude-code)