### PR TITLE
docs: document cross-repo reconnect enforcement in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Status is **derived from timestamps**, not stored: `completedAt` → complete, `
 
 `Task.upsert()` intentionally does not overwrite status fields on conflict, so re-syncing at startup never clobbers existing assignments.
 
-Task assignment is **repo-scoped**: `TaskManager.tryAssignWork()` only assigns a task to a worker if (a) the worker's repo status is `"active"` and (b) the task's `repoId` matches the worker's repo. Workers from inactive or mismatched repos are silently skipped.
+Task assignment is **repo-scoped**: `TaskManager.tryAssignWork()` only assigns a task to a worker if (a) the worker's repo status is `"active"` and (b) the task's `repoId` matches the worker's repo. Workers from inactive or mismatched repos are silently skipped. Cross-repo enforcement also applies on reconnect: if a worker reconnects claiming a task that belongs to a different repo, `handleBusyHello` sends `cancelled` and the worker resets to idle.
 
 ## Worker/Foreman handshake
 


### PR DESCRIPTION
## Summary

- Adds a sentence to the "Task lifecycle" section of CLAUDE.md noting that cross-repo enforcement also applies on reconnect: a worker that reconnects claiming a task from a different repo receives `cancelled` and resets to idle

This behavior was added in #871 but not captured in project documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)