### PR TITLE
fix: ^C at tool permissions prompt no longer quits the agent

### DIFF
--- a/src/agent/controllers/agent-controller.ts
+++ b/src/agent/controllers/agent-controller.ts
@@ -3,7 +3,7 @@ import { query } from "@anthropic-ai/claude-agent-sdk";
 import type { CanUseTool, PermissionResult } from "@anthropic-ai/claude-agent-sdk";
 import { c } from "../views/style.js";
 import type { Display } from "../views/display.js";
-import { Picker } from "../views/picker.js";
+import { Picker, PickerCancelledError } from "../views/picker.js";
 import type { PickQuestionResult } from "../views/picker.js";
 import { Settings } from "../models/settings.js";
 import type { ModelInfo } from "../models/settings.js";
@@ -44,6 +44,8 @@ type QueryWithModels = { supportedModels?: () => Promise<ModelInfo[]> };
  * AgentController owns the single action of executing one query turn.
  */
 export class AgentController {
+  private currentAbortController: AbortController | null = null;
+
   constructor(
     private display: Display,
     private picker: Picker,
@@ -105,6 +107,7 @@ export class AgentController {
 
     // Use caller-provided AbortController (worker mode) or create our own (REPL mode).
     const ac = abortController ?? new AbortController();
+    this.currentAbortController = ac;
 
     const iterable = query({
       prompt,
@@ -170,6 +173,7 @@ export class AgentController {
       if (!(err instanceof Error && /aborted by user/i.test(err.message))) throw err;
     } finally {
       process.stdin.removeListener("data", onInterrupt);
+      this.currentAbortController = null;
     }
 
     display.stopBar();
@@ -197,20 +201,29 @@ export class AgentController {
     const questions = (input.questions as Question[]) ?? [];
     const answers: Record<string, string> = {};
 
-    for (const q of questions) {
-      display.print(c.yellow(`\n? ${q.question}`));
-      if (q.multiSelect) {
-        const lines = q.options.map((o: QuestionOption) => o.description ? `${o.label} — ${o.description}` : o.label);
-        const idxs = await this.picker.pickMultiple(lines);
-        answers[q.question] = idxs.map((i: number) => q.options[i].label).join(", ");
-      } else {
-        const result: PickQuestionResult = await this.picker.pickQuestion(q.options);
-        if (result.type === "discuss") {
-          display.startBar(getStatusText);
-          return { behavior: "deny", message: "The user would like to discuss more before answering. Prompt them to begin the discussion." };
+    try {
+      for (const q of questions) {
+        display.print(c.yellow(`\n? ${q.question}`));
+        if (q.multiSelect) {
+          const lines = q.options.map((o: QuestionOption) => o.description ? `${o.label} — ${o.description}` : o.label);
+          const idxs = await this.picker.pickMultiple(lines);
+          answers[q.question] = idxs.map((i: number) => q.options[i].label).join(", ");
+        } else {
+          const result: PickQuestionResult = await this.picker.pickQuestion(q.options);
+          if (result.type === "discuss") {
+            display.startBar(getStatusText);
+            return { behavior: "deny", message: "The user would like to discuss more before answering. Prompt them to begin the discussion." };
+          }
+          answers[q.question] = result.type === "answer" ? result.value : result.text;
         }
-        answers[q.question] = result.type === "answer" ? result.value : result.text;
       }
+    } catch (err) {
+      if (err instanceof PickerCancelledError) {
+        display.startBar(getStatusText);
+        this.currentAbortController?.abort();
+        return { behavior: "deny", message: "User cancelled" };
+      }
+      throw err;
     }
 
     display.startBar(getStatusText);
@@ -227,6 +240,11 @@ export class AgentController {
     display.print(c.amber(`\n⚠ ${toolName}(${display.fmtArgs(input)})`));
     const idx = await this.picker.pick(["Allow", "Deny"]);
     display.startBar(getStatusText);
+    if (idx === -1) {
+      // ^C pressed — abort the running query
+      this.currentAbortController?.abort();
+      return { behavior: "deny", message: "User cancelled" };
+    }
     if (idx === 0) return { behavior: "allow", updatedInput: input };
     return { behavior: "deny", message: "User denied tool request" };
   }

--- a/src/agent/views/picker.ts
+++ b/src/agent/views/picker.ts
@@ -1,5 +1,15 @@
 import { s } from "./style.js";
 
+// ── Errors ────────────────────────────────────────────────────────────────────
+
+/** Thrown when the user cancels a picker with Ctrl+C. */
+export class PickerCancelledError extends Error {
+  constructor() {
+    super("Picker cancelled by user");
+    this.name = "PickerCancelledError";
+  }
+}
+
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 export type PickConfig = {
@@ -68,7 +78,7 @@ export class Picker {
     this.onStart?.();
     display?.clearBar();
 
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       let idx = hasConfig && currentIdx >= 0 ? currentIdx : 0;
       let done = false;
       const count = options.length;
@@ -149,8 +159,11 @@ export class Picker {
             else if (ch === "\x11")   { navigateTo((idx + 1) % count); }
             else if (ch === "\x7f" || ch === "\x08") {
               if (textBuf.length > 0) { textBuf = textBuf.slice(0, -1); process.stdout.write("\x08 \x08"); }
-            } else if (ch === "\x03") { process.stdout.write("^C\r\n"); process.exit(0); }
-            else if (ch.charCodeAt(0) >= 32) { textBuf += ch; process.stdout.write(ch); }
+            } else if (ch === "\x03") {
+              eraseMenu();
+              if (hasConfig) { finish({ type: "cancelled" }); } else { finish(-1); }
+              return;
+            } else if (ch.charCodeAt(0) >= 32) { textBuf += ch; process.stdout.write(ch); }
           } else {
             if (ch === "\x10") { navigateTo((idx - 1 + count) % count); }
             else if (ch === "\x11") { navigateTo((idx + 1) % count); }
@@ -164,7 +177,11 @@ export class Picker {
                 finish(idx);
               }
               return;
-            } else if (ch === "\x03") { process.stdout.write("^C\r\n"); process.exit(0); }
+            } else if (ch === "\x03") {
+              eraseMenu();
+              if (hasConfig) { finish({ type: "cancelled" }); } else { finish(-1); }
+              return;
+            }
           }
         }
       }
@@ -183,7 +200,7 @@ export class Picker {
     this.onStart?.();
     display?.clearBar();
 
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       let idx = 0;
       let done = false;
       const count = options.length;
@@ -223,8 +240,11 @@ export class Picker {
             display?.drawBar();
             resolve([...selected].sort((a, b) => a - b));
           } else if (ch === "\x03") {
-            process.stdout.write("^C\r\n");
-            process.exit(0);
+            done = true;
+            process.stdin.removeListener("data", onData);
+            display?.drawBar();
+            reject(new PickerCancelledError());
+            return;
           }
         }
       }
@@ -238,7 +258,7 @@ export class Picker {
    * supporting backspace. No autocomplete or multiline support.
    */
   promptLine(prompt: string): Promise<string> {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       let buf = "";
       process.stdout.write(prompt);
 
@@ -258,8 +278,9 @@ export class Picker {
               process.stdout.write("\x08 \x08");
             }
           } else if (ch === "\x03") {
-            process.stdout.write("^C\r\n");
-            process.exit(0);
+            process.stdin.removeListener("data", onData);
+            reject(new PickerCancelledError());
+            return;
           } else if (ch.charCodeAt(0) >= 32) {
             buf += ch;
             process.stdout.write(ch);
@@ -285,7 +306,7 @@ export class Picker {
     this.onStart?.();
     display?.clearBar();
 
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       const extras = [
         { label: "Other:",        description: "" },
         { label: "Let's discuss", description: "" },
@@ -382,8 +403,11 @@ export class Picker {
                 process.stdout.write("\x08 \x08");
               }
             } else if (ch === "\x03") {
-              process.stdout.write("^C\r\n");
-              process.exit(0);
+              done = true;
+              process.stdin.removeListener("data", onData);
+              display?.drawBar();
+              reject(new PickerCancelledError());
+              return;
             } else if (ch.charCodeAt(0) >= 32) {
               textBuf += ch;
               process.stdout.write(ch);
@@ -402,8 +426,11 @@ export class Picker {
               }
               return;
             } else if (ch === "\x03") {
-              process.stdout.write("^C\r\n");
-              process.exit(0);
+              done = true;
+              process.stdin.removeListener("data", onData);
+              display?.drawBar();
+              reject(new PickerCancelledError());
+              return;
             } else if (ch >= "1" && ch <= "9") {
               const n = parseInt(ch, 10) - 1;
               if (n < count) { navigateTo(n); }

--- a/tests/picker.test.ts
+++ b/tests/picker.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { Picker } from "../src/agent/views/picker.js";
+import { Picker, PickerCancelledError } from "../src/agent/views/picker.js";
 import { AgentStatus } from "../src/agent/models/agent-status.js";
 import { Display } from "../src/agent/views/display.js";
 import { getConfig } from "../src/config.js";
@@ -176,5 +176,116 @@ describe("Picker: status bar not corrupted when ask() is active (issue #832)", (
     const all = written.join("");
     const afterOptions = all.indexOf(BAR_MARKER, all.indexOf("Yes"));
     expect(afterOptions).toBeGreaterThan(-1);
+  });
+});
+
+// ── Issue #887: ^C at picker should not exit the process ──────────────────────
+//
+// Bug: All picker methods called process.exit(0) when Ctrl+C was pressed, which
+// killed the whole agent instead of just cancelling the current operation.
+//
+// Fix: On ^C, picker methods should clean up and resolve/reject gracefully:
+// - pick() without config → resolves with -1 (sentinel for "cancelled")
+// - pick() with config → resolves with { type: "cancelled" } (same as Escape)
+// - pickMultiple() → rejects with PickerCancelledError
+// - pickQuestion() → rejects with PickerCancelledError
+// - promptLine() → rejects with PickerCancelledError
+
+describe("Picker: ^C cancels cleanly without calling process.exit (issue #887)", () => {
+  afterEach(() => {
+    process.stdin.removeAllListeners("data");
+    vi.restoreAllMocks();
+  });
+
+  it("pick() without config: ^C resolves with -1 instead of exiting", async () => {
+    vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    const picker = new Picker();
+
+    const promise = picker.pick(["Allow", "Deny"]);
+    process.stdin.emit("data", "\x03");
+    await expect(promise).resolves.toBe(-1);
+  });
+
+  it("pick() with config: ^C resolves with { type: 'cancelled' } instead of exiting", async () => {
+    vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    const picker = new Picker();
+
+    const promise = picker.pick(["Allow", "Deny"], { escapable: true });
+    process.stdin.emit("data", "\x03");
+    await expect(promise).resolves.toEqual({ type: "cancelled" });
+  });
+
+  it("pick() with config (non-escapable): ^C resolves with { type: 'cancelled' } instead of exiting", async () => {
+    vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    const picker = new Picker();
+
+    const promise = picker.pick(["Allow", "Deny"], {});
+    process.stdin.emit("data", "\x03");
+    await expect(promise).resolves.toEqual({ type: "cancelled" });
+  });
+
+  it("pick() without config in text mode: ^C resolves with -1 instead of exiting", async () => {
+    vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    const picker = new Picker();
+
+    const promise = picker.pick(["Option A", "Other"], { lastIsTextEntry: true });
+    // Navigate to "Other" to enter text mode, then ^C
+    process.stdin.emit("data", "\x11"); // down arrow → select "Other" (text mode)
+    process.stdin.emit("data", "\x03");
+    await expect(promise).resolves.toEqual({ type: "cancelled" });
+  });
+
+  it("pickMultiple(): ^C rejects with PickerCancelledError instead of exiting", async () => {
+    vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    const picker = new Picker();
+
+    const promise = picker.pickMultiple(["A", "B"]);
+    process.stdin.emit("data", "\x03");
+    await expect(promise).rejects.toBeInstanceOf(PickerCancelledError);
+  });
+
+  it("pickQuestion(): ^C rejects with PickerCancelledError instead of exiting", async () => {
+    vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    const picker = new Picker();
+    const opts = [{ label: "Yes", description: "Proceed" }];
+
+    const promise = picker.pickQuestion(opts);
+    process.stdin.emit("data", "\x03");
+    await expect(promise).rejects.toBeInstanceOf(PickerCancelledError);
+  });
+
+  it("pickQuestion() in text mode: ^C rejects with PickerCancelledError instead of exiting", async () => {
+    vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    const picker = new Picker();
+    const opts = [{ label: "Yes", description: "Proceed" }];
+
+    const promise = picker.pickQuestion(opts);
+    // Navigate to "Other:" option to enter text mode, then ^C
+    // "Other:" is second-to-last, "Let's discuss" is last
+    // Down twice from "Yes" → past "Let's discuss" ... actually let's just send ^C directly in normal mode
+    process.stdin.emit("data", "\x11"); // down → "Other:" (text mode)
+    process.stdin.emit("data", "\x03");
+    await expect(promise).rejects.toBeInstanceOf(PickerCancelledError);
+  });
+
+  it("promptLine(): ^C rejects with PickerCancelledError instead of exiting", async () => {
+    vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    const picker = new Picker();
+
+    const promise = picker.promptLine("Enter value: ");
+    process.stdin.emit("data", "\x03");
+    await expect(promise).rejects.toBeInstanceOf(PickerCancelledError);
+  });
+
+  it("pick() without config: drawBar() is called after ^C cancellation", async () => {
+    vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    const display = { clearBar: vi.fn(), drawBar: vi.fn() };
+    const picker = new Picker(display);
+
+    const promise = picker.pick(["Allow", "Deny"]);
+    process.stdin.emit("data", "\x03");
+    await promise;
+
+    expect(display.drawBar).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- All picker methods (`pick`, `pickMultiple`, `pickQuestion`, `promptLine`) called `process.exit(0)` on Ctrl+C, killing the whole agent instead of gracefully cancelling.
- `pick()` without config now resolves with `-1` on ^C (sentinel for "cancelled"), treated as Deny + query abort in `handleToolPermission`
- `pick()` with config now resolves with `{ type: "cancelled" }` on ^C (same as Escape), so settings pickers (model/effort/permissions) already handle it correctly
- `pickMultiple()`, `pickQuestion()`, `promptLine()` now reject with a new `PickerCancelledError` on ^C
- `AgentController` stores the current `AbortController` and aborts it when picker cancellation is detected, stopping the agentic loop and leaving the user at the input prompt

## Test plan

- [x] New tests in `tests/picker.test.ts` covering ^C in all picker modes (normal + text entry) — verified they failed before the fix and pass after
- [x] All existing tests pass (1501 tests, no regressions)
- [x] TypeScript type check passes
- [x] ESLint passes (no new warnings)

Closes #887

🤖 Generated with [Claude Code](https://claude.com/claude-code)