### PR TITLE
feat: show new repos on the dashboard

### DIFF
--- a/docs/2026-04-21-multi-repo-support.md
+++ b/docs/2026-04-21-multi-repo-support.md
@@ -40,6 +40,8 @@ A `'new'` repo is known to the foreman but not yet in play:
 
 Only `'active'` repos have tasks processed and workers assigned.
 
+**Update (issue #882):** The original spec said new repos should not appear on the admin dashboard until activated. This was reversed: new repos are now shown on the dashboard, clearly labeled "not activated". The repo detail page explains that no tasks will be assigned until a `brunel` worker connects and activates the repo.
+
 ### Activation is worker-driven (not dashboard-driven)
 
 All interaction happens through the agent, not the dashboard. Flow:

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -49,6 +49,9 @@ export default function Dashboard() {
             {repos.map((r) => (
               <li key={r.repoId}>
                 <Link to={`/repos/${r.repoId}`}>{r.fullName}</Link>
+                {r.status === "new" && (
+                  <span style={{ marginLeft: "0.5rem", color: "#999", fontSize: "0.85em" }}>not activated</span>
+                )}
               </li>
             ))}
           </ul>

--- a/frontend/src/pages/RepoDetail.tsx
+++ b/frontend/src/pages/RepoDetail.tsx
@@ -47,6 +47,20 @@ export default function RepoDetail() {
       <h2>{repo ? repo.fullName : `Repo #${id}`}</h2>
       <p><Link to="/">← Dashboard</Link></p>
 
+      {repo?.status === "new" && (
+        <section style={{ marginBottom: "2rem", padding: "1rem", background: "#fff8e1", border: "1px solid #ffe082", borderRadius: "4px" }}>
+          <strong>This repo is not yet activated.</strong>
+          <p style={{ margin: "0.5rem 0 0" }}>
+            No tasks will be assigned until the repo is activated. To activate it, start a{" "}
+            <code>brunel</code> worker in this repo:
+          </p>
+          <pre style={{ margin: "0.5rem 0 0", padding: "0.5rem", background: "#f5f5f5", borderRadius: "3px" }}>npm run worker</pre>
+          <p style={{ margin: "0.5rem 0 0" }}>
+            The worker will prompt you to activate the repo on first connection.
+          </p>
+        </section>
+      )}
+
       <section>
         <h3>Tasks ({tasks.length})</h3>
         {tasks.length === 0 ? <p>No tasks.</p> : (

--- a/frontend/src/pages/RepoDetail.tsx
+++ b/frontend/src/pages/RepoDetail.tsx
@@ -51,12 +51,8 @@ export default function RepoDetail() {
         <section style={{ marginBottom: "2rem", padding: "1rem", background: "#fff8e1", border: "1px solid #ffe082", borderRadius: "4px" }}>
           <strong>This repo is not yet activated.</strong>
           <p style={{ margin: "0.5rem 0 0" }}>
-            No tasks will be assigned until the repo is activated. To activate it, start a{" "}
-            <code>brunel</code> worker in this repo:
-          </p>
-          <pre style={{ margin: "0.5rem 0 0", padding: "0.5rem", background: "#f5f5f5", borderRadius: "3px" }}>npm run worker</pre>
-          <p style={{ margin: "0.5rem 0 0" }}>
-            The worker will prompt you to activate the repo on first connection.
+            No tasks will be assigned until the repo is activated. To activate it, run{" "}
+            <code>brunel</code> in this repo — the worker will prompt you to activate on first connection.
           </p>
         </section>
       )}

--- a/src/foreman/controllers/http-server.ts
+++ b/src/foreman/controllers/http-server.ts
@@ -130,7 +130,7 @@ export function createHttpServer({ webhooks, routeEvent }: HttpServerOptions): h
 
   app.get("/api/repos", async (c) => {
     try {
-      const repos = await Repo.listActive();
+      const repos = await Repo.list();
       return c.json(repos.map((r) => r.toWire()));
     } catch (err) {
       log(`ERROR API query failed: ${fmtError(err)}`);

--- a/src/foreman/controllers/wss.ts
+++ b/src/foreman/controllers/wss.ts
@@ -279,7 +279,7 @@ export class ForemanWss {
     this.adminWss.broadcastSnapshot({
       tasks: await TaskManager.getAllTasksForBroadcast(),
       workers: await Worker.allForDashboard(),
-      repos: (await Repo.listActive()).map((r) => r.toWire()),
+      repos: (await Repo.list()).map((r) => r.toWire()),
     });
   }
 

--- a/src/foreman/index.ts
+++ b/src/foreman/index.ts
@@ -39,7 +39,7 @@ if (isMain) {
   const adminWss = createAdminWss(server, async () => ({
     tasks: await TaskManager.getAllTasksForBroadcast(),
     workers: Worker.all().map((w) => w.toWire()),
-    repos: (await Repo.listActive()).map((r) => r.toWire()),
+    repos: (await Repo.list()).map((r) => r.toWire()),
   }));
 
   foremanWss = new ForemanWss({ config, server, adminWss });

--- a/tests/browser/repo.spec.ts
+++ b/tests/browser/repo.spec.ts
@@ -165,5 +165,5 @@ test("repo detail page: shows activation banner for new (unactivated) repo", asy
 
   // Repo detail should show the activation banner
   await expect(page.getByText(/This repo is not yet activated/)).toBeVisible();
-  await expect(page.getByText("npm run worker")).toBeVisible();
+  await expect(page.getByText(/run.*brunel/)).toBeVisible();
 });

--- a/tests/browser/repo.spec.ts
+++ b/tests/browser/repo.spec.ts
@@ -123,3 +123,47 @@ test("worker detail page: shows repo info", async ({ page }) => {
     await disconnectWorker(workerId);
   }
 });
+
+test("dashboard: shows new (unactivated) repo with 'not activated' label", async ({ page }) => {
+  // Posting a webhook from a new repo creates it with status "new"
+  await postWebhook("issues", {
+    action: "labeled",
+    label: { name: "brunel:ready" },
+    issue: {
+      number: 9001,
+      title: "Test issue for unactivated repo",
+      body: "",
+      labels: [{ name: "brunel:ready" }],
+    },
+    repository: { full_name: "owner/new-repo-9001" },
+  });
+
+  await page.goto("/");
+  const reposSection = page.locator("section").filter({ has: page.locator("h3").filter({ hasText: /Repos/ }) });
+  await expect(reposSection.getByRole("link", { name: "owner/new-repo-9001" })).toBeVisible();
+  // The new repo should be labeled "not activated"
+  const repoItem = reposSection.getByRole("listitem").filter({ has: page.getByRole("link", { name: "owner/new-repo-9001" }) });
+  await expect(repoItem.getByText("not activated")).toBeVisible();
+});
+
+test("repo detail page: shows activation banner for new (unactivated) repo", async ({ page }) => {
+  await postWebhook("issues", {
+    action: "labeled",
+    label: { name: "brunel:ready" },
+    issue: {
+      number: 9002,
+      title: "Test issue for activation banner",
+      body: "",
+      labels: [{ name: "brunel:ready" }],
+    },
+    repository: { full_name: "owner/new-repo-9002" },
+  });
+
+  await page.goto("/");
+  const reposSection = page.locator("section").filter({ has: page.locator("h3").filter({ hasText: /Repos/ }) });
+  await reposSection.getByRole("link", { name: "owner/new-repo-9002" }).click();
+
+  // Repo detail should show the activation banner
+  await expect(page.getByText(/This repo is not yet activated/)).toBeVisible();
+  await expect(page.getByText("npm run worker")).toBeVisible();
+});

--- a/tests/browser/server.ts
+++ b/tests/browser/server.ts
@@ -145,7 +145,7 @@ async function handleTestRoute(
 const adminWss = createAdminWss(server, async () => ({
   tasks: await TaskManager.getAllTasksForBroadcast(),
   workers: await Worker.allForDashboard(),
-  repos: (await Repo.listActive()).map((r) => r.toWire()),
+  repos: (await Repo.list()).map((r) => r.toWire()),
 }));
 
 // ── Foreman WebSocket ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- New (unactivated) repos now appear on the dashboard instead of being hidden until activated
- They are clearly labeled "not activated" in the repos section
- The repo detail page shows an activation banner for unactivated repos, explaining that no tasks will be assigned and giving instructions to run `npm run worker` to activate

## Changes

- Backend: snapshot builders (`wss.ts`, `index.ts`, `http-server.ts`, browser test `server.ts`) now use `Repo.list()` instead of `Repo.listActive()` so all repos are included
- Frontend: Dashboard shows "not activated" label next to unactivated repos
- Frontend: RepoDetail shows a banner with activation instructions when `repo.status === "new"`
- Tests: Two new Playwright browser tests cover the "not activated" label and the activation banner

## Test plan

- [ ] Dashboard shows unactivated repos with "not activated" label
- [ ] Clicking an unactivated repo navigates to its detail page
- [ ] Repo detail page shows the activation banner with `npm run worker` instructions
- [ ] Activated repos (`owner/repo`) have no banner
- [ ] Playwright browser tests pass (`npm run test:browser`)
- [ ] Unit tests pass (`npm test`)

Closes #882

🤖 Generated with [Claude Code](https://claude.com/claude-code)