### PR TITLE
fix: send claimTaskId atomically in worker_hello

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,8 @@ Every `worker_hello` gets a `hello_ack` with one of three statuses before any ta
 - `busy` — reconnection accepted, worker may resume
 - `cancelled` — task was taken or completed; worker should reset and become idle
 
+An idle `worker_hello` may include `claimTaskId` to atomically register and claim a specific task (used by the `/worker:claim` command on first connect). The foreman sends `hello_ack { status: "idle" }` first, then immediately sends `task_assigned` or a non-fatal `foreman_error`.
+
 `hello_ack` also carries `repoStatus: "new" | "active"`. If `"new"`, the worker prompts the user to activate the repo. On confirmation the worker sends `activate_repo`; the foreman activates the repo, seeds tasks from open labeled issues, and replies with `repo_activated`. The worker then transitions to idle and normal task assignment proceeds. If the user declines activation, the worker exits worker mode and returns to the interactive REPL.
 
 If a catastrophic error occurs, the foreman sends `foreman_error` (`{ type, message, fatal }`). `fatal: true` causes the worker to stop reconnecting and return to interactive REPL mode.

--- a/shared/wire.ts
+++ b/shared/wire.ts
@@ -95,7 +95,7 @@ export interface TaskIssue {
 
 // Worker → Foreman messages
 export type WorkerMessage =
-  | { type: "worker_hello"; workerId: string; repo: string; taskId?: string; status: "idle" | "busy"; workerSecret?: string }
+  | { type: "worker_hello"; workerId: string; repo: string; taskId?: string; claimTaskId?: string; status: "idle" | "busy"; workerSecret?: string }
   | { type: "task_complete"; workerId: string; taskId: string; stats?: { inputTokens: number; outputTokens: number; costUsd?: number } }
   | { type: "worker_goodbye"; workerId: string; taskId?: string }
   | { type: "activate_repo"; workerId: string }

--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -432,8 +432,11 @@ export class WorkerController extends EventEmitter {
           return undefined;
         }
         if (!this._isActive) {
+          // Include the claim in the hello so it's atomic with registration.
+          this._pendingClaimTaskId = taskId;
           await this.start();
-          if (!this._isActive) return undefined;
+          if (!this._isActive) this._pendingClaimTaskId = undefined;
+          return undefined;
         }
         if (this.connectionState === "registered") {
           this.sendClaimTask(taskId);
@@ -453,19 +456,7 @@ export class WorkerController extends EventEmitter {
   }
 
   private buildWsFactory(): WsFactory {
-    return (agentId, taskId) => {
-      const ws = new WebSocket(`${getConfig().foremanUrl}/worker`);
-      ws.on("open", () => {
-        ws.send(JSON.stringify({
-          type: "worker_hello",
-          workerId: agentId,
-          repo: this.repo,
-          taskId,
-          status: taskId ? "busy" : "idle",
-        }));
-      });
-      return ws;
-    };
+    return () => new WebSocket(`${getConfig().foremanUrl}/worker`);
   }
 
   private resetSessionState(): void {
@@ -558,6 +549,18 @@ export class WorkerController extends EventEmitter {
     };
 
     ws.on("open", () => {
+      // Read and consume any pending claim so it's included in this hello exactly once.
+      const claimTaskId = this._pendingClaimTaskId;
+      this._pendingClaimTaskId = undefined;
+      ws.send(JSON.stringify({
+        type: "worker_hello",
+        workerId: this.agentStatus.agentId,
+        repo: this.repo,
+        ...(this.currentTaskId !== undefined && { taskId: this.currentTaskId }),
+        ...(claimTaskId && { claimTaskId }),
+        status: this.currentTaskId ? "busy" : "idle",
+      } satisfies Wire.WorkerMessage));
+
       this.connectionState = "hello_sent";
       this.agentStatus.update({ connectionStatus: "handshaking" });
 

--- a/src/foreman/controllers/wss.ts
+++ b/src/foreman/controllers/wss.ts
@@ -341,6 +341,8 @@ export class ForemanWss {
 
     if (msg.status === "busy" && msg.taskId) {
       await this.handleBusyHello(workerId, msg.taskId, ws, repo);
+    } else if (msg.claimTaskId) {
+      await this.handleClaimHello(workerId, msg.claimTaskId, ws, repo);
     } else {
       await this.handleIdleHello(workerId, ws, repo);
     }
@@ -465,6 +467,27 @@ export class ForemanWss {
       // Worker retries on reconnect and the operation succeeds once the DB recovers.
       this.sendError(ws, `Internal error during idle hello: ${fmtError(err)}`, false, workerId, repo.id);
     }
+  }
+
+  /**
+   * Handles a worker_hello that carries claimTaskId — the worker is connecting
+   * fresh and wants to be assigned a specific task. Registers as idle first
+   * (reverting any prior stale assignment and sending hello_ack), then
+   * immediately processes the claim exactly like handleClaimTask does.
+   */
+  async handleClaimHello(workerId: string, claimTaskId: string, ws: WebSocket, repo: Repo): Promise<void> {
+    await this.handleIdleHello(workerId, ws, repo);
+    const worker = Worker.fromRegistry(workerId);
+    if (!worker) return; // handleIdleHello failed; error already sent to ws
+    this.workerLog(workerId, `hello claim task=#${claimTaskId}`);
+    const outcome = await worker.repo.taskManager.claimTask(worker, claimTaskId);
+    if (!outcome.ok) {
+      this.sendMsg(worker, { type: "foreman_error", message: outcome.error, fatal: false }, { logTaskId: claimTaskId });
+      return;
+    }
+    const { task } = outcome;
+    this.sendMsg(worker, { type: "task_assigned", taskId: task.taskId, issue: task.toAssignmentPayload() });
+    this.workerLog(workerId, `→ claim task_assigned #${task.issueNumber} "${task.title}"`);
   }
 
   async handleActivateRepo(workerId: string, ws: WebSocket): Promise<void> {

--- a/tests/foreman.hello-handlers.test.ts
+++ b/tests/foreman.hello-handlers.test.ts
@@ -577,6 +577,108 @@ describe("activate_repo", () => {
   });
 });
 
+// ── handleClaimHello ───────────────────────────────────────────────────────────
+
+describe("handleClaimHello", () => {
+  beforeEach(async () => {
+    await taskManager.repo.activate();
+  });
+
+  it("sends idle hello_ack then task_assigned for a valid unassigned task", async () => {
+    await seedTask({ task_id: "77", issue_number: 77, repo_id: taskManager.repo.id });
+    const { wss, sendMsg } = makeWss(taskManager);
+
+    await wss.handleClaimHello("w1", "77", fakeWs(), taskManager.repo);
+
+    const ack = helloAck(sendMsg);
+    expect(ack?.status).toBe("idle");
+
+    const assignedCall = sendMsg.mock.calls.find(([, msg]) => (msg as { type: string }).type === "task_assigned");
+    expect(assignedCall).toBeDefined();
+    expect((assignedCall![1] as { taskId: string }).taskId).toBe("77");
+  });
+
+  it("registers worker as busy with the claimed task", async () => {
+    await seedTask({ task_id: "77", issue_number: 77, repo_id: taskManager.repo.id });
+    const { wss } = makeWss(taskManager);
+
+    await wss.handleClaimHello("w1", "77", fakeWs(), taskManager.repo);
+
+    expect(Worker.fromRegistry("w1")?.status).toBe("busy");
+    expect(Worker.fromRegistry("w1")?.currentTaskId).toBe("77");
+  });
+
+  it("sends foreman_error (non-fatal) when task does not exist", async () => {
+    const { wss, sendMsg } = makeWss(taskManager);
+
+    await wss.handleClaimHello("w1", "999", fakeWs(), taskManager.repo);
+
+    const ack = helloAck(sendMsg);
+    expect(ack?.status).toBe("idle");
+
+    const errorCall = sendMsg.mock.calls.find(([, msg]) => (msg as { type: string }).type === "foreman_error");
+    expect(errorCall).toBeDefined();
+    expect((errorCall![1] as { fatal: boolean }).fatal).toBe(false);
+    expect((errorCall![1] as { message: string }).message).toContain("999");
+  });
+
+  it("worker is idle when claim fails", async () => {
+    const { wss } = makeWss(taskManager);
+    await wss.handleClaimHello("w1", "nonexistent", fakeWs(), taskManager.repo);
+    expect(Worker.fromRegistry("w1")?.status).toBe("idle");
+  });
+
+  it("sends foreman_error when task is held by an active worker", async () => {
+    const repo = taskManager.repo;
+    // Seed task with worker_id set so claimTask sees it as assigned in the DB
+    const task = await seedTask({ task_id: "77", issue_number: 77, repo_id: repo.id, worker_id: "w2", assigned_at: new Date().toISOString() });
+    const w2 = Worker.register("w2", fakeWs(), repo);
+    w2.assign(task);
+
+    const { wss, sendMsg } = makeWss(taskManager);
+    await wss.handleClaimHello("w1", "77", fakeWs(), repo);
+
+    const errorCall = sendMsg.mock.calls.find(([, msg]) => (msg as { type: string }).type === "foreman_error");
+    expect(errorCall).toBeDefined();
+    expect((errorCall![1] as { fatal: boolean }).fatal).toBe(false);
+  });
+});
+
+// ── handleWorkerHello routing for claimTaskId ──────────────────────────────────
+
+describe("handleWorkerHello with claimTaskId", () => {
+  it("routes to handleClaimHello when hello has claimTaskId and status is idle", async () => {
+    const { wss } = makeWss(taskManager);
+    vi.spyOn(Repo, "findOrCreate").mockResolvedValue(taskManager.repo as unknown as Repo);
+    const claimHelloSpy = vi.spyOn(wss, "handleClaimHello").mockResolvedValue();
+
+    await wss.handleWorkerHello("w1", fakeWs(), {
+      type: "worker_hello",
+      workerId: "w1",
+      repo: "owner/repo",
+      status: "idle",
+      claimTaskId: "77",
+    });
+
+    expect(claimHelloSpy).toHaveBeenCalledWith("w1", "77", expect.anything(), taskManager.repo);
+  });
+
+  it("routes to handleIdleHello when hello has no claimTaskId", async () => {
+    const { wss } = makeWss(taskManager);
+    vi.spyOn(Repo, "findOrCreate").mockResolvedValue(taskManager.repo as unknown as Repo);
+    const idleHelloSpy = vi.spyOn(wss, "handleIdleHello").mockResolvedValue();
+
+    await wss.handleWorkerHello("w1", fakeWs(), {
+      type: "worker_hello",
+      workerId: "w1",
+      repo: "owner/repo",
+      status: "idle",
+    });
+
+    expect(idleHelloSpy).toHaveBeenCalled();
+  });
+});
+
 // ── ForemanMessage.buildSummary — foreman_error ────────────────────────────────
 
 describe("ForemanMessage.buildSummary — foreman_error", () => {

--- a/tests/worker.claim.test.ts
+++ b/tests/worker.claim.test.ts
@@ -47,6 +47,16 @@ function sentClaimTask(ws: FakeWs): { type: string; taskId: string; workerId: st
   return undefined;
 }
 
+function sentHello(ws: FakeWs): Record<string, unknown> | undefined {
+  for (const call of ws.send.mock.calls) {
+    try {
+      const msg = JSON.parse(call[0] as string);
+      if (msg.type === "worker_hello") return msg as Record<string, unknown>;
+    } catch { /* ignore */ }
+  }
+  return undefined;
+}
+
 function printedMessages(display: { print: ReturnType<typeof vi.fn> }): string[] {
   return display.print.mock.calls.map((a) => stripAnsi(String(a[0])));
 }
@@ -204,12 +214,40 @@ describe("when worker mode is not active", () => {
     expect(session.isActive).toBe(true);
   });
 
-  it("sends claim_task after starting (connectionState becomes registered)", async () => {
-    // start() leaves connectionState as "registered" since FakeWs never fires "open"
+  it("includes claimTaskId in the worker_hello when connecting", async () => {
     const handler = await getClaimHandler(session);
     await handler("42");
-    const msg = sentClaimTask(fakeWs);
-    expect(msg).toBeDefined();
-    expect(msg?.taskId).toBe("42");
+    // Fire the open event — this triggers the hello send in connect()'s open handler
+    fakeWs.emit("open");
+    await new Promise<void>((r) => setImmediate(r));
+
+    const hello = sentHello(fakeWs);
+    expect(hello).toBeDefined();
+    expect(hello?.claimTaskId).toBe("42");
+    expect(hello?.status).toBe("idle");
+  });
+
+  it("does not send a separate claim_task message when fresh-connecting", async () => {
+    const handler = await getClaimHandler(session);
+    await handler("42");
+    fakeWs.emit("open");
+    await new Promise<void>((r) => setImmediate(r));
+
+    expect(sentClaimTask(fakeWs)).toBeUndefined();
+  });
+
+  it("clears the pending claim after the hello so reconnect does not re-send claimTaskId", async () => {
+    const handler = await getClaimHandler(session);
+    await handler("42");
+    fakeWs.emit("open");
+    await new Promise<void>((r) => setImmediate(r));
+
+    // Simulate reconnect: reset the send mock and fire open again
+    fakeWs.send.mockClear();
+    fakeWs.emit("open");
+    await new Promise<void>((r) => setImmediate(r));
+
+    const hello2 = sentHello(fakeWs);
+    expect(hello2?.claimTaskId).toBeUndefined();
   });
 });

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -763,8 +763,9 @@ describe("hello_ack handshake — buffering", () => {
       // Reconnect: new WS is created
       const newWs = reconnectWithNewWs();
 
-      // Open event → hello_sent state
+      // Open event → hello_sent state (hello is sent here)
       newWs.emit("open");
+      newWs.send.mockClear();
 
       // Try to send task_complete — should be buffered (hello_ack not yet received)
       await session.completeCurrentTask();
@@ -790,6 +791,7 @@ describe("hello_ack handshake — buffering", () => {
 
       const newWs = reconnectWithNewWs();
       newWs.emit("open");
+      newWs.send.mockClear();
 
       // Buffer a task_complete
       await session.completeCurrentTask();
@@ -962,6 +964,7 @@ describe("hello_ack handshake — buffering", () => {
 
       const newWs = reconnectWithNewWs();
       newWs.emit("open");
+      newWs.send.mockClear();
 
       await session.completeCurrentTask();
       expect(newWs.send).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- Adds `claimTaskId` to the `worker_hello` wire message so a fresh-connecting worker can atomically register and claim a specific task in a single roundtrip
- New `handleClaimHello` path on the foreman: registers as idle (sends `hello_ack idle`), then immediately assigns the task or returns a non-fatal `foreman_error`
- Worker no longer sends a separate `claim_task` message on fresh connect — the claim travels with the hello
- Updated CLAUDE.md to document the new handshake path

## Test plan

- [ ] `npm test` passes (all non-DB tests green)
- [ ] New tests in `tests/foreman.hello-handlers.test.ts` cover the `handleClaimHello` path (valid task, missing task, already-assigned task, routing)
- [ ] New tests in `tests/worker.claim.test.ts` verify `claimTaskId` appears in the hello and is cleared after the first send so reconnects don't re-claim

Closes #897

🤖 Generated with [Claude Code](https://claude.com/claude-code)