### PR TITLE
feat: status-dependent task-start prompts for partially-in-progress tasks

### DIFF
--- a/shared/wire.ts
+++ b/shared/wire.ts
@@ -88,7 +88,7 @@ export interface TaskIssue {
   body: string;
   labels: string[];
   repoUrl: string;
-  status?: TaskStatus;
+  status: TaskStatus;
   prNumber?: number | null;
   branch?: string | null;
 }

--- a/shared/wire.ts
+++ b/shared/wire.ts
@@ -88,6 +88,9 @@ export interface TaskIssue {
   body: string;
   labels: string[];
   repoUrl: string;
+  status?: TaskStatus;
+  prNumber?: number | null;
+  branch?: string | null;
 }
 
 // Worker → Foreman messages

--- a/src/agent/worker-prompts.ts
+++ b/src/agent/worker-prompts.ts
@@ -48,12 +48,12 @@ function sectionB(issue: Wire.TaskIssue): string {
 
   if (status === "pushed") {
     const detail = prRef && branchRef ? ` — ${prRef} on ${branchRef}` : prRef ? ` — ${prRef}` : branchRef ? ` on ${branchRef}` : "";
-    return `There is already an open PR for this task${detail}. You are picking up where a previous worker left off.`;
+    return `There is already an open PR for this task${detail}. You are picking up work in progress.`;
   }
 
   if (status === "merged") {
     const detail = prRef && branchRef ? ` (${prRef}, ${branchRef})` : prRef ? ` (${prRef})` : branchRef ? ` (${branchRef})` : "";
-    return `The PR for this task has already been merged${detail}, but the issue is still open. This is an edge case.`;
+    return `The PR for this task has already been merged${detail}, but the issue is still open.`;
   }
 
   if (status === "closed" || status === "complete") {

--- a/src/agent/worker-prompts.ts
+++ b/src/agent/worker-prompts.ts
@@ -13,23 +13,23 @@ function formatCommentLocation(
 
 // ── buildInitialPrompt ────────────────────────────────────────────────────────
 // Structured as five sections:
-//   A. Issue header (generic)
-//   B. Status-specific context, including PR/branch details if relevant
-//   C. Workspace context (generic)
-//   D. Action guidance, specific to task status
-//   E. Standing instructions (generic)
+//   1. Issue header (generic)
+//   2. Task status context, including PR/branch details if relevant
+//   3. Workspace context (generic)
+//   4. Action guidance, specific to task status
+//   5. Standing instructions (generic)
 
 export function buildInitialPrompt(issue: Wire.TaskIssue, isolatedCheckout: boolean): string {
   return [
-    sectionA(issue),
-    sectionB(issue),
-    sectionC(isolatedCheckout),
-    sectionD(issue, isolatedCheckout),
-    SECTION_E,
+    section1IssueHeader(issue),
+    section2TaskStatus(issue),
+    section3WorkspaceContext(isolatedCheckout),
+    section4ActionGuidance(issue, isolatedCheckout),
+    SECTION_5_STANDING_INSTRUCTIONS,
   ].filter(Boolean).join("\n\n");
 }
 
-function sectionA(issue: Wire.TaskIssue): string {
+function section1IssueHeader(issue: Wire.TaskIssue): string {
   return `You are being assigned GitHub issue #${issue.number}: "${issue.title}" in ${issue.repoUrl}.
 
 Issue description:
@@ -41,7 +41,7 @@ ${issue.body || "(no description)"}
 Labels: ${issue.labels.join(", ") || "(none)"}`;
 }
 
-function sectionB(issue: Wire.TaskIssue): string {
+function section2TaskStatus(issue: Wire.TaskIssue): string {
   const { status, prNumber, branch } = issue;
   const prRef = prNumber != null ? `PR #${prNumber}` : null;
   const branchRef = branch ? `branch \`${branch}\`` : null;
@@ -64,22 +64,22 @@ function sectionB(issue: Wire.TaskIssue): string {
   return "";
 }
 
-function sectionC(isolatedCheckout: boolean): string {
+function section3WorkspaceContext(isolatedCheckout: boolean): string {
   return isolatedCheckout
     ? "You are working in an isolated workspace with your own checkout of the repo."
     : "You are working in a potentially shared workspace.";
 }
 
-function sectionD(issue: Wire.TaskIssue, isolatedCheckout: boolean): string {
+function section4ActionGuidance(issue: Wire.TaskIssue, isolatedCheckout: boolean): string {
   const { status } = issue;
 
-  if (status === "pushed") return sectionDPushed(issue, isolatedCheckout);
-  if (status === "merged") return sectionDMerged();
-  if (status === "closed" || status === "complete") return sectionDClosed();
-  return sectionDAssigned(issue, isolatedCheckout);
+  if (status === "pushed") return section4Pushed(issue, isolatedCheckout);
+  if (status === "merged") return section4Merged();
+  if (status === "closed" || status === "complete") return section4Closed();
+  return section4Assigned(issue, isolatedCheckout);
 }
 
-function sectionDAssigned(issue: Wire.TaskIssue, isolatedCheckout: boolean): string {
+function section4Assigned(issue: Wire.TaskIssue, isolatedCheckout: boolean): string {
   const branchInstruction = isolatedCheckout
     ? "Create a new branch for this task (no need for a worktree). Make all changes on the branch."
     : "Create a new branch and an isolated worktree for this task. Make no changes in the main workspace, only in the worktree.";
@@ -95,7 +95,7 @@ Use your branch-discipline skill, and remember key practices:
 5. Create a PR when done, and include the text "Closes #${issue.number}".`;
 }
 
-function sectionDPushed(issue: Wire.TaskIssue, isolatedCheckout: boolean): string {
+function section4Pushed(issue: Wire.TaskIssue, isolatedCheckout: boolean): string {
   const { prNumber, branch } = issue;
   const prRef = prNumber != null ? ` #${prNumber}` : "";
   const step1 = isolatedCheckout
@@ -114,15 +114,25 @@ function sectionDPushed(issue: Wire.TaskIssue, isolatedCheckout: boolean): strin
 4. Before creating any new commits, check whether any project documentation should be updated to reflect your changes.`;
 }
 
-function sectionDMerged(): string {
+function section4Merged(): string {
   return "Please inspect the issue to understand why it was not closed when the PR was merged, and determine the appropriate next steps.";
 }
 
-function sectionDClosed(): string {
-  return "Please review the issue and the PR that was merged, and look for any followup work that should be done (such as filing follow-up issues, updating skills or documentation, or other cleanup).";
+function section4Closed(): string {
+  return `Please review the issue and the PR that was merged.\n\n${FOLLOWUP_CHECKLIST}`;
 }
 
-const SECTION_E = "Do not work on any other issues: leave task assignment to the foreman. Do not merge any PRs or set them to auto-merge: leave merging to the user after UAT.";
+const SECTION_5_STANDING_INSTRUCTIONS = "Do not work on any other issues: leave task assignment to the foreman. Do not merge any PRs or set them to auto-merge: leave merging to the user after UAT.";
+
+const FOLLOWUP_CHECKLIST = `Before we end this session, consider:
+
+* Are there any followup issues we should file?
+* Are there any updates to skills that we should make, or new skills to record?
+* Are there any updates to be made to project documentation?
+
+Do not use project memories: they may not persist across sessions, and they aren't available to other users or projects. Capture general practices in skills, and project-specific information in CLAUDE.md or other project docs.
+
+Please do the above if necessary. Then summarize any such followups/updates, and anything else the user should know.`;
 
 export function buildEventPrompt(events: Wire.WebhookEvent[]): string {
   const coalesced = coalesceEvents(events);
@@ -298,15 +308,7 @@ const EVENT_FMT: EventTemplateFmtTable = {
     if (p.action === "closed") {
       return `PR #${prNumber} was ${pr?.merged ? 'merged' : 'closed without merging'}. Please delete the local branch (no need to delete it from origin, though). Also remove your worktree, if any.
 
-Then, before we end this session, consider:
-
-* Are there any followup issues we should file?
-* Are there any updates to skills that we should make, or new skills to record?
-* Are there any updates to be made to project documentation?
-
-Do not use project memories: they may not persist across sessions, and they aren't available to other users or projects. Capture general practices in skills, and project-specific information in CLAUDE.md or other project docs.
-
-Please do the above if necessary. Then summarize any such followups/updates, and anything else the user should know.`;
+${FOLLOWUP_CHECKLIST}`;
     }
     return "";
   },

--- a/src/agent/worker-prompts.ts
+++ b/src/agent/worker-prompts.ts
@@ -12,12 +12,22 @@ function formatCommentLocation(
 }
 
 export function buildInitialPrompt(issue: Wire.TaskIssue, isolatedCheckout: boolean): string {
-  const workspaceContext = isolatedCheckout ? "an isolated workspace with your own checkout of the repo" : "a potentially shared workspace";
-  const branchInstruction = isolatedCheckout
-    ? "Create a new branch for this task (no need for a worktree). Make all changes on the branch."
-    : "Create a new branch and an isolated worktree for this task. Make no changes in the main workspace, only in the worktree.";
+  const status = issue.status ?? "assigned";
 
-  return `Please work on GitHub issue #${issue.number}: "${issue.title}" in ${issue.repoUrl}.
+  if (status === "closed" || status === "complete") {
+    return buildClosedPrompt(issue);
+  }
+  if (status === "merged") {
+    return buildMergedPrompt(issue);
+  }
+  if (status === "pushed") {
+    return buildPushedPrompt(issue, isolatedCheckout);
+  }
+  return buildAssignedPrompt(issue, isolatedCheckout);
+}
+
+function issueHeader(issue: Wire.TaskIssue): string {
+  return `GitHub issue #${issue.number}: "${issue.title}" in ${issue.repoUrl}.
 
 Issue description:
 
@@ -25,7 +35,16 @@ Issue description:
 ${issue.body || "(no description)"}
 ---------------
 
-Labels: ${issue.labels.join(", ") || "(none)"}
+Labels: ${issue.labels.join(", ") || "(none)"}`;
+}
+
+function buildAssignedPrompt(issue: Wire.TaskIssue, isolatedCheckout: boolean): string {
+  const workspaceContext = isolatedCheckout ? "an isolated workspace with your own checkout of the repo" : "a potentially shared workspace";
+  const branchInstruction = isolatedCheckout
+    ? "Create a new branch for this task (no need for a worktree). Make all changes on the branch."
+    : "Create a new branch and an isolated worktree for this task. Make no changes in the main workspace, only in the worktree.";
+
+  return `Please work on ${issueHeader(issue)}
 
 You should ask for any clarifications you need about requirements or product spec, but you should decide on the technical implementation on your own. If the technical design is complex enough to need review, use a subagent instead of asking the user.
 
@@ -36,6 +55,44 @@ You are working in ${workspaceContext}. Use your branch-discipline skill, and re
 3. As much as possible, use test-driven development.
 4. Before creating a PR, check whether your changes call for updates to project documentation. Include any doc updates in the same PR as the code changes.
 5. Create a PR when done, and include the text "Closes #${issue.number}".
+
+Do not work on any other issues: leave task assignment to the foreman. Do not merge any PRs or set them to auto-merge: leave merging to the user after UAT.`;
+}
+
+function buildPushedPrompt(issue: Wire.TaskIssue, isolatedCheckout: boolean): string {
+  const workspaceContext = isolatedCheckout ? "an isolated workspace with your own checkout of the repo" : "a potentially shared workspace";
+  const branchInstruction = isolatedCheckout
+    ? "No worktree is needed — you're already in an isolated checkout."
+    : "Work in an isolated worktree for this branch. Make no changes in the main workspace.";
+
+  return `You are being assigned to continue work on ${issueHeader(issue)}
+
+There is already an open PR #${issue.prNumber} for this task on branch \`${issue.branch}\`. You are picking up where a previous worker left off.
+
+You are working in ${workspaceContext}. ${branchInstruction}
+
+Please do the following:
+
+1. Fetch the branch and switch to it: \`git fetch origin ${issue.branch} && git checkout ${issue.branch}\`
+2. Review the open PR and any code review comments on it.
+3. Determine whether any more work needs to be done on this PR right now, and do it if so.
+4. Before creating any new commits, check whether any project documentation should be updated to reflect your changes.
+
+Do not work on any other issues: leave task assignment to the foreman. Do not merge any PRs or set them to auto-merge: leave merging to the user after UAT.`;
+}
+
+function buildMergedPrompt(issue: Wire.TaskIssue): string {
+  return `You are being assigned to follow up on ${issueHeader(issue)}
+
+The PR for this task has already been merged, but the issue is still open. This is an edge case — please inspect the issue to understand why it was not closed when the PR was merged, and determine the appropriate next steps.
+
+Do not work on any other issues: leave task assignment to the foreman. Do not merge any PRs or set them to auto-merge: leave merging to the user after UAT.`;
+}
+
+function buildClosedPrompt(issue: Wire.TaskIssue): string {
+  return `You are being assigned to review the completed work for ${issueHeader(issue)}
+
+The issue is now closed. Please review the issue and the PR that was merged, and look for any followup work that should be done (such as filing follow-up issues, updating skills or documentation, or other cleanup).
 
 Do not work on any other issues: leave task assignment to the foreman. Do not merge any PRs or set them to auto-merge: leave merging to the user after UAT.`;
 }

--- a/src/agent/worker-prompts.ts
+++ b/src/agent/worker-prompts.ts
@@ -130,9 +130,7 @@ const FOLLOWUP_CHECKLIST = `Before we end this session, consider:
 * Are there any updates to skills that we should make, or new skills to record?
 * Are there any updates to be made to project documentation?
 
-Do not use project memories: they may not persist across sessions, and they aren't available to other users or projects. Capture general practices in skills, and project-specific information in CLAUDE.md or other project docs.
-
-Please do the above if necessary. Then summarize any such followups/updates, and anything else the user should know.`;
+Do not use project memories: they may not persist across sessions, and they aren't available to other users or projects. Capture general practices in skills, and project-specific information in project docs.`;
 
 export function buildEventPrompt(events: Wire.WebhookEvent[]): string {
   const coalesced = coalesceEvents(events);

--- a/src/agent/worker-prompts.ts
+++ b/src/agent/worker-prompts.ts
@@ -11,23 +11,26 @@ function formatCommentLocation(
   return `${pathStr} line ${line}`;
 }
 
-export function buildInitialPrompt(issue: Wire.TaskIssue, isolatedCheckout: boolean): string {
-  const status = issue.status ?? "assigned";
+// ── buildInitialPrompt ────────────────────────────────────────────────────────
+// Structured as five sections:
+//   A. Issue header (generic)
+//   B. Status-specific context, including PR/branch details if relevant
+//   C. Workspace context (generic)
+//   D. Action guidance, specific to task status
+//   E. Standing instructions (generic)
 
-  if (status === "closed" || status === "complete") {
-    return buildClosedPrompt(issue);
-  }
-  if (status === "merged") {
-    return buildMergedPrompt(issue);
-  }
-  if (status === "pushed") {
-    return buildPushedPrompt(issue, isolatedCheckout);
-  }
-  return buildAssignedPrompt(issue, isolatedCheckout);
+export function buildInitialPrompt(issue: Wire.TaskIssue, isolatedCheckout: boolean): string {
+  return [
+    sectionA(issue),
+    sectionB(issue),
+    sectionC(isolatedCheckout),
+    sectionD(issue, isolatedCheckout),
+    SECTION_E,
+  ].filter(Boolean).join("\n\n");
 }
 
-function issueHeader(issue: Wire.TaskIssue): string {
-  return `GitHub issue #${issue.number}: "${issue.title}" in ${issue.repoUrl}.
+function sectionA(issue: Wire.TaskIssue): string {
+  return `You are being assigned GitHub issue #${issue.number}: "${issue.title}" in ${issue.repoUrl}.
 
 Issue description:
 
@@ -38,64 +41,88 @@ ${issue.body || "(no description)"}
 Labels: ${issue.labels.join(", ") || "(none)"}`;
 }
 
-function buildAssignedPrompt(issue: Wire.TaskIssue, isolatedCheckout: boolean): string {
-  const workspaceContext = isolatedCheckout ? "an isolated workspace with your own checkout of the repo" : "a potentially shared workspace";
+function sectionB(issue: Wire.TaskIssue): string {
+  const { status, prNumber, branch } = issue;
+  const prRef = prNumber != null ? `PR #${prNumber}` : null;
+  const branchRef = branch ? `branch \`${branch}\`` : null;
+
+  if (status === "pushed") {
+    const detail = prRef && branchRef ? ` — ${prRef} on ${branchRef}` : prRef ? ` — ${prRef}` : branchRef ? ` on ${branchRef}` : "";
+    return `There is already an open PR for this task${detail}. You are picking up where a previous worker left off.`;
+  }
+
+  if (status === "merged") {
+    const detail = prRef && branchRef ? ` (${prRef}, ${branchRef})` : prRef ? ` (${prRef})` : branchRef ? ` (${branchRef})` : "";
+    return `The PR for this task has already been merged${detail}, but the issue is still open. This is an edge case.`;
+  }
+
+  if (status === "closed" || status === "complete") {
+    const detail = prRef && branchRef ? ` ${prRef} on ${branchRef} was merged.` : prRef ? ` ${prRef} was merged.` : "";
+    return `The issue is now closed.${detail}`;
+  }
+
+  return "";
+}
+
+function sectionC(isolatedCheckout: boolean): string {
+  return isolatedCheckout
+    ? "You are working in an isolated workspace with your own checkout of the repo."
+    : "You are working in a potentially shared workspace.";
+}
+
+function sectionD(issue: Wire.TaskIssue, isolatedCheckout: boolean): string {
+  const { status } = issue;
+
+  if (status === "pushed") return sectionDPushed(issue, isolatedCheckout);
+  if (status === "merged") return sectionDMerged();
+  if (status === "closed" || status === "complete") return sectionDClosed();
+  return sectionDAssigned(issue, isolatedCheckout);
+}
+
+function sectionDAssigned(issue: Wire.TaskIssue, isolatedCheckout: boolean): string {
   const branchInstruction = isolatedCheckout
     ? "Create a new branch for this task (no need for a worktree). Make all changes on the branch."
     : "Create a new branch and an isolated worktree for this task. Make no changes in the main workspace, only in the worktree.";
 
-  return `Please work on ${issueHeader(issue)}
+  return `You should ask for any clarifications you need about requirements or product spec, but you should decide on the technical implementation on your own. If the technical design is complex enough to need review, use a subagent instead of asking the user.
 
-You should ask for any clarifications you need about requirements or product spec, but you should decide on the technical implementation on your own. If the technical design is complex enough to need review, use a subagent instead of asking the user.
-
-You are working in ${workspaceContext}. Use your branch-discipline skill, and remember key practices:
+Use your branch-discipline skill, and remember key practices:
 
 1. Pull main to get the latest before making any edits.
 2. ${branchInstruction}
 3. As much as possible, use test-driven development.
 4. Before creating a PR, check whether your changes call for updates to project documentation. Include any doc updates in the same PR as the code changes.
-5. Create a PR when done, and include the text "Closes #${issue.number}".
-
-Do not work on any other issues: leave task assignment to the foreman. Do not merge any PRs or set them to auto-merge: leave merging to the user after UAT.`;
+5. Create a PR when done, and include the text "Closes #${issue.number}".`;
 }
 
-function buildPushedPrompt(issue: Wire.TaskIssue, isolatedCheckout: boolean): string {
-  const workspaceContext = isolatedCheckout ? "an isolated workspace with your own checkout of the repo" : "a potentially shared workspace";
-  const branchInstruction = isolatedCheckout
-    ? "No worktree is needed — you're already in an isolated checkout."
-    : "Work in an isolated worktree for this branch. Make no changes in the main workspace.";
+function sectionDPushed(issue: Wire.TaskIssue, isolatedCheckout: boolean): string {
+  const { prNumber, branch } = issue;
+  const prRef = prNumber != null ? ` #${prNumber}` : "";
+  const step1 = isolatedCheckout
+    ? branch
+      ? `Fetch and switch to the branch: \`git fetch origin ${branch} && git checkout ${branch}\``
+      : "Fetch and switch to the existing branch for this PR."
+    : branch
+      ? `Create a worktree for the branch and work within it: \`git fetch origin ${branch} && git worktree add <path> ${branch}\`. Make no changes in the main workspace, only in the worktree.`
+      : "Create a worktree for the existing branch and work within it. Make no changes in the main workspace, only in the worktree.";
 
-  return `You are being assigned to continue work on ${issueHeader(issue)}
+  return `Use your branch-discipline skill, and please do the following:
 
-There is already an open PR #${issue.prNumber} for this task on branch \`${issue.branch}\`. You are picking up where a previous worker left off.
-
-You are working in ${workspaceContext}. ${branchInstruction}
-
-Please do the following:
-
-1. Fetch the branch and switch to it: \`git fetch origin ${issue.branch} && git checkout ${issue.branch}\`
-2. Review the open PR and any code review comments on it.
+1. ${step1}
+2. Review the open PR${prRef} and any code review comments on it.
 3. Determine whether any more work needs to be done on this PR right now, and do it if so.
-4. Before creating any new commits, check whether any project documentation should be updated to reflect your changes.
-
-Do not work on any other issues: leave task assignment to the foreman. Do not merge any PRs or set them to auto-merge: leave merging to the user after UAT.`;
+4. Before creating any new commits, check whether any project documentation should be updated to reflect your changes.`;
 }
 
-function buildMergedPrompt(issue: Wire.TaskIssue): string {
-  return `You are being assigned to follow up on ${issueHeader(issue)}
-
-The PR for this task has already been merged, but the issue is still open. This is an edge case — please inspect the issue to understand why it was not closed when the PR was merged, and determine the appropriate next steps.
-
-Do not work on any other issues: leave task assignment to the foreman. Do not merge any PRs or set them to auto-merge: leave merging to the user after UAT.`;
+function sectionDMerged(): string {
+  return "Please inspect the issue to understand why it was not closed when the PR was merged, and determine the appropriate next steps.";
 }
 
-function buildClosedPrompt(issue: Wire.TaskIssue): string {
-  return `You are being assigned to review the completed work for ${issueHeader(issue)}
-
-The issue is now closed. Please review the issue and the PR that was merged, and look for any followup work that should be done (such as filing follow-up issues, updating skills or documentation, or other cleanup).
-
-Do not work on any other issues: leave task assignment to the foreman. Do not merge any PRs or set them to auto-merge: leave merging to the user after UAT.`;
+function sectionDClosed(): string {
+  return "Please review the issue and the PR that was merged, and look for any followup work that should be done (such as filing follow-up issues, updating skills or documentation, or other cleanup).";
 }
+
+const SECTION_E = "Do not work on any other issues: leave task assignment to the foreman. Do not merge any PRs or set them to auto-merge: leave merging to the user after UAT.";
 
 export function buildEventPrompt(events: Wire.WebhookEvent[]): string {
   const coalesced = coalesceEvents(events);

--- a/src/foreman/models/task.ts
+++ b/src/foreman/models/task.ts
@@ -103,13 +103,16 @@ export class Task extends ActiveRecord {
     };
   }
 
-  toAssignmentPayload(): { number: number; title: string; body: string; labels: string[]; repoUrl: string } {
+  toAssignmentPayload(): Wire.TaskIssue {
     return {
       number: this.issueNumber,
       title: this.title,
       body: this.body,
       labels: this.labels,
       repoUrl: this.repoUrl,
+      status: this.status,
+      prNumber: this.prNumber,
+      branch: this.branch,
     };
   }
 

--- a/tests/foreman.task-manager.test.ts
+++ b/tests/foreman.task-manager.test.ts
@@ -681,7 +681,7 @@ describe("Task.toAssignmentPayload", () => {
       body: "It is broken",
       labels: ["bug", "brunel:ready"],
     });
-    expect(task.toAssignmentPayload()).toEqual({
+    expect(task.toAssignmentPayload()).toMatchObject({
       number: 42,
       title: "Fix the bug",
       body: "It is broken",

--- a/tests/foreman.task-manager.test.ts
+++ b/tests/foreman.task-manager.test.ts
@@ -687,6 +687,9 @@ describe("Task.toAssignmentPayload", () => {
       body: "It is broken",
       labels: ["bug", "brunel:ready"],
       repoUrl: "https://github.com/owner/repo",
+      status: "pending",
+      prNumber: null,
+      branch: null,
     });
   });
 });

--- a/tests/worker-prompts.test.ts
+++ b/tests/worker-prompts.test.ts
@@ -88,6 +88,101 @@ describe("buildInitialPrompt", () => {
 
 });
 
+describe("buildInitialPrompt — status-dependent prompts", () => {
+  const baseIssue = {
+    number: 99,
+    title: "My Task",
+    body: "Some work to do",
+    labels: ["feature"],
+    repoUrl: "https://github.com/x/y",
+  };
+
+  describe("status: assigned (default, no PR)", () => {
+    it("uses the standard new-task prompt", () => {
+      const p = buildInitialPrompt({ ...baseIssue, status: "assigned" }, true);
+      expect(p).toContain("#99");
+      expect(p).toContain("Please work on GitHub issue");
+      expect(p).toContain("Create a PR when done");
+    });
+
+    it("default (no status field) behaves like assigned", () => {
+      const p = buildInitialPrompt({ ...baseIssue }, true);
+      expect(p).toContain("Please work on GitHub issue");
+      expect(p).toContain("Create a PR when done");
+    });
+  });
+
+  describe("status: pushed (open PR exists)", () => {
+    it("mentions the open PR and its number", () => {
+      const p = buildInitialPrompt(
+        { ...baseIssue, status: "pushed", prNumber: 42, branch: "fix/my-task" },
+        true,
+      );
+      expect(p).toContain("PR #42");
+    });
+
+    it("tells the worker to fetch and switch to the branch", () => {
+      const p = buildInitialPrompt(
+        { ...baseIssue, status: "pushed", prNumber: 42, branch: "fix/my-task" },
+        true,
+      );
+      expect(p).toContain("fix/my-task");
+      expect(p).toMatch(/fetch/i);
+    });
+
+    it("tells the worker to review code review comments", () => {
+      const p = buildInitialPrompt(
+        { ...baseIssue, status: "pushed", prNumber: 42, branch: "fix/my-task" },
+        true,
+      );
+      expect(p).toMatch(/code review/i);
+    });
+
+    it("does NOT include the standard new-task Create-a-PR instruction", () => {
+      const p = buildInitialPrompt(
+        { ...baseIssue, status: "pushed", prNumber: 42, branch: "fix/my-task" },
+        true,
+      );
+      expect(p).not.toContain("Create a PR when done");
+    });
+  });
+
+  describe("status: merged (PR merged, issue still open)", () => {
+    it("tells the worker the PR was merged", () => {
+      const p = buildInitialPrompt({ ...baseIssue, status: "merged" }, true);
+      expect(p).toMatch(/PR.*merged|merged.*PR/i);
+    });
+
+    it("tells the worker the issue was not closed and to determine next steps", () => {
+      const p = buildInitialPrompt({ ...baseIssue, status: "merged" }, true);
+      expect(p).toMatch(/not closed/i);
+      expect(p).toMatch(/next steps?/i);
+    });
+
+    it("does NOT include the standard new-task Create-a-PR instruction", () => {
+      const p = buildInitialPrompt({ ...baseIssue, status: "merged" }, true);
+      expect(p).not.toContain("Create a PR when done");
+    });
+  });
+
+  describe("status: closed (issue is closed)", () => {
+    it("tells the worker the issue is closed", () => {
+      const p = buildInitialPrompt({ ...baseIssue, status: "closed" }, true);
+      expect(p).toMatch(/issue.*closed|closed.*issue/i);
+    });
+
+    it("instructs the worker to look for followup work", () => {
+      const p = buildInitialPrompt({ ...baseIssue, status: "closed" }, true);
+      expect(p).toMatch(/follow.?up/i);
+    });
+
+    it("does NOT include the standard new-task Create-a-PR instruction", () => {
+      const p = buildInitialPrompt({ ...baseIssue, status: "closed" }, true);
+      expect(p).not.toContain("Create a PR when done");
+    });
+  });
+});
+
 describe("buildEventPrompt", () => {
   it("returns multi-event fallback for 2+ events", () => {
     const events: Wire.WebhookEvent[] = [

--- a/tests/worker-prompts.test.ts
+++ b/tests/worker-prompts.test.ts
@@ -10,6 +10,7 @@ describe("buildInitialPrompt", () => {
       body: "It crashes",
       labels: ["bug"],
       repoUrl: "https://github.com/x/y",
+      status: "assigned",
     });
     expect(p).toContain("#42");
     expect(p).toContain("Fix bug");
@@ -25,6 +26,7 @@ describe("buildInitialPrompt", () => {
       body: null as unknown as string,
       labels: [],
       repoUrl: "https://github.com/x/y",
+      status: "assigned",
     });
     expect(p).toContain("no description");
   });
@@ -36,6 +38,7 @@ describe("buildInitialPrompt", () => {
       body: "",
       labels: [],
       repoUrl: "https://github.com/x/y",
+      status: "assigned",
     });
     expect(p).toContain("no description");
   });
@@ -47,6 +50,7 @@ describe("buildInitialPrompt", () => {
       body: "body",
       labels: [],
       repoUrl: "https://github.com/x/y",
+      status: "assigned",
     });
     expect(p).toContain("(none)");
   });
@@ -58,6 +62,7 @@ describe("buildInitialPrompt", () => {
       body: "body",
       labels: ["bug", "help wanted", "brunel:ready"],
       repoUrl: "https://github.com/x/y",
+      status: "assigned",
     }, true);
     expect(p).toContain("bug");
     expect(p).toContain("help wanted");
@@ -66,7 +71,7 @@ describe("buildInitialPrompt", () => {
 
   it("isolated checkout — says 'own checkout' and clarifies no worktree needed", () => {
     const p = buildInitialPrompt({
-      number: 1, title: "T", body: "body", labels: [], repoUrl: "https://github.com/x/y",
+      number: 1, title: "T", body: "body", labels: [], repoUrl: "https://github.com/x/y", status: "assigned",
     }, true);
     expect(p).toContain("own checkout");
     expect(p).not.toContain("isolated worktree");
@@ -74,14 +79,14 @@ describe("buildInitialPrompt", () => {
 
   it("reminds worker to update project docs alongside code changes", () => {
     const p = buildInitialPrompt({
-      number: 1, title: "T", body: "body", labels: [], repoUrl: "https://github.com/x/y",
+      number: 1, title: "T", body: "body", labels: [], repoUrl: "https://github.com/x/y", status: "assigned",
     }, true);
     expect(p).toMatch(/project doc/i);
   });
 
   it("shared checkout — mentions worktree", () => {
     const p = buildInitialPrompt({
-      number: 1, title: "T", body: "body", labels: [], repoUrl: "https://github.com/x/y",
+      number: 1, title: "T", body: "body", labels: [], repoUrl: "https://github.com/x/y", status: "assigned",
     }, false);
     expect(p).toContain("worktree");
   });
@@ -89,26 +94,69 @@ describe("buildInitialPrompt", () => {
 });
 
 describe("buildInitialPrompt — status-dependent prompts", () => {
-  const baseIssue = {
+  const baseIssue: Wire.TaskIssue = {
     number: 99,
     title: "My Task",
     body: "Some work to do",
     labels: ["feature"],
     repoUrl: "https://github.com/x/y",
+    status: "assigned",
   };
 
   describe("status: assigned (default, no PR)", () => {
-    it("uses the standard new-task prompt", () => {
+    it("includes issue number and title", () => {
       const p = buildInitialPrompt({ ...baseIssue, status: "assigned" }, true);
       expect(p).toContain("#99");
-      expect(p).toContain("Please work on GitHub issue");
-      expect(p).toContain("Create a PR when done");
+      expect(p).toContain("My Task");
     });
 
-    it("default (no status field) behaves like assigned", () => {
-      const p = buildInitialPrompt({ ...baseIssue }, true);
-      expect(p).toContain("Please work on GitHub issue");
+    it("instructs to create a PR when done", () => {
+      const p = buildInitialPrompt({ ...baseIssue, status: "assigned" }, true);
       expect(p).toContain("Create a PR when done");
+    });
+  });
+
+  describe("workspace context — present in all status variants", () => {
+    it("assigned + isolated — mentions own checkout", () => {
+      const p = buildInitialPrompt({ ...baseIssue, status: "assigned" }, true);
+      expect(p).toMatch(/own checkout/i);
+    });
+
+    it("pushed + isolated — mentions own checkout", () => {
+      const p = buildInitialPrompt(
+        { ...baseIssue, status: "pushed", prNumber: 42, branch: "fix/my-task" },
+        true,
+      );
+      expect(p).toMatch(/own checkout/i);
+    });
+
+    it("merged + isolated — mentions own checkout", () => {
+      const p = buildInitialPrompt(
+        { ...baseIssue, status: "merged", prNumber: 42, branch: "fix/my-task" },
+        true,
+      );
+      expect(p).toMatch(/own checkout/i);
+    });
+
+    it("closed + isolated — mentions own checkout", () => {
+      const p = buildInitialPrompt(
+        { ...baseIssue, status: "closed", prNumber: 42, branch: "fix/my-task" },
+        true,
+      );
+      expect(p).toMatch(/own checkout/i);
+    });
+
+    it("assigned + shared — mentions shared workspace", () => {
+      const p = buildInitialPrompt({ ...baseIssue, status: "assigned" }, false);
+      expect(p).toMatch(/shared workspace/i);
+    });
+
+    it("pushed + shared — mentions shared workspace", () => {
+      const p = buildInitialPrompt(
+        { ...baseIssue, status: "pushed", prNumber: 42, branch: "fix/my-task" },
+        false,
+      );
+      expect(p).toMatch(/shared workspace/i);
     });
   });
 
@@ -121,13 +169,30 @@ describe("buildInitialPrompt — status-dependent prompts", () => {
       expect(p).toContain("PR #42");
     });
 
-    it("tells the worker to fetch and switch to the branch", () => {
+    it("tells the worker to fetch and switch to the branch (isolated)", () => {
       const p = buildInitialPrompt(
         { ...baseIssue, status: "pushed", prNumber: 42, branch: "fix/my-task" },
         true,
       );
       expect(p).toContain("fix/my-task");
       expect(p).toMatch(/fetch/i);
+    });
+
+    it("tells the worker to create a worktree for the branch (shared workspace)", () => {
+      const p = buildInitialPrompt(
+        { ...baseIssue, status: "pushed", prNumber: 42, branch: "fix/my-task" },
+        false,
+      );
+      expect(p).toMatch(/worktree/i);
+      expect(p).toContain("fix/my-task");
+    });
+
+    it("shared workspace pushed — does not say to fetch/checkout as step 1 without worktree", () => {
+      const p = buildInitialPrompt(
+        { ...baseIssue, status: "pushed", prNumber: 42, branch: "fix/my-task" },
+        false,
+      );
+      expect(p).not.toMatch(/git checkout fix\/my-task(?!\s)/);
     });
 
     it("tells the worker to review code review comments", () => {
@@ -149,35 +214,85 @@ describe("buildInitialPrompt — status-dependent prompts", () => {
 
   describe("status: merged (PR merged, issue still open)", () => {
     it("tells the worker the PR was merged", () => {
-      const p = buildInitialPrompt({ ...baseIssue, status: "merged" }, true);
+      const p = buildInitialPrompt(
+        { ...baseIssue, status: "merged", prNumber: 42, branch: "fix/my-task" },
+        true,
+      );
       expect(p).toMatch(/PR.*merged|merged.*PR/i);
     });
 
+    it("includes the PR number", () => {
+      const p = buildInitialPrompt(
+        { ...baseIssue, status: "merged", prNumber: 42, branch: "fix/my-task" },
+        true,
+      );
+      expect(p).toContain("PR #42");
+    });
+
+    it("includes the branch name", () => {
+      const p = buildInitialPrompt(
+        { ...baseIssue, status: "merged", prNumber: 42, branch: "fix/my-task" },
+        true,
+      );
+      expect(p).toContain("fix/my-task");
+    });
+
     it("tells the worker the issue was not closed and to determine next steps", () => {
-      const p = buildInitialPrompt({ ...baseIssue, status: "merged" }, true);
+      const p = buildInitialPrompt(
+        { ...baseIssue, status: "merged", prNumber: 42, branch: "fix/my-task" },
+        true,
+      );
       expect(p).toMatch(/not closed/i);
       expect(p).toMatch(/next steps?/i);
     });
 
     it("does NOT include the standard new-task Create-a-PR instruction", () => {
-      const p = buildInitialPrompt({ ...baseIssue, status: "merged" }, true);
+      const p = buildInitialPrompt(
+        { ...baseIssue, status: "merged", prNumber: 42, branch: "fix/my-task" },
+        true,
+      );
       expect(p).not.toContain("Create a PR when done");
     });
   });
 
   describe("status: closed (issue is closed)", () => {
     it("tells the worker the issue is closed", () => {
-      const p = buildInitialPrompt({ ...baseIssue, status: "closed" }, true);
+      const p = buildInitialPrompt(
+        { ...baseIssue, status: "closed", prNumber: 42, branch: "fix/my-task" },
+        true,
+      );
       expect(p).toMatch(/issue.*closed|closed.*issue/i);
     });
 
+    it("includes the PR number", () => {
+      const p = buildInitialPrompt(
+        { ...baseIssue, status: "closed", prNumber: 42, branch: "fix/my-task" },
+        true,
+      );
+      expect(p).toContain("PR #42");
+    });
+
+    it("includes the branch name", () => {
+      const p = buildInitialPrompt(
+        { ...baseIssue, status: "closed", prNumber: 42, branch: "fix/my-task" },
+        true,
+      );
+      expect(p).toContain("fix/my-task");
+    });
+
     it("instructs the worker to look for followup work", () => {
-      const p = buildInitialPrompt({ ...baseIssue, status: "closed" }, true);
+      const p = buildInitialPrompt(
+        { ...baseIssue, status: "closed", prNumber: 42, branch: "fix/my-task" },
+        true,
+      );
       expect(p).toMatch(/follow.?up/i);
     });
 
     it("does NOT include the standard new-task Create-a-PR instruction", () => {
-      const p = buildInitialPrompt({ ...baseIssue, status: "closed" }, true);
+      const p = buildInitialPrompt(
+        { ...baseIssue, status: "closed", prNumber: 42, branch: "fix/my-task" },
+        true,
+      );
       expect(p).not.toContain("Create a PR when done");
     });
   });


### PR DESCRIPTION
## Summary

- Extends `Wire.TaskIssue` with optional `status`, `prNumber`, and `branch` fields, populated by `Task.toAssignmentPayload()`
- `buildInitialPrompt()` now generates four distinct prompts based on task status:
  - **pushed**: instructs the worker to fetch/checkout the existing branch and review the open PR + code review comments
  - **merged**: alerts the worker the PR merged but the issue is still open; asks them to determine next steps
  - **closed** (or complete): tells the worker the issue is closed and to look for followup work
  - **assigned** (default): unchanged existing prompt
- 10 new tests covering each status variant (written TDD — watched fail before implementing)

## Test plan

- [ ] Run `npm test` — all non-DB tests pass
- [ ] Run `npx tsc --noEmit` — no type errors
- [ ] Run `npm run lint` — no new errors
- [ ] Manually assign a task with `worker:claim` on an issue that already has a PR (status "pushed") and verify the worker receives the branch-pickup prompt
- [ ] Verify a fresh task assignment still uses the standard prompt

Closes #876

🤖 Generated with [Claude Code](https://claude.com/claude-code)