### PR TITLE
feat: runtime worker mode switching

### DIFF
--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -18,6 +18,15 @@ import { WorkspaceController } from "./workspace-controller.js";
 
 const execAsync = promisify(exec);
 
+async function getCurrentBranch(): Promise<string> {
+  try {
+    const { stdout } = await execAsync("git rev-parse --abbrev-ref HEAD");
+    return stdout.trim();
+  } catch {
+    return "";
+  }
+}
+
 function fmtTaskStats(inputTokens: number, outputTokens: number, costUsd: number | undefined): string {
   const parts = [`tokens: ${fmtNum(inputTokens)} in / ${fmtNum(outputTokens)} out`];
   if (costUsd != null) parts.push(`cost: $${costUsd.toFixed(2)}`);
@@ -185,24 +194,7 @@ export class WorkerSession extends EventEmitter {
   get agentId(): string { return this.agentStatus.agentId; }
 
   private async refreshBranch(): Promise<void> {
-    let branch = "";
-    try {
-      const { stdout } = await execAsync("git rev-parse --abbrev-ref HEAD");
-      branch = stdout.trim();
-    } catch {
-      branch = "";
-    }
-    this.agentStatus.update({ branch });
-  }
-
-  /** Returns the current git branch name, or "" on any error. */
-  static async getCurrentBranch(): Promise<string> {
-    try {
-      const { stdout } = await execAsync("git rev-parse --abbrev-ref HEAD");
-      return stdout.trim();
-    } catch {
-      return "";
-    }
+    this.agentStatus.update({ branch: await getCurrentBranch() });
   }
 
   /**
@@ -695,51 +687,108 @@ export class WorkerSession extends EventEmitter {
  * Register the worker-namespace commands into the given registry (which should
  * already be scoped, e.g. registry.scoped("worker")). Commands degrade
  * gracefully when not connected to a foreman.
- *
- * Accepts a getter so handlers always resolve the current session even when
- * worker mode is started or stopped at runtime after registration. onStart and
- * onStop are called by the /worker:start and /worker:stop command handlers.
  */
-export function registerWorkerCommands(
-  getSession: () => WorkerSession | undefined,
-  registry: CommandRegistry,
-  display: WorkerDisplay,
-  onStart: () => Promise<void>,
-  onStop: () => Promise<void>,
-): void {
-  registry.register("complete", {
-    description: "Mark the current task as done",
-    handler: async () => {
-      const session = getSession();
-      if (!session) {
-        display.print(c.boldRed("Not connected to a foreman."));
-        return undefined;
-      }
-      return session.completeCurrentTask();
-    },
-  });
-  registry.register("start", {
-    description: "Connect to the foreman and start accepting tasks",
-    handler: async () => { await onStart(); },
-  });
-  registry.register("stop", {
-    description: "Disconnect from the foreman",
-    handler: async () => {
-      if (!getSession()) {
-        display.print(c.amber("Worker mode is not active."));
-        return undefined;
-      }
-      await onStop();
-    },
-  });
+export class WorkerController extends EventEmitter {
+  private _session: WorkerSession | undefined;
+  private _cleanup: (() => Promise<void>) | undefined;
+
+  constructor(
+    private readonly display: Display,
+    private readonly picker: Picker,
+    private readonly workspaceController: WorkspaceController | undefined,
+    private readonly repo: string,
+  ) {
+    super();
+  }
+
+  /** The active WorkerSession, or undefined when worker mode is off. */
+  get session(): WorkerSession | undefined { return this._session; }
+  /** True when worker mode is active (connected or connecting). */
+  get isActive(): boolean { return this._session !== undefined; }
+  /** True when a worker cleanup must run on exit (i.e., worker is active). */
+  get isCleanupPending(): boolean { return this._cleanup !== undefined; }
+
+  hasTask(): boolean { return this._session?.hasTask() ?? false; }
+  interrupt(): boolean { return this._session?.interrupt() ?? false; }
+  sendGoodbye(): void { this._session?.sendGoodbye(); }
+  getTaskQuitInfo(): TaskQuitInfo | undefined { return this._session?.getTaskQuitInfo(); }
+  async confirmTaskQuit(info: TaskQuitInfo): Promise<"quit" | "complete-and-quit" | "cancel"> {
+    return this._session!.confirmTaskQuit(info);
+  }
+  async completeCurrentTask(): Promise<void> { await this._session?.completeCurrentTask(); }
+
+  /** Connect to the foreman and begin accepting tasks. Emits "session-started". */
+  async start(): Promise<void> {
+    if (this._session) {
+      this.display.print(c.amber("Worker mode is already active."));
+      return;
+    }
+    const { session, cleanup } = await startWorkerMode(
+      this.display, this.picker, this.workspaceController, this.repo,
+    );
+    this._session = session;
+    this._cleanup = cleanup;
+    this.emit("session-started", session);
+  }
+
+  /** Disconnect from the foreman. Prompts if a task is in progress. */
+  async stop(): Promise<void> {
+    if (!this._session) return;
+    const taskInfo = this._session.getTaskQuitInfo();
+    if (taskInfo) {
+      const choice = await this._session.confirmTaskQuit(taskInfo);
+      if (choice === "cancel") return;
+      if (choice === "complete-and-quit") await this._session.completeCurrentTask();
+    }
+    this._session.stop();
+    this._session = undefined;
+    this._cleanup = undefined; // cleared so later exit takes the non-worker path
+    this.display.agentStatus.setWorkerModeActive(false);
+    this.display.print(c.sageGreen("Worker mode stopped."));
+  }
+
+  /** Run worker teardown: send goodbye, destroy workspace, tear down I/O. */
+  async cleanup(): Promise<void> {
+    if (this._cleanup) await this._cleanup();
+  }
+
+  /** Register /worker:complete, /worker:start, /worker:stop into the given (already-scoped) registry. */
+  registerCommands(registry: CommandRegistry): void {
+    registry.register("complete", {
+      description: "Mark the current task as done",
+      handler: async () => {
+        if (!this._session) {
+          this.display.print(c.boldRed("Not connected to a foreman."));
+          return undefined;
+        }
+        return this._session.completeCurrentTask();
+      },
+    });
+    registry.register("start", {
+      description: "Connect to the foreman and start accepting tasks",
+      handler: async () => { await this.start(); },
+    });
+    registry.register("stop", {
+      description: "Disconnect from the foreman",
+      handler: async () => {
+        if (!this._session) {
+          this.display.print(c.amber("Worker mode is not active."));
+          return undefined;
+        }
+        await this.stop();
+      },
+    });
+  }
+
+  /** Returns the current git branch name, or "" on any error. */
+  static getCurrentBranch = getCurrentBranch;
 }
 
+// ── startWorkerMode ───────────────────────────────────────────────────────────
+
 /**
- * Set up worker mode: configure the WorkerSession and start the session.
- * Receives the full Display (which owns agentStatus and bar rendering) and a
- * WorkspaceController. Returns the session and a cleanup function — does NOT
- * call main(). The caller (main itself) owns the query loop, installs signal
- * handlers, and calls cleanup() after the loop exits.
+ * Create and start a WorkerSession. Sets workerModeActive on agentStatus.
+ * Returns the session and a cleanup function for use by WorkerController.
  */
 export async function startWorkerMode(
   display: Display,

--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -195,6 +195,16 @@ export class WorkerSession extends EventEmitter {
     this.agentStatus.update({ branch });
   }
 
+  /** Returns the current git branch name, or "" on any error. */
+  static async getCurrentBranch(): Promise<string> {
+    try {
+      const { stdout } = await execAsync("git rev-parse --abbrev-ref HEAD");
+      return stdout.trim();
+    } catch {
+      return "";
+    }
+  }
+
   /**
    * Returns the repo in "owner/name" format by parsing the git remote origin URL.
    * Handles both HTTPS (https://github.com/owner/repo.git) and SSH
@@ -686,10 +696,17 @@ export class WorkerSession extends EventEmitter {
  * already be scoped, e.g. registry.scoped("worker")). Commands degrade
  * gracefully when not connected to a foreman.
  *
- * Accepts a getter so the command handlers always resolve the current session,
- * even when worker mode is started or stopped at runtime after registration.
+ * Accepts a getter so handlers always resolve the current session even when
+ * worker mode is started or stopped at runtime after registration. onStart and
+ * onStop are called by the /worker:start and /worker:stop command handlers.
  */
-export function registerWorkerCommands(getSession: () => WorkerSession | undefined, registry: CommandRegistry, display: WorkerDisplay): void {
+export function registerWorkerCommands(
+  getSession: () => WorkerSession | undefined,
+  registry: CommandRegistry,
+  display: WorkerDisplay,
+  onStart: () => Promise<void>,
+  onStop: () => Promise<void>,
+): void {
   registry.register("complete", {
     description: "Mark the current task as done",
     handler: async () => {
@@ -699,6 +716,20 @@ export function registerWorkerCommands(getSession: () => WorkerSession | undefin
         return undefined;
       }
       return session.completeCurrentTask();
+    },
+  });
+  registry.register("start", {
+    description: "Connect to the foreman and start accepting tasks",
+    handler: async () => { await onStart(); },
+  });
+  registry.register("stop", {
+    description: "Disconnect from the foreman",
+    handler: async () => {
+      if (!getSession()) {
+        display.print(c.amber("Worker mode is not active."));
+        return undefined;
+      }
+      await onStop();
     },
   });
 }

--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -357,6 +357,21 @@ export class WorkerSession extends EventEmitter {
   }
 
   /**
+   * Gracefully stop this session: prevent reconnection, send goodbye, close
+   * the WebSocket, and cancel any pending debounce timer. Called by
+   * /worker:stop and the idle-^C handler to deactivate worker mode at runtime.
+   */
+  stop(): void {
+    this.stopped = true; // prevents reconnect on close
+    this.sendGoodbye();
+    this.ws?.close();
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+  }
+
+  /**
    * Send worker_goodbye to the foreman if the WebSocket is currently open.
    * Called before clean exits (SIGTERM, /quit) so the foreman can immediately
    * revert the task to pending without waiting for the reclaim timeout.
@@ -670,11 +685,15 @@ export class WorkerSession extends EventEmitter {
  * Register the worker-namespace commands into the given registry (which should
  * already be scoped, e.g. registry.scoped("worker")). Commands degrade
  * gracefully when not connected to a foreman.
+ *
+ * Accepts a getter so the command handlers always resolve the current session,
+ * even when worker mode is started or stopped at runtime after registration.
  */
-export function registerWorkerCommands(session: WorkerSession | undefined, registry: CommandRegistry, display: WorkerDisplay): void {
+export function registerWorkerCommands(getSession: () => WorkerSession | undefined, registry: CommandRegistry, display: WorkerDisplay): void {
   registry.register("complete", {
     description: "Mark the current task as done",
     handler: async () => {
+      const session = getSession();
       if (!session) {
         display.print(c.boldRed("Not connected to a foreman."));
         return undefined;
@@ -685,11 +704,11 @@ export function registerWorkerCommands(session: WorkerSession | undefined, regis
 }
 
 /**
- * Set up worker mode: configure the WorkerSession, install signal handlers,
- * and start the session. Receives the full Display (which owns agentStatus and
- * bar rendering) and a WorkspaceController. Returns the session and a cleanup
- * function — does NOT call main(). The caller (main itself) owns the query
- * loop and calls cleanup() after it exits.
+ * Set up worker mode: configure the WorkerSession and start the session.
+ * Receives the full Display (which owns agentStatus and bar rendering) and a
+ * WorkspaceController. Returns the session and a cleanup function — does NOT
+ * call main(). The caller (main itself) owns the query loop, installs signal
+ * handlers, and calls cleanup() after the loop exits.
  */
 export async function startWorkerMode(
   display: Display,
@@ -703,8 +722,6 @@ export async function startWorkerMode(
   await workspaceController?.onCreate();
 
   const afterTask = workspaceController ? () => workspaceController.onReset() : undefined;
-
-  let shuttingDown = false;
 
   const wsFactory: WsFactory = (agentId, taskId) => {
     const ws = new WebSocket(`${getConfig().foremanUrl}/worker`);
@@ -722,6 +739,7 @@ export async function startWorkerMode(
 
   const { agentStatus } = display;
   agentStatus.update({ model: getConfig().model, effort: getConfig().effort });
+  agentStatus.setWorkerModeActive(true);
 
   const session = new WorkerSession(agentStatus, wsFactory, display, {
     afterTask,
@@ -732,43 +750,10 @@ export async function startWorkerMode(
     repo,
   });
 
-  const shutdown = async () => {
-    if (shuttingDown) return;
-    shuttingDown = true;
-    const taskInfo = session.getTaskQuitInfo();
-    if (taskInfo) {
-      const choice = await session.confirmTaskQuit(taskInfo);
-      if (choice === "cancel") { shuttingDown = false; return; }
-      if (choice === "complete-and-quit") await session.completeCurrentTask();
-    }
-    await workspaceController?.onDestroy();
-    process.exit(0);
-  };
-
-  // SIGINT: interrupt the running query if one is active; otherwise prompt and shut down.
-  // This lets the user press ^C to interrupt a running tool without killing the worker.
-  process.on("SIGINT", () => {
-    if (!session.interrupt()) {
-      void shutdown();
-    }
-  });
-
-  // SIGTERM is a system/orchestrator signal: send goodbye then force-destroy without prompting.
-  process.on("SIGTERM", () => {
-    session.sendGoodbye();
-    if (workspaceController) {
-      void workspaceController.onForceDestroy().then(() => process.exit(0));
-    } else {
-      process.exit(0);
-    }
-  });
-
-  display.startPersistentBar();
   session.start();
 
   const cleanup = async () => {
     session.sendGoodbye();
-    shuttingDown = true;
     await workspaceController?.onDestroy();
     process.stdout.write("\x1b[?2004l\r\n");
     if (process.stdin.isTTY) process.stdin.setRawMode(false);

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -7,7 +7,7 @@ import { c, hr } from "./views/style.js";
 import { AgentStatus } from "./models/agent-status.js";
 import { Input } from "./views/input.js";
 import { Picker } from "./views/picker.js";
-import { registerWorkerCommands, startWorkerMode, WorkerSession } from "./controllers/worker-controller.js";
+import { WorkerController, WorkerSession } from "./controllers/worker-controller.js";
 import { loadConfig, getConfig, type BrunelConfig } from "../config.js";
 import { Workspace } from "./models/workspace.js";
 import { fmtError } from "../utils.js";
@@ -70,7 +70,7 @@ export class BrunelAgent {
     // Always detect the repo so /worker:start can use it at runtime.
     const repo = await WorkerSession.getRemoteRepo();
     // Show current branch in the minimal status bar before worker mode activates.
-    this.agentStatus.update({ branch: await WorkerSession.getCurrentBranch() });
+    this.agentStatus.update({ branch: await WorkerController.getCurrentBranch() });
 
     // Build workspace config after repo detection. repoUrl can be set explicitly
     // in config; otherwise it's derived from the detected git remote + token.
@@ -89,10 +89,6 @@ export class BrunelAgent {
       : undefined;
     const workspaceController = new WorkspaceController(workspace, this.display, config);
 
-    // Mutable session and cleanup refs — updated when worker mode is started/stopped.
-    let session: WorkerSession | undefined;
-    let workerCleanup: (() => Promise<void>) | undefined;
-
     // doExit handles workspace cleanup and stdin/stdout teardown.
     // Called on exit from pure REPL mode (no active worker session).
     const doExit = async () => {
@@ -104,8 +100,8 @@ export class BrunelAgent {
 
     // ── Routing queue ─────────────────────────────────────────────────────────
     //
-    // Defined early so attachSessionListeners (which is called by startWorker)
-    // can enqueue session events before the routing loop is reached.
+    // Defined early so the session-started listener (which fires before the
+    // routing loop starts) can enqueue session events into it.
 
     type RoutingEvent =
       | { type: "line"; value: string }
@@ -124,9 +120,10 @@ export class BrunelAgent {
       return new Promise((resolve) => { routingWaiter = resolve; });
     };
 
-    // ── Session listener attachment ────────────────────────────────────────────
+    // ── Worker controller ─────────────────────────────────────────────────────
 
-    const attachSessionListeners = (s: WorkerSession): void => {
+    const workerController = new WorkerController(this.display, this.picker, workspaceController, repo);
+    workerController.on("session-started", (s: WorkerSession) => {
       s.on("prompts_ready", () => {
         this.input.cancel();
         enqueueRoutingEvent({ type: "session", event: "prompts_ready" });
@@ -135,35 +132,7 @@ export class BrunelAgent {
         this.input.cancel();
         enqueueRoutingEvent({ type: "session", event: "fatal" });
       });
-    };
-
-    // ── Worker mode start/stop helpers ────────────────────────────────────────
-
-    const stopWorker = async (): Promise<void> => {
-      if (!session) return;
-      const taskInfo = session.getTaskQuitInfo();
-      if (taskInfo) {
-        const choice = await session.confirmTaskQuit(taskInfo);
-        if (choice === "cancel") return;
-        if (choice === "complete-and-quit") await session.completeCurrentTask();
-      }
-      session.stop();
-      session = undefined;
-      workerCleanup = undefined; // prevent double-cleanup on later exit
-      this.agentStatus.setWorkerModeActive(false);
-      this.display.print(c.sageGreen("Worker mode stopped."));
-    };
-
-    const startWorker = async (): Promise<void> => {
-      if (session) {
-        this.display.print(c.amber("Worker mode is already active."));
-        return;
-      }
-      const ctx = await startWorkerMode(this.display, this.picker, workspaceController, repo);
-      session = ctx.session;
-      workerCleanup = ctx.cleanup;
-      attachSessionListeners(session);
-    };
+    });
 
     // ── Signal handlers ───────────────────────────────────────────────────────
     //
@@ -171,20 +140,20 @@ export class BrunelAgent {
     // regardless of when worker mode is started or stopped.
 
     process.on("SIGINT", () => {
-      if (!session?.interrupt()) {
+      if (!workerController.interrupt()) {
         // Nothing to interrupt — print a newline to keep the terminal tidy.
         process.stdout.write("\n");
       }
     });
     process.on("SIGTERM", async () => {
-      session?.sendGoodbye();
+      workerController.sendGoodbye();
       await doExit();
       process.exit(0);
     });
 
     // Start worker mode immediately if requested via --worker-mode flag.
     if (runWorkerMode) {
-      await startWorker();
+      await workerController.start();
     }
 
     // Status bar is always shown regardless of worker mode.
@@ -207,17 +176,16 @@ export class BrunelAgent {
     // modes; commands that require a foreman connection degrade gracefully.
     const registry = this.controller.registry;
     workspaceController.registerCommands(registry.scoped("workspace"));
-    const workerRegistry = registry.scoped("worker");
-    registerWorkerCommands(() => session, workerRegistry, this.display, startWorker, stopWorker);
+    workerController.registerCommands(registry.scoped("worker"));
     registry.register("exit", {
       description: "Exit",
       handler: async () => {
-        if (!session) { await doExit(); return "exit"; }
-        const taskInfo = session.getTaskQuitInfo();
+        if (!workerController.isActive) { await doExit(); return "exit"; }
+        const taskInfo = workerController.getTaskQuitInfo();
         if (taskInfo) {
-          const choice = await session.confirmTaskQuit(taskInfo);
+          const choice = await workerController.confirmTaskQuit(taskInfo);
           if (choice === "cancel") return undefined;
-          if (choice === "complete-and-quit") await session.completeCurrentTask();
+          if (choice === "complete-and-quit") await workerController.completeCurrentTask();
         }
         return "exit";
       },
@@ -266,11 +234,11 @@ export class BrunelAgent {
      */
     const runPrompt = async (prompt: string): Promise<boolean> => {
       const ac = new AbortController();
-      session?.notifyQueryStart(ac);
+      workerController.session?.notifyQueryStart(ac);
       try {
         const { sessionId: newId, stats } = await this.agentController.runQuery(prompt, sessionId, ac);
         sessionId = newId ?? sessionId;
-        if (session) {
+        if (workerController.isActive) {
           this.agentStatus.addQueryStats(stats.inputTokens, stats.outputTokens, stats.costUsd);
         }
         return !ac.signal.aborted;
@@ -279,7 +247,7 @@ export class BrunelAgent {
         logFull("ERROR", err instanceof Error ? { message: err.message, stack: err.stack } : err);
         return false;
       } finally {
-        session?.notifyQueryEnd(ac.signal.aborted);
+        workerController.session?.notifyQueryEnd(ac.signal.aborted);
       }
     };
 
@@ -288,8 +256,8 @@ export class BrunelAgent {
      * draining if a prompt is interrupted or errors.
      */
     const drainPendingPrompts = async (): Promise<void> => {
-      while (session?.hasPendingPrompts()) {
-        const item = session.takeNextPrompt()!;
+      while (workerController.session?.hasPendingPrompts()) {
+        const item = workerController.session.takeNextPrompt()!;
         if (item.fresh) sessionId = undefined; // new task → fresh conversation
         const ok = await runPrompt(item.prompt);
         if (!ok) break;
@@ -306,8 +274,8 @@ export class BrunelAgent {
     // In worker mode with no active task, use an empty prompt so stdin remains
     // active (^D / ^C still work) but no "[agent] > " is displayed while waiting.
     const listenForInput = (): void => {
-      const promptStr = session
-        ? (session.hasTask() ? "\n[agent] > " : "")
+      const promptStr = workerController.isActive
+        ? (workerController.hasTask() ? "\n[agent] > " : "")
         : "\n> ";
       void this.input.ask(promptStr, () => this.controller.listCommands()).then((line) => {
         if (line !== null) enqueueRoutingEvent({ type: "line", value: line });
@@ -317,7 +285,7 @@ export class BrunelAgent {
     while (true) {
       // Skip showing the prompt when session prompts are already queued
       // (avoids briefly flashing the prompt before immediately cancelling it).
-      if (session?.hasPendingPrompts()) {
+      if (workerController.session?.hasPendingPrompts()) {
         await drainPendingPrompts();
         continue;
       }
@@ -342,12 +310,12 @@ export class BrunelAgent {
 
       // ^D on empty buffer — treat as exit.
       if (userInput === "__eof__") {
-        if (!session) { await doExit(); break; }
-        const taskInfo = session.getTaskQuitInfo();
+        if (!workerController.isActive) { await doExit(); break; }
+        const taskInfo = workerController.getTaskQuitInfo();
         if (taskInfo) {
-          const choice = await session.confirmTaskQuit(taskInfo);
+          const choice = await workerController.confirmTaskQuit(taskInfo);
           if (choice === "cancel") continue;
-          if (choice === "complete-and-quit") await session.completeCurrentTask();
+          if (choice === "complete-and-quit") await workerController.completeCurrentTask();
         }
         break;
       }
@@ -355,8 +323,8 @@ export class BrunelAgent {
       // ^C on empty buffer — stop worker mode if idle; otherwise ignore
       // (the running query was already interrupted by the SIGINT handler).
       if (userInput === "__ctrl_c__") {
-        if (session && !session.hasTask()) {
-          await stopWorker();
+        if (workerController.isActive && !workerController.hasTask()) {
+          await workerController.stop();
         }
         continue;
       }
@@ -386,8 +354,8 @@ export class BrunelAgent {
     }
 
     // Worker mode post-loop: send goodbye, destroy workspace, tear down I/O, exit.
-    if (workerCleanup) {
-      await workerCleanup();
+    if (workerController.isCleanupPending) {
+      await workerController.cleanup();
       process.exit(0);
     }
   }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -62,15 +62,13 @@ export class BrunelAgent {
   /**
    * Complete setup and enter the routing loop.
    *
-   * If runWorkerMode is true, subscribes to workspace events, clones the repo,
-   * connects to the foreman, and installs signal handlers before starting the
-   * loop. In REPL mode the loop starts immediately with no foreman connection.
+   * If runWorkerMode is true, connects to the foreman immediately (equivalent
+   * to running /worker:start on startup). Worker mode can also be toggled at
+   * runtime via /worker:start and /worker:stop. The status bar is always shown.
    */
   async start(runWorkerMode: boolean): Promise<void> {
-    // Worker mode setup: discover the repo at startup, then subscribe to
-    // workspace events, create the clone, configure the WorkerSession, and
-    // install signal handlers.
-    const repo = runWorkerMode ? await WorkerSession.getRemoteRepo() : "";
+    // Always detect the repo so /worker:start can use it at runtime.
+    const repo = await WorkerSession.getRemoteRepo();
 
     // Build workspace config after repo detection. repoUrl can be set explicitly
     // in config; otherwise it's derived from the detected git remote + token.
@@ -89,20 +87,106 @@ export class BrunelAgent {
       : undefined;
     const workspaceController = new WorkspaceController(workspace, this.display, config);
 
-    const workerCtx = runWorkerMode
-      ? await startWorkerMode(this.display, this.picker, workspaceController, repo)
-      : undefined;
-    const session = workerCtx?.session;
-    const workerCleanup = workerCtx?.cleanup;
+    // Mutable session and cleanup refs — updated when worker mode is started/stopped.
+    let session: WorkerSession | undefined;
+    let workerCleanup: (() => Promise<void>) | undefined;
 
-    // doExit handles REPL workspace cleanup and stdin/stdout teardown.
-    // Only called in REPL mode (worker mode cleanup goes through workerCleanup()).
+    // doExit handles workspace cleanup and stdin/stdout teardown.
+    // Called on exit from pure REPL mode (no active worker session).
     const doExit = async () => {
       await workspaceController.onDestroy();
       process.stdout.write("\x1b[?2004l\r\n");
       if (process.stdin.isTTY) process.stdin.setRawMode(false);
       process.stdin.pause();
     };
+
+    // ── Routing queue ─────────────────────────────────────────────────────────
+    //
+    // Defined early so attachSessionListeners (which is called by startWorker)
+    // can enqueue session events before the routing loop is reached.
+
+    type RoutingEvent =
+      | { type: "line"; value: string }
+      | { type: "session"; event: "prompts_ready" | "fatal" };
+
+    const routingQueue: RoutingEvent[] = [];
+    let routingWaiter: ((e: RoutingEvent) => void) | null = null;
+
+    const enqueueRoutingEvent = (event: RoutingEvent): void => {
+      if (routingWaiter) { const w = routingWaiter; routingWaiter = null; w(event); }
+      else routingQueue.push(event);
+    };
+
+    const nextRoutingEvent = (): Promise<RoutingEvent> => {
+      if (routingQueue.length) return Promise.resolve(routingQueue.shift()!);
+      return new Promise((resolve) => { routingWaiter = resolve; });
+    };
+
+    // ── Session listener attachment ────────────────────────────────────────────
+
+    const attachSessionListeners = (s: WorkerSession): void => {
+      s.on("prompts_ready", () => {
+        this.input.cancel();
+        enqueueRoutingEvent({ type: "session", event: "prompts_ready" });
+      });
+      s.on("fatal", () => {
+        this.input.cancel();
+        enqueueRoutingEvent({ type: "session", event: "fatal" });
+      });
+    };
+
+    // ── Worker mode start/stop helpers ────────────────────────────────────────
+
+    const stopWorker = async (): Promise<void> => {
+      if (!session) return;
+      const taskInfo = session.getTaskQuitInfo();
+      if (taskInfo) {
+        const choice = await session.confirmTaskQuit(taskInfo);
+        if (choice === "cancel") return;
+        if (choice === "complete-and-quit") await session.completeCurrentTask();
+      }
+      session.stop();
+      session = undefined;
+      workerCleanup = undefined; // prevent double-cleanup on later exit
+      this.agentStatus.setWorkerModeActive(false);
+      this.display.print(c.sageGreen("Worker mode stopped."));
+    };
+
+    const startWorker = async (): Promise<void> => {
+      if (session) {
+        this.display.print(c.amber("Worker mode is already active."));
+        return;
+      }
+      const ctx = await startWorkerMode(this.display, this.picker, workspaceController, repo);
+      session = ctx.session;
+      workerCleanup = ctx.cleanup;
+      attachSessionListeners(session);
+    };
+
+    // ── Signal handlers ───────────────────────────────────────────────────────
+    //
+    // Registered once; close over `session` so they always see the current state
+    // regardless of when worker mode is started or stopped.
+
+    process.on("SIGINT", () => {
+      if (!session?.interrupt()) {
+        // Nothing to interrupt — print a newline to keep the terminal tidy.
+        process.stdout.write("\n");
+      }
+    });
+    process.on("SIGTERM", async () => {
+      session?.sendGoodbye();
+      await doExit();
+      process.exit(0);
+    });
+
+    // Start worker mode immediately if requested via --worker-mode flag.
+    if (runWorkerMode) {
+      await startWorker();
+    }
+
+    // Status bar is always shown regardless of worker mode.
+    this.display.startPersistentBar();
 
     // Print the startup banner.
     this.display.print(c.sageGreen(hr("═")));
@@ -119,11 +203,24 @@ export class BrunelAgent {
 
     // Register all commands. All commands are present in both REPL and worker
     // modes; commands that require a foreman connection degrade gracefully.
-    // Registration happens here rather than the constructor because some
-    // handlers close over start()-local state (sessionId, doExit, session).
     const registry = this.controller.registry;
     workspaceController.registerCommands(registry.scoped("workspace"));
-    registerWorkerCommands(session, registry.scoped("worker"), this.display);
+    const workerRegistry = registry.scoped("worker");
+    registerWorkerCommands(() => session, workerRegistry, this.display);
+    workerRegistry.register("start", {
+      description: "Connect to the foreman and start accepting tasks",
+      handler: async () => { await startWorker(); },
+    });
+    workerRegistry.register("stop", {
+      description: "Disconnect from the foreman",
+      handler: async () => {
+        if (!session) {
+          this.display.print(c.amber("Worker mode is not active."));
+          return undefined;
+        }
+        await stopWorker();
+      },
+    });
     registry.register("exit", {
       description: "Exit",
       handler: async () => {
@@ -211,42 +308,10 @@ export class BrunelAgent {
       }
     };
 
-    // ── Routing ─────────────────────────────────────────────────────────────
+    // ── Routing loop ──────────────────────────────────────────────────────────
     //
-    // Session events and user input flow through a shared async event channel.
-    // No promise-racing or event-to-promise adapters needed: session events push
-    // directly to the channel, and ask() pushes when it receives real input.
-    // The routing loop sleeps until the next event arrives.
-
-    type RoutingEvent =
-      | { type: "line"; value: string }
-      | { type: "session"; event: "prompts_ready" | "fatal" };
-
-    // Minimal async FIFO queue.
-    const routingQueue: RoutingEvent[] = [];
-    let routingWaiter: ((e: RoutingEvent) => void) | null = null;
-
-    const enqueueRoutingEvent = (event: RoutingEvent): void => {
-      if (routingWaiter) { const w = routingWaiter; routingWaiter = null; w(event); }
-      else routingQueue.push(event);
-    };
-
-    const nextRoutingEvent = (): Promise<RoutingEvent> => {
-      if (routingQueue.length) return Promise.resolve(routingQueue.shift()!);
-      return new Promise((resolve) => { routingWaiter = resolve; });
-    };
-
-    // Session events push directly to the channel (and cancel any active prompt).
-    if (session) {
-      session.on("prompts_ready", () => {
-        this.input.cancel();
-        enqueueRoutingEvent({ type: "session", event: "prompts_ready" });
-      });
-      session.on("fatal", () => {
-        this.input.cancel();
-        enqueueRoutingEvent({ type: "session", event: "fatal" });
-      });
-    }
+    // Session events and user input flow through the shared async event channel
+    // defined above. The routing loop sleeps until the next event arrives.
 
     // One round of readline: shows the prompt and pushes to the channel when the
     // user submits real input. Fire-and-forget — the loop calls this when ready.
@@ -260,9 +325,6 @@ export class BrunelAgent {
         if (line !== null) enqueueRoutingEvent({ type: "line", value: line });
       });
     };
-
-    // ── Routing loop ─────────────────────────────────────────────────────
-    // Sleeps until the next routing event arrives, then dispatches it.
 
     while (true) {
       // Skip showing the prompt when session prompts are already queued
@@ -290,7 +352,7 @@ export class BrunelAgent {
       // event.type === "line" — real user input
       const userInput = event.value;
 
-      // ^D / ^C on empty buffer — treat as exit.
+      // ^D on empty buffer — treat as exit.
       if (userInput === "__eof__") {
         if (!session) { await doExit(); break; }
         const taskInfo = session.getTaskQuitInfo();
@@ -300,6 +362,15 @@ export class BrunelAgent {
           if (choice === "complete-and-quit") await session.completeCurrentTask();
         }
         break;
+      }
+
+      // ^C on empty buffer — stop worker mode if idle; otherwise ignore
+      // (the running query was already interrupted by the SIGINT handler).
+      if (userInput === "__ctrl_c__") {
+        if (session && !session.hasTask()) {
+          await stopWorker();
+        }
+        continue;
       }
 
       const action = await this.controller.dispatch(userInput);

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -69,6 +69,8 @@ export class BrunelAgent {
   async start(runWorkerMode: boolean): Promise<void> {
     // Always detect the repo so /worker:start can use it at runtime.
     const repo = await WorkerSession.getRemoteRepo();
+    // Show current branch in the minimal status bar before worker mode activates.
+    this.agentStatus.update({ branch: await WorkerSession.getCurrentBranch() });
 
     // Build workspace config after repo detection. repoUrl can be set explicitly
     // in config; otherwise it's derived from the detected git remote + token.
@@ -206,21 +208,7 @@ export class BrunelAgent {
     const registry = this.controller.registry;
     workspaceController.registerCommands(registry.scoped("workspace"));
     const workerRegistry = registry.scoped("worker");
-    registerWorkerCommands(() => session, workerRegistry, this.display);
-    workerRegistry.register("start", {
-      description: "Connect to the foreman and start accepting tasks",
-      handler: async () => { await startWorker(); },
-    });
-    workerRegistry.register("stop", {
-      description: "Disconnect from the foreman",
-      handler: async () => {
-        if (!session) {
-          this.display.print(c.amber("Worker mode is not active."));
-          return undefined;
-        }
-        await stopWorker();
-      },
-    });
+    registerWorkerCommands(() => session, workerRegistry, this.display, startWorker, stopWorker);
     registry.register("exit", {
       description: "Exit",
       handler: async () => {

--- a/src/agent/models/agent-status.ts
+++ b/src/agent/models/agent-status.ts
@@ -42,6 +42,7 @@ export class AgentStatus extends EventEmitter {
   private _taskInputTokens = 0;
   private _taskOutputTokens = 0;
   private _taskCostUsd: number | undefined;
+  private _workerModeActive = false;
 
   // Fired after a tool result is printed (tool has just finished running).
   // Used by the worker to refresh git branch in the status bar after Bash.
@@ -81,6 +82,7 @@ export class AgentStatus extends EventEmitter {
   get taskInputTokens(): number { return this._taskInputTokens; }
   get taskOutputTokens(): number { return this._taskOutputTokens; }
   get taskCostUsd(): number | undefined { return this._taskCostUsd; }
+  get workerModeActive(): boolean { return this._workerModeActive; }
 
   /** Apply a partial status update and emit "change". */
   update(patch: WorkerStatusPatch): void {
@@ -105,6 +107,12 @@ export class AgentStatus extends EventEmitter {
     if (costUsd != null) {
       this._taskCostUsd = (this._taskCostUsd ?? 0) + costUsd;
     }
+    this.emit("change");
+  }
+
+  /** Set whether worker mode is active and emit "change". */
+  setWorkerModeActive(active: boolean): void {
+    this._workerModeActive = active;
     this.emit("change");
   }
 

--- a/src/agent/views/input.ts
+++ b/src/agent/views/input.ts
@@ -500,7 +500,7 @@ export class Input {
         return;
       }
       else if (ch === "\x7f" || ch === "\x08")      { this._deleteBack(); }
-      else if (ch === "\x03") { if (this._buffer) { this._replaceBuffer(""); } else { process.stdout.write("^C"); this._exit(); } }
+      else if (ch === "\x03") { if (this._buffer) { this._replaceBuffer(""); } else { process.stdout.write("^C"); this._submit("__ctrl_c__"); } }
       else if (ch === "\x04") { if (!this._buffer) this._exit(); else this._deleteForward(); }
       else if (ch === "\x01")                       { this._moveTo(0); }                      // ^A
       else if (ch === "\x05")                       { this._moveTo(this._buffer.length); }    // ^E

--- a/src/agent/views/renderer.ts
+++ b/src/agent/views/renderer.ts
@@ -577,10 +577,14 @@ export class Renderer {
   fmtStatusBar(status: AgentStatus, width: number): string {
     const modelName = (!status.model || status.model === "default") ? "sonnet" : status.model;
     const effortStr = status.effort ? ` (${status.effort})` : "";
+    // Base parts shared by both modes: worker id + model/effort.
+    const baseParts = [`worker ${shortWorkerId(status.agentId)}`, `${modelName}${effortStr}`];
 
     if (!status.workerModeActive) {
-      // Minimal bar when worker mode is off: agent ID + model/effort only.
-      let leftText = [`worker ${shortWorkerId(status.agentId)}`, `${modelName}${effortStr}`].join(" ∙ ");
+      // Minimal bar: agent ID + model/effort + branch (if known).
+      const parts = [...baseParts];
+      if (status.branch) parts.push(status.branch);
+      let leftText = parts.join(" ∙ ");
       if (leftText.length > width) leftText = leftText.slice(0, Math.max(0, width - 1)) + "…";
       // Dim sage-green background + bright-white text. No trailing reset: drawRaw()
       // appends \x1b[K (fills remaining width with the same background) then \x1b[0m.
@@ -602,7 +606,7 @@ export class Renderer {
                                                    `Disconnected${codeStr}`;
 
     // Left side: worker {id8} ∙ {model} ∙ {task info}
-    const parts: string[] = [`worker ${shortWorkerId(status.agentId)}`, `${modelName}${effortStr}`];
+    const parts = [...baseParts];
     if (status.taskNumber != null) parts.push(`task #${status.taskNumber}`);
     else parts.push("no current task");
     if (status.prNumber != null) parts.push(`PR #${status.prNumber}`);

--- a/src/agent/views/renderer.ts
+++ b/src/agent/views/renderer.ts
@@ -575,6 +575,18 @@ export class Renderer {
    * Called by Display._updatePersistent() and Display._handleResize().
    */
   fmtStatusBar(status: AgentStatus, width: number): string {
+    const modelName = (!status.model || status.model === "default") ? "sonnet" : status.model;
+    const effortStr = status.effort ? ` (${status.effort})` : "";
+
+    if (!status.workerModeActive) {
+      // Minimal bar when worker mode is off: agent ID + model/effort only.
+      let leftText = [`worker ${shortWorkerId(status.agentId)}`, `${modelName}${effortStr}`].join(" ∙ ");
+      if (leftText.length > width) leftText = leftText.slice(0, Math.max(0, width - 1)) + "…";
+      // Dim sage-green background + bright-white text. No trailing reset: drawRaw()
+      // appends \x1b[K (fills remaining width with the same background) then \x1b[0m.
+      return `\x1b[48;5;22m\x1b[97m${leftText.padEnd(width)}`;
+    }
+
     // Right side: connection status
     const retryInSeconds = status.reconnectAt != null
       ? Math.max(0, Math.ceil((status.reconnectAt - Date.now()) / 1000))
@@ -590,8 +602,6 @@ export class Renderer {
                                                    `Disconnected${codeStr}`;
 
     // Left side: worker {id8} ∙ {model} ∙ {task info}
-    const modelName = (!status.model || status.model === "default") ? "sonnet" : status.model;
-    const effortStr = status.effort ? ` (${status.effort})` : "";
     const parts: string[] = [`worker ${shortWorkerId(status.agentId)}`, `${modelName}${effortStr}`];
     if (status.taskNumber != null) parts.push(`task #${status.taskNumber}`);
     else parts.push("no current task");

--- a/src/agent/views/renderer.ts
+++ b/src/agent/views/renderer.ts
@@ -575,6 +575,10 @@ export class Renderer {
    * Called by Display._updatePersistent() and Display._handleResize().
    */
   fmtStatusBar(status: AgentStatus, width: number): string {
+    // Dim sage-green bg + bright-white text. No trailing reset: drawRaw() appends
+    // \x1b[K (fills remaining width with the same bg) then \x1b[0m.
+    const styledBar = (content: string) => `\x1b[48;5;22m\x1b[97m${content}`;
+
     const modelName = (!status.model || status.model === "default") ? "sonnet" : status.model;
     const effortStr = status.effort ? ` (${status.effort})` : "";
     // Base parts shared by both modes: worker id + model/effort.
@@ -586,9 +590,7 @@ export class Renderer {
       if (status.branch) parts.push(status.branch);
       let leftText = parts.join(" ∙ ");
       if (leftText.length > width) leftText = leftText.slice(0, Math.max(0, width - 1)) + "…";
-      // Dim sage-green background + bright-white text. No trailing reset: drawRaw()
-      // appends \x1b[K (fills remaining width with the same background) then \x1b[0m.
-      return `\x1b[48;5;22m\x1b[97m${leftText.padEnd(width)}`;
+      return styledBar(leftText.padEnd(width));
     }
 
     // Right side: connection status
@@ -626,8 +628,6 @@ export class Renderer {
     }
 
     const gap = Math.max(1, width - leftText.length - rightText.length);
-    // Dim sage-green background + bright-white text. No trailing reset: drawRaw()
-    // appends \x1b[K (fills remaining width with the same background) then \x1b[0m.
-    return `\x1b[48;5;22m\x1b[97m${leftText + " ".repeat(gap) + rightText}`;
+    return styledBar(leftText + " ".repeat(gap) + rightText);
   }
 }

--- a/tests/display.worker-status.test.ts
+++ b/tests/display.worker-status.test.ts
@@ -34,6 +34,7 @@ function getStatusText(opts: {
     disconnectCode: opts.disconnectCode,
     reconnectAt: opts.reconnectAt,
   });
+  status.setWorkerModeActive(true);
   const display = new Display(getConfig(), status);
   return stripAnsi(display.renderer.fmtStatusBar(status, opts.width ?? 119));
 }
@@ -265,6 +266,7 @@ describe("Display persistent status bar", () => {
 
   beforeEach(() => {
     agentStatus = new AgentStatus({ agentId: "test-agent" });
+    agentStatus.setWorkerModeActive(true);
     display = new Display(getConfig(), agentStatus);
     stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
     // Ensure clean state

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -30,9 +30,13 @@ export async function registerTestCommands(): Promise<CommandController> {
   registry.register("clear",  { description: "Clear the conversation", handler: noop });
   registry.register("model",  { description: "Select the Claude model to use", handler: noop });
   registry.register("effort", { description: "Set the effort level for Claude's thinking", handler: noop });
-  registry.scoped("worker").register("complete", {
+  registry.register("permissions", { description: "Set the permission mode for tool use", handler: noop });
+  const workerRegistry = registry.scoped("worker");
+  workerRegistry.register("complete", {
     description: "Mark the current task as done",
     handler: async () => "task-complete",
   });
+  workerRegistry.register("start", { description: "Connect to the foreman and start accepting tasks", handler: noop });
+  workerRegistry.register("stop", { description: "Disconnect from the foreman", handler: noop });
   return controller;
 }

--- a/tests/repl.autocomplete.test.ts
+++ b/tests/repl.autocomplete.test.ts
@@ -61,7 +61,7 @@ describe("listCommandNames", () => {
 
   it("returns only builtins when directory is missing", () => {
     const result = registry.listCommandNames(() => null);
-    expect(result).toEqual(["clear", "effort", "exit", "model", "worker:complete", "workspace:create", "workspace:prune", "workspace:remove", "workspace:reset"]);
+    expect(result).toEqual(["clear", "effort", "exit", "model", "permissions", "worker:complete", "worker:start", "worker:stop", "workspace:create", "workspace:prune", "workspace:remove", "workspace:reset"]);
   });
 
   it("includes a file at root level", () => {

--- a/tests/repl.input.test.ts
+++ b/tests/repl.input.test.ts
@@ -328,13 +328,13 @@ describe("ask() - exit conditions", () => {
     });
   });
 
-  it("^C with empty buffer → resolves with '__eof__' (does not call process.exit)", async () => {
+  it("^C with empty buffer → resolves with '__ctrl_c__' (does not call process.exit)", async () => {
     const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as any);
     await withFakeStdin(async (stdin) => {
       const p = testInput.ask("> ", () => []);
       stdin.push("\x03"); // ^C with empty buffer
       const result = await p;
-      expect(result).toBe("__eof__");
+      expect(result).toBe("__ctrl_c__");
       expect(exitSpy).not.toHaveBeenCalled();
     });
     exitSpy.mockRestore();

--- a/tests/status-bar.test.ts
+++ b/tests/status-bar.test.ts
@@ -38,6 +38,7 @@ describe("AgentStatus getStatusText", () => {
   it("shows worker id and no current task when idle", () => {
     const status = new AgentStatus({ agentId: "7c254628-abcd-1234-efgh-000000000000" });
     status.update({ connectionStatus: "connected" });
+    status.setWorkerModeActive(true);
     const display = new Display(getConfig(), status);
     const result = stripAnsi(display.renderer.fmtStatusBar(status, 119));
     expect(result).toContain("worker 7c254628");
@@ -49,6 +50,7 @@ describe("AgentStatus getStatusText", () => {
     const status = new AgentStatus({ agentId: "abc12345-0000-0000-0000-000000000000" });
     getConfig().verbose = true;
     status.update({ connectionStatus: "disconnected", disconnectCode: 1006, reconnectAt: Date.now() + 2000 });
+    status.setWorkerModeActive(true);
     const display = new Display(getConfig(), status);
     const result = stripAnsi(display.renderer.fmtStatusBar(status, 119));
     expect(result).toContain("Disconnected (1006)");
@@ -58,6 +60,7 @@ describe("AgentStatus getStatusText", () => {
     const status = new AgentStatus({ agentId: "abc12345-0000-0000-0000-000000000000" });
     getConfig().verbose = false;
     status.update({ connectionStatus: "disconnected", disconnectCode: 1006 });
+    status.setWorkerModeActive(true);
     const display = new Display(getConfig(), status);
     const result = stripAnsi(display.renderer.fmtStatusBar(status, 119));
     expect(result).toContain("Disconnected");
@@ -67,6 +70,7 @@ describe("AgentStatus getStatusText", () => {
   it("shows task, PR, and branch when set", () => {
     const status = new AgentStatus({ agentId: "7c254628-abcd-1234-efgh-000000000000" });
     status.update({ taskNumber: 374, prNumber: 406, branch: "db-single-source-of-truth", connectionStatus: "connected" });
+    status.setWorkerModeActive(true);
     const display = new Display(getConfig(), status);
     const result = stripAnsi(display.renderer.fmtStatusBar(status, 119));
     expect(result).toContain("task #374");

--- a/tests/worker.main.test.ts
+++ b/tests/worker.main.test.ts
@@ -49,20 +49,19 @@ const fakeWorkspace = vi.hoisted(() => {
   return ws;
 });
 
-// Captures the WorkerSession created by startWorkerMode so tests can emit session
-// events directly (e.g. "prompts_ready") without a real foreman connection.
+// Captures the WorkerSession created by WorkerController.start() so tests can emit
+// session events directly (e.g. "prompts_ready") without a real foreman connection.
 const capturedSession = vi.hoisted(() => ({ current: null as import("../src/agent/controllers/worker-controller.js").WorkerSession | null }));
 
 vi.mock("../src/agent/controllers/worker-controller.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../src/agent/controllers/worker-controller.js")>();
-  return {
-    ...actual,
-    startWorkerMode: async (...args: Parameters<typeof actual.startWorkerMode>) => {
-      const result = await actual.startWorkerMode(...args);
-      capturedSession.current = result.session;
-      return result;
-    },
-  };
+  class CapturingController extends actual.WorkerController {
+    override async start(): Promise<void> {
+      await super.start();
+      capturedSession.current = this.session ?? null;
+    }
+  }
+  return { ...actual, WorkerController: CapturingController };
 });
 
 vi.mock("../src/agent/models/workspace.js", async (importOriginal) => {

--- a/tests/worker.mode-switching.test.ts
+++ b/tests/worker.mode-switching.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ── Module mocks ─────────────────────────────────────────────────────────────
+
+vi.mock("ws", async () => {
+  const { EventEmitter } = await import("node:events");
+  return {
+    WebSocket: class FakeWebSocket extends EventEmitter {
+      readyState = 1;
+      send = () => {};
+      close = () => {};
+      terminate = () => {};
+    },
+  };
+});
+
+// Captures sessions created by startWorkerMode so tests can inspect state.
+const capturedSessions = vi.hoisted(() => ({
+  list: [] as import("../src/agent/controllers/worker-controller.js").WorkerSession[],
+}));
+
+vi.mock("../src/agent/controllers/worker-controller.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/agent/controllers/worker-controller.js")>();
+  return {
+    ...actual,
+    startWorkerMode: async (...args: Parameters<typeof actual.startWorkerMode>) => {
+      const result = await actual.startWorkerMode(...args);
+      capturedSessions.list.push(result.session);
+      return result;
+    },
+  };
+});
+
+vi.mock("../src/agent/models/workspace.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/agent/models/workspace.js")>();
+  const MockWorkspace = vi.fn().mockImplementation(function() {
+    return {
+      dir: "/fake/workers/test",
+      workspaceDir: "/fake/workers",
+      sessionId: "test",
+      originalCwd: "/fake/original",
+      isCreated: false,
+      on: vi.fn(),
+      create: vi.fn().mockResolvedValue(undefined),
+      destroy: vi.fn().mockResolvedValue(undefined),
+      reset: vi.fn().mockResolvedValue(undefined),
+      checkSafety: vi.fn().mockResolvedValue({ uncommittedFiles: [], unpushedCommits: [], noUpstream: false }),
+      confirm: vi.fn().mockResolvedValue(true),
+    };
+  });
+  (MockWorkspace as any).prune = vi.fn().mockResolvedValue([]);
+  return { ...actual, Workspace: MockWorkspace, confirmIfUnsafe: vi.fn().mockResolvedValue(true) };
+});
+
+vi.mock("../src/agent/views/input.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/agent/views/input.js")>();
+  return { ...actual, Input: vi.fn() };
+});
+vi.mock("../src/agent/views/picker.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/agent/views/picker.js")>();
+  return { ...actual, Picker: vi.fn() };
+});
+vi.mock("../src/agent/controllers/agent-controller.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/agent/controllers/agent-controller.js")>();
+  return { ...actual, AgentController: vi.fn() };
+});
+
+import { BrunelAgent } from "../src/agent/index.js";
+import type { AgentStatus } from "../src/agent/models/agent-status.js";
+import { Input } from "../src/agent/views/input.js";
+import { Picker } from "../src/agent/views/picker.js";
+import { AgentController } from "../src/agent/controllers/agent-controller.js";
+import { getConfig } from "../src/config.js";
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+let mockInput: { ask: ReturnType<typeof vi.fn>; cancel: ReturnType<typeof vi.fn> };
+let mockPicker: { pick: ReturnType<typeof vi.fn> };
+
+function makeMocks() {
+  mockInput = { ask: vi.fn().mockResolvedValue("__eof__"), cancel: vi.fn() };
+  mockPicker = { pick: vi.fn().mockResolvedValue(0) };
+
+  vi.mocked(Input).mockImplementation(function() { return mockInput as unknown as Input; });
+  vi.mocked(Picker).mockImplementation(function() { return mockPicker as unknown as Picker; });
+  vi.mocked(AgentController).mockImplementation(function() {
+    return { runQuery: vi.fn().mockResolvedValue(undefined) } as unknown as AgentController;
+  });
+}
+
+/**
+ * Run BrunelAgent.start(runWorkerMode) and return the agent.
+ * Mocks process.exit so it throws instead of exiting.
+ * Cleans up the persistent bar to avoid resize-listener accumulation.
+ */
+async function runAgent(runWorkerMode: boolean, agentOverride?: BrunelAgent): Promise<BrunelAgent> {
+  const exitSpy = vi.spyOn(process, "exit").mockImplementation((code?: number | string) => {
+    throw new Error("__process_exit__");
+  }) as unknown as ReturnType<typeof vi.spyOn>;
+  const chdirSpy = vi.spyOn(process, "chdir").mockImplementation(() => {});
+  const agent = agentOverride ?? new BrunelAgent(getConfig());
+  try {
+    await agent.start(runWorkerMode);
+  } catch (err) {
+    if (!(err instanceof Error && err.message === "__process_exit__")) throw err;
+  } finally {
+    agent.display.stopPersistentBar(); // prevent resize-listener accumulation
+    exitSpy.mockRestore();
+    chdirSpy.mockRestore();
+  }
+  return agent;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("worker mode switching", () => {
+  beforeEach(() => {
+    capturedSessions.list = [];
+    makeMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("workerModeActive is false by default in REPL mode", async () => {
+    let capturedStatus: AgentStatus | undefined;
+    vi.mocked(AgentController).mockImplementation(function(this: unknown, display: unknown) {
+      capturedStatus = (display as { agentStatus: AgentStatus }).agentStatus;
+      return { runQuery: vi.fn().mockResolvedValue(undefined) } as unknown as AgentController;
+    });
+
+    await runAgent(false);
+    expect(capturedStatus?.workerModeActive).toBe(false);
+  });
+
+  it("workerModeActive is true when --worker-mode flag is used", async () => {
+    let capturedStatus: AgentStatus | undefined;
+    vi.mocked(AgentController).mockImplementation(function(this: unknown, display: unknown) {
+      capturedStatus = (display as { agentStatus: AgentStatus }).agentStatus;
+      return { runQuery: vi.fn().mockResolvedValue(undefined) } as unknown as AgentController;
+    });
+
+    await runAgent(true);
+    expect(capturedStatus?.workerModeActive).toBe(true);
+  });
+
+  it("/worker:start activates worker mode", async () => {
+    let capturedStatus: AgentStatus | undefined;
+    vi.mocked(AgentController).mockImplementation(function(this: unknown, display: unknown) {
+      capturedStatus = (display as { agentStatus: AgentStatus }).agentStatus;
+      return { runQuery: vi.fn().mockResolvedValue(undefined) } as unknown as AgentController;
+    });
+
+    let askCallCount = 0;
+    mockInput.ask.mockImplementation(() => {
+      askCallCount++;
+      if (askCallCount === 1) return Promise.resolve("/worker:start");
+      return Promise.resolve("__eof__");
+    });
+
+    await runAgent(false);
+
+    expect(capturedSessions.list).toHaveLength(1);
+    expect(capturedStatus?.workerModeActive).toBe(true);
+  });
+
+  it("/worker:stop deactivates worker mode", async () => {
+    let capturedStatus: AgentStatus | undefined;
+    vi.mocked(AgentController).mockImplementation(function(this: unknown, display: unknown) {
+      capturedStatus = (display as { agentStatus: AgentStatus }).agentStatus;
+      return { runQuery: vi.fn().mockResolvedValue(undefined) } as unknown as AgentController;
+    });
+
+    let askCallCount = 0;
+    mockInput.ask.mockImplementation(() => {
+      askCallCount++;
+      if (askCallCount === 1) return Promise.resolve("/worker:start");
+      if (askCallCount === 2) return Promise.resolve("/worker:stop");
+      return Promise.resolve("__eof__");
+    });
+
+    await runAgent(false);
+    expect(capturedStatus?.workerModeActive).toBe(false);
+  });
+
+  it("/worker:start when already active prints a message and does not create a second session", async () => {
+    const agent = new BrunelAgent(getConfig());
+    const printedMessages: string[] = [];
+    vi.spyOn(agent.display, "print").mockImplementation((line) => {
+      if (line) printedMessages.push(String(line));
+    });
+
+    let askCallCount = 0;
+    mockInput.ask.mockImplementation(() => {
+      askCallCount++;
+      if (askCallCount === 1) return Promise.resolve("/worker:start");
+      if (askCallCount === 2) return Promise.resolve("/worker:start"); // second start
+      return Promise.resolve("__eof__");
+    });
+
+    await runAgent(false, agent);
+
+    expect(capturedSessions.list).toHaveLength(1); // only one session created
+    expect(printedMessages.some(m => m.includes("already active"))).toBe(true);
+  });
+
+  it("/worker:stop when not active prints a message", async () => {
+    const agent = new BrunelAgent(getConfig());
+    const printedMessages: string[] = [];
+    vi.spyOn(agent.display, "print").mockImplementation((line) => {
+      if (line) printedMessages.push(String(line));
+    });
+
+    let askCallCount = 0;
+    mockInput.ask.mockImplementation(() => {
+      askCallCount++;
+      if (askCallCount === 1) return Promise.resolve("/worker:stop");
+      return Promise.resolve("__eof__");
+    });
+
+    await runAgent(false, agent);
+    expect(printedMessages.some(m => m.includes("not active"))).toBe(true);
+  });
+
+  it("__ctrl_c__ when worker is idle stops worker mode", async () => {
+    let capturedStatus: AgentStatus | undefined;
+    vi.mocked(AgentController).mockImplementation(function(this: unknown, display: unknown) {
+      capturedStatus = (display as { agentStatus: AgentStatus }).agentStatus;
+      return { runQuery: vi.fn().mockResolvedValue(undefined) } as unknown as AgentController;
+    });
+
+    let askCallCount = 0;
+    mockInput.ask.mockImplementation(() => {
+      askCallCount++;
+      if (askCallCount === 1) return Promise.resolve("/worker:start");
+      if (askCallCount === 2) return Promise.resolve("__ctrl_c__"); // ^C while idle (no task)
+      return Promise.resolve("__eof__");
+    });
+
+    await runAgent(false);
+    expect(capturedStatus?.workerModeActive).toBe(false);
+  });
+
+  it("__ctrl_c__ while worker has an active task does not stop worker mode", async () => {
+    let capturedStatus: AgentStatus | undefined;
+    vi.mocked(AgentController).mockImplementation(function(this: unknown, display: unknown) {
+      capturedStatus = (display as { agentStatus: AgentStatus }).agentStatus;
+      return { runQuery: vi.fn().mockResolvedValue(undefined) } as unknown as AgentController;
+    });
+
+    let askCallCount = 0;
+    mockInput.ask.mockImplementation(() => {
+      askCallCount++;
+      if (askCallCount === 1) return Promise.resolve("/worker:start");
+      if (askCallCount === 2) {
+        // Inject a task into the session before returning ^C
+        const s = capturedSessions.list[0];
+        if (s) {
+          (s as any).currentTaskId = "task-99";
+          (s as any).currentIssue = { number: 99, title: "Test", body: "", labels: [], repoUrl: "" };
+        }
+        return Promise.resolve("__ctrl_c__"); // ^C with task in progress
+      }
+      return Promise.resolve("__eof__");
+    });
+    // "Yes, quit anyway" so the exit confirmation allows the loop to break
+    mockPicker.pick.mockResolvedValue(1);
+
+    await runAgent(false);
+
+    // Worker mode should still be active — ^C did not stop it (task was in progress)
+    expect(capturedStatus?.workerModeActive).toBe(true);
+  });
+
+  it("after /worker:stop, exiting does not call process.exit(0)", async () => {
+    // When worker mode is stopped before exit, workerCleanup is cleared.
+    // The exit path should go through doExit() which does NOT call process.exit.
+    let askCallCount = 0;
+    mockInput.ask.mockImplementation(() => {
+      askCallCount++;
+      if (askCallCount === 1) return Promise.resolve("/worker:start");
+      if (askCallCount === 2) return Promise.resolve("/worker:stop");
+      return Promise.resolve("__eof__");
+    });
+
+    let exitCalled = false;
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      exitCalled = true;
+      throw new Error("__process_exit__");
+    }) as unknown as ReturnType<typeof vi.spyOn>;
+    const chdirSpy = vi.spyOn(process, "chdir").mockImplementation(() => {});
+    const agent = new BrunelAgent(getConfig());
+    try {
+      await agent.start(false);
+    } catch (err) {
+      if (!(err instanceof Error && err.message === "__process_exit__")) throw err;
+    } finally {
+      agent.display.stopPersistentBar();
+      exitSpy.mockRestore();
+      chdirSpy.mockRestore();
+    }
+
+    expect(exitCalled).toBe(false);
+  });
+});

--- a/tests/worker.mode-switching.test.ts
+++ b/tests/worker.mode-switching.test.ts
@@ -14,21 +14,21 @@ vi.mock("ws", async () => {
   };
 });
 
-// Captures sessions created by startWorkerMode so tests can inspect state.
+// Captures sessions created by WorkerController.start() so tests can inspect state.
 const capturedSessions = vi.hoisted(() => ({
   list: [] as import("../src/agent/controllers/worker-controller.js").WorkerSession[],
 }));
 
 vi.mock("../src/agent/controllers/worker-controller.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../src/agent/controllers/worker-controller.js")>();
-  return {
-    ...actual,
-    startWorkerMode: async (...args: Parameters<typeof actual.startWorkerMode>) => {
-      const result = await actual.startWorkerMode(...args);
-      capturedSessions.list.push(result.session);
-      return result;
-    },
-  };
+  class CapturingController extends actual.WorkerController {
+    override async start(): Promise<void> {
+      const hadSession = this.session !== undefined;
+      await super.start();
+      if (!hadSession && this.session) capturedSessions.list.push(this.session);
+    }
+  }
+  return { ...actual, WorkerController: CapturingController };
 });
 
 vi.mock("../src/agent/models/workspace.js", async (importOriginal) => {

--- a/tests/worker.status-model.test.ts
+++ b/tests/worker.status-model.test.ts
@@ -5,6 +5,7 @@ import { getConfig } from "../src/config.js";
 import { stripAnsi } from "./helpers.js";
 
 function fmtStatus(status: AgentStatus): string {
+  status.setWorkerModeActive(true);
   return stripAnsi(new Display(getConfig(), status).renderer.fmtStatusBar(status, 100));
 }
 

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -40,6 +40,7 @@ function sendMsg(ws: FakeWs, msg: Wire.ForemanMessage) {
 }
 
 function fmtStatus(status: AgentStatus): string {
+  status.setWorkerModeActive(true);
   return stripAnsi(new Display(getConfig(), status).renderer.fmtStatusBar(status, 100));
 }
 


### PR DESCRIPTION
## Summary

- Add `/worker:start` and `/worker:stop` slash commands to connect/disconnect from the foreman at runtime, without restarting the agent
- `--worker-mode` flag becomes syntactic sugar for `/worker:start` on startup
- `^C` when worker is idle now invokes `/worker:stop`; when a task is in progress, `^C` still interrupts the query with the same quit prompt
- Persistent status bar is always shown: minimal (agent ID + model) when worker mode is off, full worker status when on
- `AgentStatus.workerModeActive` boolean controls which status bar view renders

## Test plan

- [ ] `npm test` — all unit tests pass (1461 tests, only DB tests fail without Supabase)
- [ ] `npx tsc --noEmit` — type check passes
- [ ] `tests/worker.mode-switching.test.ts` — 9 new tests covering all mode-switching scenarios
- [ ] Manual: start agent in REPL mode, use `/worker:start`, confirm status bar expands; use `/worker:stop`, confirm status bar minimizes
- [ ] Manual: use `--worker-mode` flag and confirm it behaves identically to running `/worker:start` in REPL mode
- [ ] Manual: press `^C` when worker is idle to confirm it stops worker mode; press `^C` while a task runs to confirm it does NOT stop worker mode

Closes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)