### PR TITLE
Remind agents to update docs in the same PR as code changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ A GitHub-driven autonomous agent. Labels a GitHub issue `brunel:ready` → the f
 
 CLAUDE.md should contain high-level information about project structure, conventions, and workflows — things that help orient a developer quickly and that aren't obvious from reading the code. It should **not** document individual file APIs, method signatures, or implementation details; those belong in the code itself. Keep it concise so it doesn't consume unnecessary context tokens or drift out of date.
 
+When making a change, check whether it affects anything documented here and update this file in the same PR.
+
 ## Architecture
 
 Two independent processes: **foreman** (server) and **worker** (agent). They communicate over WebSocket. The foreman has **zero imports from agent code** — `src/agent/` belongs entirely to the worker side.


### PR DESCRIPTION
## Summary

- Adds a one-liner to CLAUDE.md's "About this file" section: *"When making a change, check whether it affects anything documented here and update this file in the same PR."*
- Adds a checklist item to the `branch-discipline` skill: *"Checked whether CLAUDE.md, README, or other project docs need updating to reflect this change; included any updates in this PR."*

## Motivation

In PR #902 I deferred the CLAUDE.md update until after the PR had already merged, requiring a separate follow-up PR (#904). The doc-check step was in the task instructions but not enforced anywhere an agent would see at PR-creation time. These two changes put the reminder in both the always-loaded project instructions and the pre-PR checklist gate.