### PR TITLE
fix: refresh branch in status bar after task completion and worker stop

### DIFF
--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -134,6 +134,8 @@ export type WorkerSessionOptions = {
   repo: string;
   /** Maximum reconnect delay in ms. Default lives in config schema; always provided in production. */
   maxReconnectDelayMs: number;
+  /** Injectable branch getter for testing. Defaults to getCurrentBranch. */
+  getBranch?: () => Promise<string>;
 };
 
 /** Task state needed to decide whether and how to prompt before quitting. */
@@ -194,7 +196,8 @@ export class WorkerSession extends EventEmitter {
   get agentId(): string { return this.agentStatus.agentId; }
 
   private async refreshBranch(): Promise<void> {
-    this.agentStatus.update({ branch: await getCurrentBranch() });
+    const getBranch = this.options.getBranch ?? getCurrentBranch;
+    this.agentStatus.update({ branch: await getBranch() });
   }
 
   /**
@@ -297,7 +300,8 @@ export class WorkerSession extends EventEmitter {
     const statsStr = fmtTaskStats(this.agentStatus.taskInputTokens, this.agentStatus.taskOutputTokens, this.agentStatus.taskCostUsd);
     this.display.print(c.sageGreen(`Task #${taskNumber} complete, ${statsStr}`));
     this.agentStatus.resetTaskStats();
-    this.agentStatus.update({ taskNumber: undefined, prNumber: undefined, branch: "" });
+    this.agentStatus.update({ taskNumber: undefined, prNumber: undefined });
+    await this.refreshBranch();
     this.display.print(c.sageGreen("Waiting for next task..."));
     return "task-complete";
   }
@@ -745,6 +749,7 @@ export class WorkerController extends EventEmitter {
     this._cleanup = undefined; // cleared so later exit takes the non-worker path
     this.display.agentStatus.setWorkerModeActive(false);
     this.display.print(c.sageGreen("Worker mode stopped."));
+    this.display.agentStatus.update({ branch: await getCurrentBranch() });
   }
 
   /** Run worker teardown: send goodbye, destroy workspace, tear down I/O. */

--- a/tests/worker.mode-switching.test.ts
+++ b/tests/worker.mode-switching.test.ts
@@ -273,6 +273,30 @@ describe("worker mode switching", () => {
     expect(capturedStatus?.workerModeActive).toBe(true);
   });
 
+  it("/worker:stop refreshes agentStatus.branch to current git branch", async () => {
+    let capturedStatus: AgentStatus | undefined;
+    vi.mocked(AgentController).mockImplementation(function(this: unknown, display: unknown) {
+      capturedStatus = (display as { agentStatus: AgentStatus }).agentStatus;
+      return { runQuery: vi.fn().mockResolvedValue(undefined) } as unknown as AgentController;
+    });
+
+    let askCallCount = 0;
+    mockInput.ask.mockImplementation(() => {
+      askCallCount++;
+      if (askCallCount === 1) return Promise.resolve("/worker:start");
+      if (askCallCount === 2) {
+        // Simulate the branch being cleared after a task completes
+        if (capturedStatus) capturedStatus.update({ branch: "" });
+        return Promise.resolve("/worker:stop");
+      }
+      return Promise.resolve("__eof__");
+    });
+
+    await runAgent(false);
+
+    expect(capturedStatus?.branch).not.toBe("");
+  });
+
   it("after /worker:stop, exiting does not call process.exit(0)", async () => {
     // When worker mode is stopped before exit, workerCleanup is cleared.
     // The exit path should go through doExit() which does NOT call process.exit.

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -281,6 +281,24 @@ describe("state after task_complete", () => {
     await session.completeCurrentTask();
     expect(fakeWs.send).not.toHaveBeenCalled();
   });
+
+  it("restores current branch in agentStatus after task completion (not empty string)", async () => {
+    const getBranch = vi.fn().mockResolvedValue("feature-branch");
+    const localSb = new AgentStatus({ agentId: AGENT_ID });
+    const localSession = new WorkerSession(localSb, wsFactory, display, {
+      repo: "owner/repo",
+      maxReconnectDelayMs: 300_000,
+      getBranch,
+    });
+    localSession.start();
+
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue: makeIssue() });
+    localSession.takeNextPrompt();
+
+    await localSession.completeCurrentTask();
+
+    expect(localSb.branch).toBe("feature-branch");
+  });
 });
 
 // ── Prompt queuing API ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `WorkerSession.completeCurrentTask()` was setting `agentStatus.branch` to `""` after a task completed, clearing the branch from the minimal status bar
- Changed it to call `refreshBranch()` instead, which updates the bar with the actual current git branch
- Also added a branch refresh in `WorkerController.stop()` as a belt-and-suspenders fix for any state where branch may have been stale
- Added `getBranch` injectable option to `WorkerSessionOptions` (following the existing `pickFn` pattern) to make the fix testable

## Test plan

- [ ] `worker.test.ts`: new test verifies `agentStatus.branch` reflects the injected branch name after `completeCurrentTask()` (not `""`)
- [ ] `worker.mode-switching.test.ts`: new test verifies `agentStatus.branch` is refreshed after `/worker:stop` even when it was cleared beforehand
- [ ] All 1484 existing tests continue to pass

Closes #873

🤖 Generated with [Claude Code](https://claude.com/claude-code)