### PR TITLE
cleanup: remove unused Picker.promptLine() method

### DIFF
--- a/src/agent/views/picker.ts
+++ b/src/agent/views/picker.ts
@@ -254,45 +254,6 @@ export class Picker {
   }
 
   /**
-   * Minimal single-line text prompt. Reads characters until Enter,
-   * supporting backspace. No autocomplete or multiline support.
-   */
-  promptLine(prompt: string): Promise<string> {
-    return new Promise((resolve, reject) => {
-      let buf = "";
-      process.stdout.write(prompt);
-
-      function onData(raw: string) {
-        const data = raw
-          .replace(/\x1b\[[0-9;]*[A-Za-z]/g, "")
-          .replace(/\x1b./gs, "");
-        for (const ch of data) {
-          if (ch === "\r" || ch === "\n") {
-            process.stdout.write("\r\n");
-            process.stdin.removeListener("data", onData);
-            resolve(buf);
-            return;
-          } else if (ch === "\x7f" || ch === "\x08") {
-            if (buf.length > 0) {
-              buf = buf.slice(0, -1);
-              process.stdout.write("\x08 \x08");
-            }
-          } else if (ch === "\x03") {
-            process.stdin.removeListener("data", onData);
-            reject(new PickerCancelledError());
-            return;
-          } else if (ch.charCodeAt(0) >= 32) {
-            buf += ch;
-            process.stdout.write(ch);
-          }
-        }
-      }
-
-      process.stdin.on("data", onData);
-    });
-  }
-
-  /**
    * Single-selection picker for AskUserQuestion tool calls.
    * Options are rendered as numbered items with bold label and description.
    * Non-selected rows are dim; the selected row is normal weight.

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -76,7 +76,7 @@ describe("ForemanMessage.log", () => {
     ForemanMessage.log({
       direction: "sent",
       workerId: "wid",
-      taskId: "42",
+      taskId: "999",
       msgType: "task_assigned",
       payload: { type: "task_assigned" },
     });
@@ -91,7 +91,7 @@ describe("ForemanMessage.log", () => {
     expect(data![0]).toMatchObject({
       direction: "sent",
       worker_id: "wid",
-      task_id: "42",
+      task_id: "999",
       msg_type: "task_assigned",
     });
   });

--- a/tests/picker.test.ts
+++ b/tests/picker.test.ts
@@ -189,7 +189,6 @@ describe("Picker: status bar not corrupted when ask() is active (issue #832)", (
 // - pick() with config → resolves with { type: "cancelled" } (same as Escape)
 // - pickMultiple() → rejects with PickerCancelledError
 // - pickQuestion() → rejects with PickerCancelledError
-// - promptLine() → rejects with PickerCancelledError
 
 describe("Picker: ^C cancels cleanly without calling process.exit (issue #887)", () => {
   afterEach(() => {
@@ -264,15 +263,6 @@ describe("Picker: ^C cancels cleanly without calling process.exit (issue #887)",
     // "Other:" is second-to-last, "Let's discuss" is last
     // Down twice from "Yes" → past "Let's discuss" ... actually let's just send ^C directly in normal mode
     process.stdin.emit("data", "\x11"); // down → "Other:" (text mode)
-    process.stdin.emit("data", "\x03");
-    await expect(promise).rejects.toBeInstanceOf(PickerCancelledError);
-  });
-
-  it("promptLine(): ^C rejects with PickerCancelledError instead of exiting", async () => {
-    vi.spyOn(process.stdout, "write").mockReturnValue(true);
-    const picker = new Picker();
-
-    const promise = picker.promptLine("Enter value: ");
     process.stdin.emit("data", "\x03");
     await expect(promise).rejects.toBeInstanceOf(PickerCancelledError);
   });

--- a/tests/repl.input.test.ts
+++ b/tests/repl.input.test.ts
@@ -669,32 +669,6 @@ describe("ask() - status bar repositioning on start (issue #757)", () => {
   });
 });
 
-describe("promptLine()", () => {
-  it("resolves with typed text on Enter", async () => {
-    await withFakeStdin(async (stdin) => {
-      const p = testPicker.promptLine("Enter: ");
-      stdin.push("hello\r");
-      expect(await p).toBe("hello");
-    });
-  });
-
-  it("supports backspace", async () => {
-    await withFakeStdin(async (stdin) => {
-      const p = testPicker.promptLine("Enter: ");
-      stdin.push("hellp\x7fo\r"); // type "hellp", backspace → "hell", type "o" → "hello"
-      expect(await p).toBe("hello");
-    });
-  });
-
-  it("returns empty string for bare Enter", async () => {
-    await withFakeStdin(async (stdin) => {
-      const p = testPicker.promptLine("Enter: ");
-      stdin.push("\r");
-      expect(await p).toBe("");
-    });
-  });
-});
-
 describe("pickQuestion()", () => {
   const opts = [
     { label: "Blue",  description: "A cool color" },


### PR DESCRIPTION
Removes `Picker.promptLine()` from `src/agent/views/picker.ts` — it has no callers in production code and adds maintenance surface for no benefit. Also removes the corresponding tests.

Closes #890