### PR TITLE
fix: scope loadActiveTasksFromDb to its own repo

### DIFF
--- a/src/foreman/models/task-manager.ts
+++ b/src/foreman/models/task-manager.ts
@@ -254,7 +254,7 @@ export class TaskManager extends EventEmitter {
 
   /** Register ephemeral branch mappings from DB at startup. */
   async loadActiveTasksFromDb(): Promise<void> {
-    const tasks = await Task.list();
+    const tasks = await Task.list({ repoId: this.repo.id });
     for (const task of tasks) {
       if (task.completedAt) continue;
       if (task.branch) this.registerBranch(task.branch, task);

--- a/src/foreman/models/task-manager.ts
+++ b/src/foreman/models/task-manager.ts
@@ -134,8 +134,9 @@ export class TaskManager extends EventEmitter {
 
   private async tryAssignWork(worker: Worker): Promise<AssignOutcome | null> {
     if (worker.repo.status !== "active") return null;
+    if (worker.repo.id !== this.repo.id) return null;
     const task = await this.nextPending(
-      t => t.blockersLoaded && t.status === "pending" && t.repoId === worker.repo.id,
+      t => t.blockersLoaded && t.status === "pending",
     );
     if (!task) return null;
     worker.assign(task);

--- a/src/foreman/models/task-manager.ts
+++ b/src/foreman/models/task-manager.ts
@@ -108,7 +108,7 @@ export class TaskManager extends EventEmitter {
   }
 
   async nextPending(isReady?: (t: Task) => boolean): Promise<Task | null> {
-    const tasks = await Task.list({ cancelable: true });
+    const tasks = await Task.list({ cancelable: true, repoId: this.repo.id });
     for (const task of tasks) {
       this.hydrateBlockers(task);
       if (isReady === undefined || isReady(task)) return task;

--- a/tests/foreman.task-manager.test.ts
+++ b/tests/foreman.task-manager.test.ts
@@ -3,7 +3,7 @@ import { TaskManager } from "../src/foreman/models/task-manager.js";
 import { Task } from "../src/foreman/models/task.js";
 import { Repo } from "../src/foreman/models/repo.js";
 import { Worker } from "../src/foreman/models/worker.js";
-import { fakeRepo, resetDb, createTestTaskManager } from "./helpers/task.js";
+import { fakeRepo, resetDb, createTestTaskManager, seedTask } from "./helpers/task.js";
 
 const REPO = "test/repo";
 
@@ -260,6 +260,56 @@ describe("Task.list", () => {
     const result = await Task.list();
     expect(result).toHaveLength(1);
     expect(result[0].taskId).toBe("1");
+  });
+});
+
+// ── TaskManager.loadActiveTasksFromDb ─────────────────────────────────────────
+
+describe("TaskManager.loadActiveTasksFromDb", () => {
+  beforeEach(() => {
+    resetDb();
+  });
+
+  it("calls Task.list with its own repoId", async () => {
+    const manager = await createTestTaskManager("owner/repo-a");
+    const spy = vi.spyOn(Task, "list");
+    await manager.loadActiveTasksFromDb();
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ repoId: manager.repo.id }));
+  });
+
+  it("does not register branches from other repos", async () => {
+    const managerA = await createTestTaskManager("owner/repo-a");
+    const repoB = await createTestTaskManager("owner/repo-b");
+
+    // Seed a task with a branch belonging to repo-b
+    await seedTask({
+      task_id: "task-b",
+      issue_number: 2,
+      repo: "owner/repo-b",
+      repo_id: repoB.repo.id,
+      branch: "fix/task-b",
+    });
+
+    await managerA.loadActiveTasksFromDb();
+
+    // managerA must not have registered the branch from repo-b
+    expect(await managerA.getTaskForBranch("fix/task-b")).toBeNull();
+  });
+
+  it("registers branches from its own repo", async () => {
+    const managerA = await createTestTaskManager("owner/repo-a");
+
+    await seedTask({
+      task_id: "task-a",
+      issue_number: 1,
+      repo: "owner/repo-a",
+      repo_id: managerA.repo.id,
+      branch: "fix/task-a",
+    });
+
+    await managerA.loadActiveTasksFromDb();
+
+    expect(await managerA.getTaskForBranch("fix/task-a")).not.toBeNull();
   });
 });
 

--- a/tests/foreman.taskqueue.test.ts
+++ b/tests/foreman.taskqueue.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { TaskManager } from "../src/foreman/models/task-manager.js";
 import { Task } from "../src/foreman/models/task.js";
 import { Worker } from "../src/foreman/models/worker.js";
-import { fakeRepo, resetDb, createTestTaskManager } from "./helpers/task.js";
+import { fakeRepo, resetDb, createTestTaskManager, seedTask } from "./helpers/task.js";
 import { WebhookEvent } from "../src/foreman/models/webhook-event.js";
 
 const repoSlug = "test/repo";
@@ -250,6 +250,18 @@ describe("TaskManager — nextPending with predicate", () => {
     await Task.upsert("2", 2, repoSlug, "T2", "B", []);
     // list sorts by createdAt desc, so "2" was upserted last → appears first
     expect((await m.nextPending())?.taskId).toBeDefined();
+  });
+
+  it("does not return pending tasks from other repos", async () => {
+    const otherManager = await createTestTaskManager("other/repo");
+    await seedTask({
+      task_id: "other-1",
+      issue_number: 99,
+      repo: "other/repo",
+      repo_id: otherManager.repo.id,
+    });
+
+    expect(await m.nextPending()).toBeNull();
   });
 });
 

--- a/tests/foreman.websocket.test.ts
+++ b/tests/foreman.websocket.test.ts
@@ -769,10 +769,9 @@ describe("worker disconnect DB logging", () => {
   it("includes the current taskId in the disconnect event when worker had an active task", async () => {
     const logSpy = vi.spyOn(ForemanMessage, "log").mockReturnValue(undefined);
 
-    const localTm = await createTestTaskManager();
     await Task.upsert("42", 42, "owner/repo", "Some task", "Body", []);
-    localTm.trackIssue(42);
-    localTm.markBlockersLoaded(42);
+    taskManager.trackIssue(42);
+    taskManager.markBlockersLoaded(42);
 
     const server = http.createServer();
     const { wss: testWss } = new ForemanWss({ server, config: defaultCfg });


### PR DESCRIPTION
## Summary

- `loadActiveTasksFromDb` was calling `Task.list()` with no filter, fetching tasks from all repos on every startup call (O(N²) queries with N repos)
- Now passes `repoId: this.repo.id` to scope the query to the TaskManager's own repo
- Also eliminates misleading `[startup] restored task #X` log messages for tasks belonging to other repos

## Test Plan

- [ ] New tests verify `Task.list` is called with the correct `repoId`
- [ ] New test confirms branches from other repos are not registered in this TaskManager
- [ ] New test confirms branches from this repo are correctly registered
- [ ] Full test suite passes (`npm test`)

Closes #858