### PR TITLE
refactor: remove unused listActiveTasks method

### DIFF
--- a/src/foreman/models/task-manager.ts
+++ b/src/foreman/models/task-manager.ts
@@ -148,12 +148,6 @@ export class TaskManager extends EventEmitter {
     }
   }
 
-  /** All active (non-complete) tasks — used by the dashboard task list API and dependency resolution. */
-  async listActiveTasks(): Promise<Task[]> {
-    const tasks = await Task.list();
-    return tasks.filter((t) => !t.completedAt);
-  }
-
   // ── Memory-only write operations (ephemeral data) ─────────────────────────
 
   queueEvent(task: Task, event: WebhookEvent): void {

--- a/tests/foreman.taskqueue.test.ts
+++ b/tests/foreman.taskqueue.test.ts
@@ -169,21 +169,6 @@ describe("TaskManager — derived blocked status", () => {
     expect(task2).toBeNull();
   });
 
-  it("listActiveTasks returns pending and assigned but not complete", async () => {
-    await Task.upsert("1", 1, repoSlug, "T1", "B", ["brunel:ready"]);
-    await Task.upsert("2", 2, repoSlug, "T2", "B", ["brunel:ready"]);
-    const t2 = await Task.get("2");
-    const fakeWs = { send: vi.fn(), close: vi.fn(), readyState: 1 } as any;
-    await t2!.assign(Worker.register("w1", fakeWs, fakeRepo()));
-    await Task.upsert("3", 3, repoSlug, "T3", "B", ["brunel:ready"]);
-    const t3 = await Task.get("3");
-    await t3!.assign(Worker.register("w2", fakeWs, fakeRepo()));
-    await t3!.complete();
-    const result = await m.listActiveTasks();
-    expect(result.map((t) => t.taskId)).toEqual(expect.arrayContaining(["1", "2"]));
-    expect(result.map((t) => t.taskId)).not.toContain("3");
-  });
-
   it("getTasksForBroadcast derives blocked status when blocker is open", async () => {
     await registerBase(); // issueNumber: 42
     m.trackIssue(42);


### PR DESCRIPTION
## Summary

- `listActiveTasks()` was never called in production code — only in its own test
- Its docstring claimed it was "used by the dashboard task list API", but that was stale; `getTasksForBroadcast` covers that use case
- It also had the same latent bug as #857: no `repoId` filter, so it would have returned tasks from all repos

Removing the method and its test.

## Test plan

- [ ] All existing tests pass (40 passing, no regressions)
- [ ] Type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)