### PR TITLE
fix: clear intermediate buffer rows on multi-line paste

### DIFF
--- a/src/agent/views/input.ts
+++ b/src/agent/views/input.ts
@@ -176,8 +176,11 @@ export class Input {
     if (prevRow > 0) process.stdout.write(`\x1b[${prevRow}A`);
     process.stdout.write("\r");
 
-    // 2. Write prompt + buffer (pasted \n → visual continuation "... ")
-    const displayStr = this._buffer.replace(/\n/g, "\r\n    ");
+    // 2. Write prompt + buffer (pasted \n → visual continuation "... ").
+    // \x1b[K before each \r\n clears the rest of each intermediate buffer row
+    // with the default background, erasing any residual colored cells left by
+    // a previous status bar that occupied those rows (issue #893).
+    const displayStr = this._buffer.replace(/\n/g, "\x1b[K\r\n    ");
     process.stdout.write(this._promptLine + displayStr);
 
     const { row: endRow } = this._screenPosOf(this._buffer.length);
@@ -229,7 +232,7 @@ export class Input {
   private _drawFresh() {
     if (this._done) return;
     this._totalDrawnRows = 0; // reset: we're drawing from a new position
-    const displayStr = this._buffer.replace(/\n/g, "\r\n    ");
+    const displayStr = this._buffer.replace(/\n/g, "\x1b[K\r\n    ");
     // print() already moved the cursor to a new line via console.log's
     // trailing \n; \r ensures we're at column 0 without adding an extra blank line.
     process.stdout.write("\r" + this._promptLine + displayStr);

--- a/tests/repl.multiline.test.ts
+++ b/tests/repl.multiline.test.ts
@@ -252,6 +252,67 @@ describe("ask() - up/down arrow navigation", () => {
   });
 });
 
+// ── Issue #893: residual green bar after multi-line paste ─────────────────────
+//
+// When a multi-line paste causes the buffer to grow past the old status bar
+// row, the new buffer content is written over those rows but only replaces
+// the characters actually typed. The columns past the last written character
+// retain the old green background from the previous drawRaw() \x1b[K.
+// Fix: insert \x1b[K before each \r\n    in the display string so every
+// intermediate buffer line is cleared to end-of-line before continuing.
+
+describe("ask() - intermediate buffer lines cleared after multi-line paste (issue #893)", () => {
+  it("each intermediate buffer line emits \\x1b[K before moving to next row", async () => {
+    // cols=80, prompt="> " (2 chars), persistent bar active.
+    // Paste "a\nb\nc" → 3 rows. The display writes "a\x1b[K\r\n    b\x1b[K\r\n    c".
+    // Each \x1b[K clears the rest of the row with default bg, removing any
+    // residual green from the old status bar that those rows may have had.
+    setColumns(80);
+    const writeSpy = vi.mocked(process.stdout.write);
+
+    testDisplay.startPersistentBar();
+
+    await withFakeStdin(async (stdin) => {
+      const p = testInput.ask("> ", () => []);
+      writeSpy.mockClear();
+
+      // Paste multi-line content — the first newline moves into what was the
+      // old blank-separator row; deeper lines move into the old status-bar row.
+      stdin.push("\x1b[200~a\nb\nc\x1b[201~");
+
+      const output = collectOutput(writeSpy);
+
+      // The two intermediate lines ("a" and "b") must each be followed by
+      // \x1b[K before the \r\n that advances to the next display row.
+      // We look for the pattern <char>\x1b[K\r\n
+      expect(output).toMatch(/a\x1b\[K\r\n/);
+      expect(output).toMatch(/b\x1b\[K\r\n/);
+
+      stdin.push("\r");
+      expect(await p).toBe("a\nb\nc");
+    });
+
+    testDisplay.stopPersistentBar();
+  });
+
+  it("buffer value is correct after multi-line paste with persistent bar active", async () => {
+    // Regression: paste should not corrupt the buffer value even when the
+    // pasted content spans rows that previously held the status bar.
+    setColumns(80);
+
+    testDisplay.startPersistentBar();
+
+    await withFakeStdin(async (stdin) => {
+      const p = testInput.ask("> ", () => []);
+      stdin.push("\x1b[200~foo\nbar\nbaz\x1b[201~");
+      stdin.push("\r");
+      expect(await p).toBe("foo\nbar\nbaz");
+    });
+
+    testDisplay.stopPersistentBar();
+  });
+});
+
 // ── Status update callback (issue #486: paste + status bar) ──────────────────
 //
 // When the persistent status bar changes while ask() has a multiline buffer


### PR DESCRIPTION
## Root cause

When a multi-line paste causes the buffer to grow past the rows previously occupied by the status bar, `_fullRedraw` writes new buffer content over those rows — but only replaces the characters actually written. The columns past the last written character retain the old green background from the previous `drawRaw()` `\x1b[K`. This left a residual green bar visible behind the pasted text.

## Fix

Add `\x1b[K` before each `\r\n    ` in the `displayStr` replacement in `_fullRedraw` and `_drawFresh`:

```ts
// Before
const displayStr = this._buffer.replace(/\n/g, "\r\n    ");

// After
const displayStr = this._buffer.replace(/\n/g, "\x1b[K\r\n    ");
```

This clears every intermediate buffer row to end-of-line with the default background before advancing to the next row, eliminating any residual colored cells from a previous status bar.

## Test plan

- [ ] New test: `each intermediate buffer line emits \x1b[K before moving to next row` — verifies the fix pattern appears in output after multi-line paste
- [ ] New test: `buffer value is correct after multi-line paste with persistent bar active` — regression guard
- [ ] All existing tests pass (1529)
- [ ] Type check clean (`npx tsc --noEmit`)
- [ ] Manual repro: start REPL with worker status bar, paste multi-line text — no residual green bar

Closes #893

🤖 Generated with [Claude Code](https://claude.com/claude-code)