### PR TITLE
fix: exit worker mode when user declines repo activation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Every `worker_hello` gets a `hello_ack` with one of three statuses before any ta
 - `busy` — reconnection accepted, worker may resume
 - `cancelled` — task was taken or completed; worker should reset and become idle
 
-`hello_ack` also carries `repoStatus: "new" | "active"`. If `"new"`, the worker prompts the user to activate the repo. On confirmation the worker sends `activate_repo`; the foreman activates the repo, seeds tasks from open labeled issues, and replies with `repo_activated`. The worker then transitions to idle and normal task assignment proceeds.
+`hello_ack` also carries `repoStatus: "new" | "active"`. If `"new"`, the worker prompts the user to activate the repo. On confirmation the worker sends `activate_repo`; the foreman activates the repo, seeds tasks from open labeled issues, and replies with `repo_activated`. The worker then transitions to idle and normal task assignment proceeds. If the user declines activation, the worker exits worker mode and returns to the interactive REPL.
 
 If a catastrophic error occurs, the foreman sends `foreman_error` (`{ type, message, fatal }`). `fatal: true` causes the worker to stop reconnecting and return to interactive REPL mode.
 

--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -642,9 +642,12 @@ export class WorkerController extends EventEmitter {
           this.ws?.send(JSON.stringify({ type: "activate_repo", workerId: this.agentId } satisfies Wire.WorkerMessage));
           return; // wait for repo_activated
         }
-        // User declined — transition to idle without activating.
-        this.display.print(c.darkGray("Repo not activated. Staying idle."));
-        this.transitionToRegistered();
+        // User declined — exit worker mode and wake the routing loop so stdin
+        // is re-established. Without this, the routing loop stays stuck at
+        // nextRoutingEvent() with no stdin listeners after the picker finishes.
+        this.display.print(c.darkGray("Repo not activated."));
+        await this.stop();
+        this.emit("prompts_ready");
       } else {
         // "idle" or "busy" with repoStatus 'active' (or no repoStatus for back-compat).
         this.transitionToRegistered();

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1957,7 +1957,7 @@ describe("repo activation flow", () => {
     expect(sess.hasPendingPrompts()).toBe(true);
   });
 
-  it("when user declines activation, transitions to registered without sending activate_repo", async () => {
+  it("when user declines activation, does not send activate_repo to the foreman", async () => {
     const pickFn = vi.fn().mockResolvedValue(1); // "No, skip"
     const { sess, ws } = await makeSessionWithPick(pickFn);
     sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "idle", repoStatus: "new" });
@@ -1967,14 +1967,22 @@ describe("repo activation flow", () => {
     expect(activateMsg).toBeUndefined();
   });
 
-  it("when user declines, session is still registered (can receive tasks later)", async () => {
+  it("when user declines activation, worker mode ends (isActive = false)", async () => {
     const pickFn = vi.fn().mockResolvedValue(1); // "No, skip"
     const { sess, ws } = await makeSessionWithPick(pickFn);
     sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "idle", repoStatus: "new" });
     await new Promise((r) => setTimeout(r, 10));
-    // After declining, a follow-up task_assigned should be enqueued (session is registered)
-    sendMsg(ws, { type: "task_assigned", taskId: "99", issue: makeIssue(99) });
-    expect(sess.hasPendingPrompts()).toBe(true);
+    expect(sess.isActive).toBe(false);
+  });
+
+  it("when user declines activation, emits prompts_ready to wake the routing loop", async () => {
+    const pickFn = vi.fn().mockResolvedValue(1); // "No, skip"
+    const { sess, ws } = await makeSessionWithPick(pickFn);
+    const onPromptsReady = vi.fn();
+    sess.on("prompts_ready", onPromptsReady);
+    sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "idle", repoStatus: "new" });
+    // stop() awaits refreshBranch() (a git command) before we emit, so wait longer
+    await vi.waitFor(() => expect(onPromptsReady).toHaveBeenCalled(), { timeout: 2000 });
   });
 
   it("when repoStatus is 'active', transitions normally without showing activation prompt", async () => {


### PR DESCRIPTION
## Summary

- When a user picks "No, skip" on the repo activation prompt, the worker was getting stuck with no stdin listeners and no way to exit (^C and ^D unresponsive)
- Root cause: `transitionToRegistered()` was called but never woke the routing loop; the picker's `onStart` had already cancelled `input.ask()` and the picker removed its own stdin listener when done, leaving the routing loop stuck at `nextRoutingEvent()` with nothing to listen on
- Fix: call `stop()` to cleanly exit worker mode and disconnect, then emit `prompts_ready` so the routing loop re-establishes stdin and drops back to the REPL prompt

## Test plan

- [ ] Manually: start worker on unactivated repo, pick "No, skip" — should return to `>` prompt
- [ ] Manually: same flow with `brunel --worker-mode` flag
- [ ] Unit tests: two new tests verify `isActive = false` and `prompts_ready` is emitted after declining

Closes #883