### PR TITLE
fix: scope loadIssuesToQueue cleanup to current repo only

### DIFF
--- a/src/foreman/clients/github.ts
+++ b/src/foreman/clients/github.ts
@@ -67,9 +67,8 @@ export async function loadIssuesToQueue(
 
   // Cleanup: delete pending tasks for issues that no longer have the task label.
   const labeledNums = new Set(loadedIssueNumbers);
-  const allTasks = await Task.list({ cancelable: true });
-  for (const t of allTasks) {
-    if (t.repoId !== taskModel.repo.id) continue;
+  const repoTasks = await Task.list({ cancelable: true, repoId: taskModel.repo.id });
+  for (const t of repoTasks) {
     if (!labeledNums.has(t.issueNumber)) {
       await t.deleteIfUnassigned().catch((err: unknown) =>
         console.error(`[startup] ERROR deleting stale task #${t.taskId}: ${fmtError(err)}`)

--- a/src/foreman/clients/github.ts
+++ b/src/foreman/clients/github.ts
@@ -69,6 +69,7 @@ export async function loadIssuesToQueue(
   const labeledNums = new Set(loadedIssueNumbers);
   const allTasks = await Task.list({ cancelable: true });
   for (const t of allTasks) {
+    if (t.repoId !== taskModel.repo.id) continue;
     if (!labeledNums.has(t.issueNumber)) {
       await t.deleteIfUnassigned().catch((err: unknown) =>
         console.error(`[startup] ERROR deleting stale task #${t.taskId}: ${fmtError(err)}`)

--- a/src/foreman/models/task.ts
+++ b/src/foreman/models/task.ts
@@ -214,12 +214,15 @@ export class Task extends ActiveRecord {
     return data ? new Task(data) : null;
   }
 
-  // Overrides base list() to add created_at ordering and the cancelable filter.
-  static async list(opts?: { cancelable?: boolean; limit?: number }): Promise<Task[]> {
+  // Overrides base list() to add created_at ordering and the cancelable/repoId filters.
+  static async list(opts?: { cancelable?: boolean; repoId?: number; limit?: number }): Promise<Task[]> {
     const limit = opts?.limit ?? 200;
     let q = Task.select();
     if (opts?.cancelable) {
       q = q.is("worker_id", null).is("completed_at", null).is("issue_closed_at", null).is("pr_merged_at", null);
+    }
+    if (opts?.repoId !== undefined) {
+      q = q.eq("repo_id", opts.repoId);
     }
     const { data, error } = await q.order("created_at", { ascending: false }).limit(limit);
     if (error) throw error;

--- a/tests/foreman.github.test.ts
+++ b/tests/foreman.github.test.ts
@@ -167,6 +167,54 @@ describe("fetchNativeBlockers", () => {
   });
 });
 
+describe("loadIssuesToQueue cleanup scoping", () => {
+  it("does not delete pending tasks from other repos during cleanup", async () => {
+    // Repo A: issue #1 is labeled
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{ number: 1, title: "Issue 1", body: "", labels: [{ name: "brunel:ready" }] }],
+    } as any);
+
+    resetDb();
+    const tmA = await createTestTaskManager("owner/repo-a");
+    const tmB = await createTestTaskManager("owner/repo-b");
+    vi.spyOn(tmA, "fetchBlockers").mockResolvedValue([]);
+
+    // Seed a pending task for Repo B with issue #7
+    await Task.upsert("repo-b-7", 7, "owner/repo-b", "Repo B issue", "", ["brunel:ready"]);
+    const repoBTask = await Task.getByRepoIssue(tmB.repo.id, 7);
+    expect(repoBTask).not.toBeNull();
+
+    // loadIssuesToQueue runs for Repo A — should only clean up Repo A's tasks
+    await loadIssuesToQueue(tmA);
+
+    // Repo B's task #7 must still exist
+    const afterCleanup = await Task.getByRepoIssue(tmB.repo.id, 7);
+    expect(afterCleanup).not.toBeNull();
+  });
+
+  it("still deletes stale tasks from the current repo", async () => {
+    // Repo A: issue #1 is labeled, but #99 is not (stale)
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{ number: 1, title: "Issue 1", body: "", labels: [{ name: "brunel:ready" }] }],
+    } as any);
+
+    resetDb();
+    const tmA = await createTestTaskManager("owner/repo-a");
+    vi.spyOn(tmA, "fetchBlockers").mockResolvedValue([]);
+
+    // Seed a stale pending task for Repo A with issue #99 (no longer labeled)
+    await Task.upsert("repo-a-99", 99, "owner/repo-a", "Stale issue", "", []);
+    expect(await Task.getByRepoIssue(tmA.repo.id, 99)).not.toBeNull();
+
+    await loadIssuesToQueue(tmA);
+
+    // Stale task from Repo A should be deleted
+    expect(await Task.getByRepoIssue(tmA.repo.id, 99)).toBeNull();
+  });
+});
+
 describe("loadIssuesToQueue with blockers", () => {
   it("populates taskManager blockers from fetchBlockers result", async () => {
     vi.mocked(fetch)


### PR DESCRIPTION
## Summary

- `loadIssuesToQueue` was fetching all cancelable tasks across every repo, then deleting any whose issue number wasn't in the current repo's labeled-issue set — silently wiping tasks from other repos.
- Added a `t.repoId !== taskModel.repo.id` guard so the cleanup loop only touches tasks belonging to the repo currently being synced.
- Added two regression tests: one that verifies other-repo tasks survive cleanup, and one that confirms same-repo stale tasks are still deleted.

## Test plan

- [ ] `npm test` passes (all non-DB tests)
- [ ] New test `does not delete pending tasks from other repos during cleanup` fails before the fix, passes after
- [ ] New test `still deletes stale tasks from the current repo` passes both before and after (confirms existing behavior preserved)

Closes #856

🤖 Generated with [Claude Code](https://claude.com/claude-code)