### PR TITLE
docs: clarify WorkerController vs WorkerSession in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Follows MVC with three subdirectories:
 
 - **Models** (`models/`) — `Workspace` (git/npm workspace management), `Settings` (runtime-settable preferences: model, effort, permissions), `QueryStats` (token usage/turn counts and API cost from SDK messages), `AgentStatus` (pure state model for worker status — emits `"change"` on updates, subscribed to by `Display` for reactive redraws)
 - **Views** (`views/`) — `Display` (TUI terminal I/O — the single doorway to stdout), `Renderer` (pure string producers, no I/O), `Input` (readline-based REPL), `Picker` (arrow-key menus), `style.ts` (terminal color/style constants)
-- **Controllers** (`controllers/`) — `AgentController` (runs queries), `WorkerController`/`WorkerSession` (WS protocol + task lifecycle), `WorkspaceController` (workspace lifecycle + `/workspace:*` slash commands), `CommandRegistry`/`CommandController` (slash command registration and dispatch), `SettingsController` (model/effort/permissions selection)
+- **Controllers** (`controllers/`) — `AgentController` (runs queries), `WorkerController` (worker mode lifecycle — start/stop, session ownership, `/worker:*` commands) + `WorkerSession` (WebSocket protocol + task lifecycle), `WorkspaceController` (workspace lifecycle + `/workspace:*` slash commands), `CommandRegistry`/`CommandController` (slash command registration and dispatch), `SettingsController` (model/effort/permissions selection)
 
 ### Shared
 


### PR DESCRIPTION
## Summary

- Clarify the distinction between `WorkerController` (worker mode lifecycle, session ownership, `/worker:*` commands) and `WorkerSession` (WebSocket protocol, task lifecycle) in the agent controllers description

Followup from #863 which introduced `WorkerController` as a proper class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)