### PR TITLE
fix: prevent event loss during zombie connections

### DIFF
--- a/docs/superpowers/specs/2026-03-27-reconnection-hardening-design.md
+++ b/docs/superpowers/specs/2026-03-27-reconnection-hardening-design.md
@@ -1,7 +1,7 @@
 # Reconnection Hardening: Findings and Plan
 
 **Date:** 2026-03-27
-**Status:** Stages 1 + 2 shipped (PR #295, PR #297). Stage 3 tracked in #298.
+**Status:** Stages 1 + 2 shipped (PR #295, PR #297). Stage 3 item 1 shipped (PR #870). Remainder tracked in #298.
 
 ---
 
@@ -133,17 +133,9 @@ Goal: Get enough signal to confirm hypotheses before investing in fixes.
 
 Goal: Stop the disconnections from happening in the first place.
 
-1. **Add foreman-side WebSocket ping** — use `ws` library's built-in ping support on the `WebSocketServer`:
-   ```typescript
-   const wss = new WebSocketServer({ noServer: true });
-   const PING_INTERVAL = 25_000; // 25s, safely under any 30s proxy timeout
-   const pingInterval = setInterval(() => {
-     for (const client of wss.clients) {
-       if (client.readyState === WebSocket.OPEN) client.ping();
-     }
-   }, PING_INTERVAL);
-   ```
-   Workers respond with pong automatically (built into the `ws` library). This keeps connections alive through Railway's proxy.
+1. **Add foreman-side WebSocket ping** — sends pings on a configurable interval (default 25 s, safely under any 30 s proxy timeout). Workers respond with pong automatically. This keeps connections alive through Railway's proxy.
+
+   Note: Stage 2 sent pings but did not track pong responses, so zombie connections (network silently dead but TCP not yet reset) could persist until the OS TCP keepalive timer fired — potentially minutes.
 
 2. **Add jitter to reconnect delay** — randomize the reconnect wait between 2–5 seconds to avoid thundering-herd on foreman restart. *(Subsequently upgraded in PR #866 to full exponential backoff — see H5 above.)*
 
@@ -153,7 +145,10 @@ Goal: Stop the disconnections from happening in the first place.
 
 Goal: Reduce the impact of disconnections, foreman restarts, and worker interruptions.
 
-1. **Fix the event-drop bug (H2)** — On worker disconnect in the foreman's `ws.on("close")` handler: if the worker had an assigned task, set the task status back to `"pending"`. Events arriving during reconnection will queue normally and be forwarded when the worker reclaims the task.
+1. **Fix the event-drop bug (H2)** ✅ (PR #870) — Three-part fix:
+   - **Foreman-side heartbeat**: track pong responses with a `WeakMap<WebSocket, boolean>`. On each timer tick, terminate connections that have not ponged since the previous ping. This mirrors the existing worker-side heartbeat and limits the zombie-connection window to ~one ping interval (25 s) instead of the OS TCP keepalive timeout (potentially minutes).
+   - **Queue on send failure**: `sendMsg()` now returns a boolean. `forwardEvent()` and `flushQueuedEvents()` check the result and queue any event whose underlying send failed (socket was not OPEN), so it is replayed on the worker's next reconnect.
+   - **Queue instead of drop for unknown-registry workers**: the previous code dropped events when `task.workerId` pointed to a worker no longer in the registry; these are now queued for replay, since the worker may be mid-reconnect.
 
 2. **Address double-assignment on foreman restart (H3)** — Two approaches (in order of complexity):
    - **Grace period:** Delay `reconcile()` on startup by a configurable number of seconds (e.g., 10s) to allow reconnecting workers to claim their tasks before new assignments are made.

--- a/src/foreman/controllers/wss.ts
+++ b/src/foreman/controllers/wss.ts
@@ -244,9 +244,9 @@ export class ForemanWss {
     });
   }
 
-  sendMsg(worker: Worker, msg: Wire.ForemanMessage, logTaskId?: string, onError?: (err: Error) => void): boolean {
-    const taskId = logTaskId ?? (("taskId" in msg ? msg.taskId : null) ?? null);
-    const sent = worker.send(msg, onError);
+  sendMsg(worker: Worker, msg: Wire.ForemanMessage, opts: { logTaskId?: string; onError?: (err: Error) => void } = {}): boolean {
+    const taskId = opts.logTaskId ?? (("taskId" in msg ? msg.taskId : null) ?? null);
+    const sent = worker.send(msg, opts.onError);
     if (sent) {
       this.logAndBroadcastSent(worker.workerId, taskId, msg.type, msg as unknown as Record<string, unknown>, worker.repo.id, worker.repo.fullName);
     }
@@ -306,11 +306,10 @@ export class ForemanWss {
       const sent = this.sendMsg(
         worker,
         { type: "event_notification", taskId: task.taskId, event: evt.toWorkerPayload() },
-        undefined,
-        (err) => {
+        { onError: (err) => {
           task.queueEvent(evt);
           this.workerLog(worker.workerId, `✗ event_notification send error — requeued #${task.issueNumber} ${evt.eventName}: ${fmtError(err)}`);
-        },
+        } },
       );
       if (sent) {
         this.workerLog(worker.workerId, `→ event_notification #${task.issueNumber} ${evt.eventName} (queued)`);
@@ -322,7 +321,7 @@ export class ForemanWss {
   }
 
   private cancelWorker(worker: Worker, task: Task | null): void {
-    this.sendMsg(worker, { type: "hello_ack", workerId: worker.workerId, status: "cancelled", repoStatus: worker.repo.status }, task?.taskId);
+    this.sendMsg(worker, { type: "hello_ack", workerId: worker.workerId, status: "cancelled", repoStatus: worker.repo.status }, { logTaskId: task?.taskId });
   }
 
   private async reclaimWorker(worker: Worker, task: Task): Promise<void> {
@@ -332,7 +331,7 @@ export class ForemanWss {
       await task.assign(worker);
     }
     // For complete tasks, the task stays complete while worker finishes cleanup/finalization work
-    this.sendMsg(worker, { type: "hello_ack", workerId: worker.workerId, status: "busy", repoStatus: worker.repo.status }, task.taskId);
+    this.sendMsg(worker, { type: "hello_ack", workerId: worker.workerId, status: "busy", repoStatus: worker.repo.status }, { logTaskId: task.taskId });
     this.flushQueuedEvents(worker, task);
   }
 
@@ -527,11 +526,10 @@ export class ForemanWss {
         const sent = this.sendMsg(
           worker,
           { type: "event_notification", taskId: task.taskId, event: evt.toWorkerPayload() },
-          undefined,
-          (err) => {
+          { onError: (err) => {
             task.queueEvent(evt);
             log(`[task ${ref}] ${evt.eventName} requeued (send error: ${fmtError(err)})`);
-          },
+          } },
         );
         if (sent) {
           log(`[worker ${shortWorkerId(task.workerId)}] → event_notification ${ref} ${evt.eventName}`);

--- a/src/foreman/controllers/wss.ts
+++ b/src/foreman/controllers/wss.ts
@@ -244,9 +244,9 @@ export class ForemanWss {
     });
   }
 
-  sendMsg(worker: Worker, msg: Wire.ForemanMessage, logTaskId?: string): boolean {
+  sendMsg(worker: Worker, msg: Wire.ForemanMessage, logTaskId?: string, onError?: (err: Error) => void): boolean {
     const taskId = logTaskId ?? (("taskId" in msg ? msg.taskId : null) ?? null);
-    const sent = worker.send(msg);
+    const sent = worker.send(msg, onError);
     if (sent) {
       this.logAndBroadcastSent(worker.workerId, taskId, msg.type, msg as unknown as Record<string, unknown>, worker.repo.id, worker.repo.fullName);
     }
@@ -303,7 +303,15 @@ export class ForemanWss {
 
   private flushQueuedEvents(worker: Worker, task: Task): void {
     for (const evt of task.drainEvents()) {
-      const sent = this.sendMsg(worker, { type: "event_notification", taskId: task.taskId, event: evt.toWorkerPayload() });
+      const sent = this.sendMsg(
+        worker,
+        { type: "event_notification", taskId: task.taskId, event: evt.toWorkerPayload() },
+        undefined,
+        (err) => {
+          task.queueEvent(evt);
+          this.workerLog(worker.workerId, `✗ event_notification send error — requeued #${task.issueNumber} ${evt.eventName}: ${fmtError(err)}`);
+        },
+      );
       if (sent) {
         this.workerLog(worker.workerId, `→ event_notification #${task.issueNumber} ${evt.eventName} (queued)`);
       } else {
@@ -516,7 +524,15 @@ export class ForemanWss {
         task.queueEvent(evt);
         log(`[task ${ref}] ${evt.eventName} queued (worker ${shortWorkerId(task.workerId)} disconnected)`);
       } else if (worker) {
-        const sent = this.sendMsg(worker, { type: "event_notification", taskId: task.taskId, event: evt.toWorkerPayload() });
+        const sent = this.sendMsg(
+          worker,
+          { type: "event_notification", taskId: task.taskId, event: evt.toWorkerPayload() },
+          undefined,
+          (err) => {
+            task.queueEvent(evt);
+            log(`[task ${ref}] ${evt.eventName} requeued (send error: ${fmtError(err)})`);
+          },
+        );
         if (sent) {
           log(`[worker ${shortWorkerId(task.workerId)}] → event_notification ${ref} ${evt.eventName}`);
         } else {

--- a/src/foreman/controllers/wss.ts
+++ b/src/foreman/controllers/wss.ts
@@ -72,8 +72,17 @@ export class ForemanWss {
     const wss = new WebSocketServer({ noServer: true });
     this.wss = wss;
 
+    // Track pong responses per socket — detect zombie connections.
+    const isAlive = new WeakMap<WebSocket, boolean>();
+
     const pingTimer = setInterval(() => {
       for (const client of wss.clients) {
+        if (!isAlive.get(client)) {
+          // No pong received since last ping — connection is zombie, terminate it.
+          client.terminate();
+          continue;
+        }
+        isAlive.set(client, false);
         if (client.readyState === WebSocket.OPEN) client.ping();
       }
     }, config.pingIntervalMs);
@@ -81,6 +90,8 @@ export class ForemanWss {
 
     wss.on("connection", (ws) => {
       let workerId = "";
+      isAlive.set(ws, true);
+      ws.on("pong", () => isAlive.set(ws, true));
 
       ws.on("message", (data) => {
         void (async () => {
@@ -233,10 +244,13 @@ export class ForemanWss {
     });
   }
 
-  sendMsg(worker: Worker, msg: Wire.ForemanMessage, logTaskId?: string): void {
+  sendMsg(worker: Worker, msg: Wire.ForemanMessage, logTaskId?: string): boolean {
     const taskId = logTaskId ?? (("taskId" in msg ? msg.taskId : null) ?? null);
-    worker.send(msg);
-    this.logAndBroadcastSent(worker.workerId, taskId, msg.type, msg as unknown as Record<string, unknown>, worker.repo.id, worker.repo.fullName);
+    const sent = worker.send(msg);
+    if (sent) {
+      this.logAndBroadcastSent(worker.workerId, taskId, msg.type, msg as unknown as Record<string, unknown>, worker.repo.id, worker.repo.fullName);
+    }
+    return sent;
   }
 
   private logAndBroadcastSent(workerId: string | null, taskId: string | null, msgType: string, payload: Record<string, unknown>, repoId: number | null, repo?: string): void {
@@ -289,8 +303,13 @@ export class ForemanWss {
 
   private flushQueuedEvents(worker: Worker, task: Task): void {
     for (const evt of task.drainEvents()) {
-      this.sendMsg(worker, { type: "event_notification", taskId: task.taskId, event: evt.toWorkerPayload() });
-      this.workerLog(worker.workerId, `→ event_notification #${task.issueNumber} ${evt.eventName} (queued)`);
+      const sent = this.sendMsg(worker, { type: "event_notification", taskId: task.taskId, event: evt.toWorkerPayload() });
+      if (sent) {
+        this.workerLog(worker.workerId, `→ event_notification #${task.issueNumber} ${evt.eventName} (queued)`);
+      } else {
+        task.queueEvent(evt);
+        this.workerLog(worker.workerId, `✗ event_notification send failed — requeued #${task.issueNumber} ${evt.eventName}`);
+      }
     }
   }
 
@@ -497,10 +516,17 @@ export class ForemanWss {
         task.queueEvent(evt);
         log(`[task ${ref}] ${evt.eventName} queued (worker ${shortWorkerId(task.workerId)} disconnected)`);
       } else if (worker) {
-        this.sendMsg(worker, { type: "event_notification", taskId: task.taskId, event: evt.toWorkerPayload() });
-        log(`[worker ${shortWorkerId(task.workerId)}] → event_notification ${ref} ${evt.eventName}`);
+        const sent = this.sendMsg(worker, { type: "event_notification", taskId: task.taskId, event: evt.toWorkerPayload() });
+        if (sent) {
+          log(`[worker ${shortWorkerId(task.workerId)}] → event_notification ${ref} ${evt.eventName}`);
+        } else {
+          task.queueEvent(evt);
+          log(`[task ${ref}] ${evt.eventName} queued (worker send failed)`);
+        }
       } else {
-        log(`[task ${ref}] ${evt.eventName} DROPPED — worker ${shortWorkerId(task.workerId)} not in registry (disconnected?)`);
+        // Worker not in registry — treat as disconnected and queue for reconnect.
+        task.queueEvent(evt);
+        log(`[task ${ref}] ${evt.eventName} queued — worker ${shortWorkerId(task.workerId)} not in registry`);
       }
     } else if (task.status === "pending" || task.status === "blocked") {
       task.queueEvent(evt);

--- a/src/foreman/models/worker.ts
+++ b/src/foreman/models/worker.ts
@@ -240,10 +240,10 @@ export class Worker extends ActiveRecord {
     return sockets.get(this.workerId) === ws;
   }
 
-  send(msg: Wire.ForemanMessage): boolean {
+  send(msg: Wire.ForemanMessage, onError?: (err: Error) => void): boolean {
     const ws = sockets.get(this.workerId);
     if (ws && ws.readyState === WebSocket.OPEN) {
-      ws.send(JSON.stringify(msg));
+      ws.send(JSON.stringify(msg), (err) => { if (err && onError) onError(err); });
       return true;
     }
     return false;

--- a/tests/foreman.event-router.test.ts
+++ b/tests/foreman.event-router.test.ts
@@ -131,6 +131,8 @@ describe("forwardEvent — active tasks still receive events", () => {
     expect(sendMsg).toHaveBeenCalledWith(
       expect.objectContaining({ workerId: "worker-1" }),
       expect.objectContaining({ type: "event_notification" }),
+      undefined,
+      expect.any(Function),
     );
   });
 

--- a/tests/foreman.event-router.test.ts
+++ b/tests/foreman.event-router.test.ts
@@ -33,7 +33,7 @@ function makeWss(_taskManager?: any): { wss: ForemanWss; sendMsg: ReturnType<typ
     config: { taskLabel: "brunel:ready", githubToken: "token", workerSecret: undefined, pingIntervalMs: 1e9 },
     server: http.createServer(),
   });
-  const sendMsg = vi.spyOn(wss, "sendMsg").mockImplementation(() => {});
+  const sendMsg = vi.spyOn(wss, "sendMsg").mockImplementation(() => true);
   return { wss, sendMsg };
 }
 
@@ -181,5 +181,47 @@ describe("forwardEvent — active tasks still receive events", () => {
 
     expect(queueSpy).toHaveBeenCalledOnce();
     expect(sendMsg).not.toHaveBeenCalled();
+  });
+});
+
+// ── Send-failure recovery ──────────────────────────────────────────────────────
+
+describe("forwardEvent — send failure recovery", () => {
+  it("queues event when sendMsg returns false (socket not open)", () => {
+    const task = Task.fromTest({
+      task_id: "42",
+      issue_number: 42,
+      repo_id: testRepoId,
+      worker_id: "worker-1",
+    });
+    const w = Worker.register("worker-1", fakeWs(), fakeRepo());
+    w.assign(task);
+    const queueSpy = vi.spyOn(task.manager, "queueEvent");
+    const { wss, sendMsg } = makeWss();
+    sendMsg.mockImplementation(() => false); // simulate closed socket
+
+    wss.forwardEvent(task, makeEvent(), "#42");
+
+    expect(sendMsg).toHaveBeenCalledOnce();
+    expect(queueSpy).toHaveBeenCalledOnce();
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("queued (worker send failed)"));
+  });
+
+  it("queues event when worker is not in registry", () => {
+    const task = Task.fromTest({
+      task_id: "42",
+      issue_number: 42,
+      repo_id: testRepoId,
+      worker_id: "worker-1",
+    });
+    // worker-1 not registered — simulates post-remove race or stale workerId
+    const queueSpy = vi.spyOn(task.manager, "queueEvent");
+    const { wss, sendMsg } = makeWss();
+
+    wss.forwardEvent(task, makeEvent(), "#42");
+
+    expect(sendMsg).not.toHaveBeenCalled();
+    expect(queueSpy).toHaveBeenCalledOnce();
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("not in registry"));
   });
 });

--- a/tests/foreman.event-router.test.ts
+++ b/tests/foreman.event-router.test.ts
@@ -131,8 +131,7 @@ describe("forwardEvent — active tasks still receive events", () => {
     expect(sendMsg).toHaveBeenCalledWith(
       expect.objectContaining({ workerId: "worker-1" }),
       expect.objectContaining({ type: "event_notification" }),
-      undefined,
-      expect.any(Function),
+      expect.objectContaining({ onError: expect.any(Function) }),
     );
   });
 

--- a/tests/foreman.reconcile.test.ts
+++ b/tests/foreman.reconcile.test.ts
@@ -60,7 +60,7 @@ describe("reconcile()", () => {
 
     await new Promise((r) => setImmediate(r));
 
-    expect(fakeWs.send).toHaveBeenCalledWith(expect.stringContaining('"task_assigned"'));
+    expect(fakeWs.send).toHaveBeenCalledWith(expect.stringContaining('"task_assigned"'), expect.any(Function));
     expect((await Task.get("42"))?.status).toBe("assigned");
     expect(Worker.fromRegistry("w1")?.status).toBe("busy");
   });

--- a/tests/foreman.registry.test.ts
+++ b/tests/foreman.registry.test.ts
@@ -70,7 +70,7 @@ describe("Worker", () => {
     const w = Worker.register("w1", ws, fakeRepo());
     const msg: Wire.ForemanMessage = { type: "task_assigned", taskId: "1", issue: { number: 1, title: "T", body: "", labels: [], repoUrl: "https://github.com/o/r" } };
     w.send(msg);
-    expect(ws.send).toHaveBeenCalledWith(JSON.stringify(msg));
+    expect(ws.send).toHaveBeenCalledWith(JSON.stringify(msg), expect.any(Function));
   });
 
   it("send returns true when OPEN", () => {

--- a/tests/foreman.websocket.test.ts
+++ b/tests/foreman.websocket.test.ts
@@ -1144,4 +1144,61 @@ describe("graceful shutdown", () => {
 
     await new Promise<void>((r) => testWss.close(() => srv.close(r)));
   });
+
+  it("terminates zombie connections that stop responding to pings", async () => {
+    // Use a very short ping interval so the test runs quickly.
+    const srv = http.createServer();
+    const localForemanWss = new ForemanWss({
+      server: srv,
+      config: { ...defaultCfg, pingIntervalMs: 50 },
+    });
+    const testPort = await new Promise<number>((r) => srv.listen(0, () => r((srv.address() as AddressInfo).port)));
+
+    // The ws library always auto-pongs when it receives a PING frame, so we can't
+    // use a ws.WebSocket client here — it would keep the connection alive. Instead,
+    // open a raw TCP socket that completes the WebSocket handshake but never sends
+    // pong frames, simulating a zombie (silently-dead) connection.
+    const { createConnection } = await import("net");
+    const { randomBytes } = await import("crypto");
+    const rawSocket = createConnection(testPort, "127.0.0.1");
+    rawSocket.on("error", () => {}); // suppress ECONNRESET on terminate()
+
+    await new Promise<void>((r) => rawSocket.once("connect", r));
+    const wsKey = randomBytes(16).toString("base64");
+    rawSocket.write(
+      `GET /worker HTTP/1.1\r\nHost: 127.0.0.1\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: ${wsKey}\r\nSec-WebSocket-Version: 13\r\n\r\n`,
+    );
+    // Wait for the 101 Switching Protocols response so the server-side ws is live.
+    await new Promise<void>((r) => rawSocket.once("data", () => r()));
+
+    // The foreman should terminate the zombie after two ping intervals:
+    // first tick → marks isAlive=false and sends ping; second tick → no pong → terminate().
+    const closed = new Promise<void>((r) => rawSocket.once("close", r));
+    await closed;
+
+    await new Promise<void>((r) => localForemanWss.wss.close(() => srv.close(r)));
+  }, 2000);
+
+  it("keeps connections alive when pongs are received", async () => {
+    // Use a short ping interval; the ws library auto-pong keeps the connection alive.
+    const srv = http.createServer();
+    const localForemanWss = new ForemanWss({
+      server: srv,
+      config: { ...defaultCfg, pingIntervalMs: 30 },
+    });
+    const testPort = await new Promise<number>((r) => srv.listen(0, () => r((srv.address() as AddressInfo).port)));
+
+    const liveWs = new WebSocket(`ws://localhost:${testPort}/worker`);
+    await new Promise<void>((resolve, reject) => { liveWs.once("open", resolve); liveWs.once("error", reject); });
+
+    // Let several ping intervals pass while the ws library auto-pongs.
+    await new Promise<void>((r) => setTimeout(r, 150));
+
+    // Connection should still be open.
+    expect(liveWs.readyState).toBe(WebSocket.OPEN);
+
+    liveWs.close();
+    await new Promise<void>((r) => liveWs.once("close", r));
+    await new Promise<void>((r) => localForemanWss.wss.close(() => srv.close(r)));
+  });
 });


### PR DESCRIPTION
## Summary

- **Foreman heartbeat**: Added pong-tracking on the foreman side (matching the existing worker-side heartbeat). A `WeakMap<WebSocket, boolean>` tracks whether each client has ponged since the last ping. Connections that miss a full interval are terminated with `ws.terminate()`, cutting the zombie detection window from minutes (OS TCP keepalive) to ~one ping interval (25 s by default).
- **Queue on send failure**: `sendMsg()` now returns a boolean. `forwardEvent()` and `flushQueuedEvents()` check the result and queue any event whose send failed (socket wasn't OPEN), so it's replayed on the worker's next reconnect.
- **Queue instead of drop for unknown registry workers**: The previous code logged `DROPPED` and discarded events when `task.workerId` pointed to a worker not in the registry. Now those events are queued for replay, since the worker may be mid-reconnect.

## Root cause

The incident showed two events sent at 7:36 AM that the worker never received. Both sides thought the connection was live (the socket's `readyState` was still `OPEN`). The foreman sent the events, logged them as sent, but the TCP connection was silently dead. When the worker reconnected at 7:58 AM, `flushQueuedEvents()` found an empty queue — the events had been "sent" but never queued.

## Test plan
- [ ] New unit tests in `foreman.event-router.test.ts`: queue on `sendMsg` returning `false`; queue when worker not in registry
- [ ] New integration tests in `foreman.websocket.test.ts`: raw-TCP zombie connection is terminated within two ping intervals; normal connections with auto-pong stay alive
- [ ] All 1463 existing tests still pass

Closes #869