### PR TITLE
fix: prevent data-loss warning and double destroy on worker restart

### DIFF
--- a/src/agent/controllers/workspace-controller.ts
+++ b/src/agent/controllers/workspace-controller.ts
@@ -18,7 +18,41 @@ export class WorkspaceController {
     readonly workspace: Workspace | undefined,
     private display: WorkerDisplay,
     private config: { verbose: boolean },
-  ) {}
+  ) {
+    this._setupListeners();
+  }
+
+  private _setupListeners(): void {
+    const { workspace } = this;
+    if (!workspace) return;
+    workspace.on("create-start", () => {
+      if (!this.config.verbose) this.display.print(c.sageGreen("Creating workspace..."));
+    });
+    workspace.on("clone-start", ({ repoUrl: url, dir }: { repoUrl: string; dir: string }) => {
+      if (this.config.verbose) this.display.print(c.sageGreen(`Cloning ${url} → ${dir}`));
+    });
+    workspace.on("npm-install", ({ dir }: { dir: string }) => {
+      if (this.config.verbose) this.display.print(c.sageGreen(`Installing dependencies in ${dir}`));
+    });
+    workspace.on("reset-start", ({ dir }: { dir: string }) => {
+      this.display.print(c.sageGreen(this.config.verbose ? `Resetting ${dir}` : "Resetting workspace..."));
+    });
+    workspace.on("reset-retry", ({ error }: { dir: string; error: string }) => {
+      this.display.print(c.amber(`Reset failed, retrying: ${error}`));
+    });
+    workspace.on("reset-reclone", ({ dir, error }: { dir: string; error: string; repoUrl: string }) => {
+      this.display.print(c.amber(this.config.verbose ? `Reset failed again, re-cloning ${dir}: ${error}` : `Reset failed again, re-cloning: ${error}`));
+    });
+    workspace.on("destroy", ({ dir }: { dir: string }) => {
+      this.display.print(c.sageGreen(this.config.verbose ? `Destroying ${dir}` : "Destroying workspace..."));
+    });
+    workspace.on("prune-start", ({ workspaceDir: dir }: { workspaceDir: string }) => {
+      this.display.print(c.sageGreen(this.config.verbose ? `Pruning orphaned workspaces in ${dir}` : "Pruning orphaned workspaces..."));
+    });
+    workspace.on("prune-remove", ({ dir }: { dir: string }) => {
+      this.display.print(c.darkGray(`  Removed: ${dir}`));
+    });
+  }
 
   /**
    * Register workspace commands into the given registry (which should already
@@ -91,44 +125,13 @@ export class WorkspaceController {
   }
 
   /**
-   * Subscribe to workspace events (for progress display) and create the
-   * workspace directory. Changes the process working directory to the workspace.
+   * Create the workspace directory and change into it.
+   * Event listeners for progress display are registered once in the constructor.
    * No-op if no workspace is configured.
    */
   async onCreate(): Promise<void> {
-    const { workspace, display } = this;
+    const { workspace } = this;
     if (!workspace) return;
-
-    const verbose = this.config.verbose;
-
-    workspace.on("create-start", () => {
-      if (!verbose) display.print(c.sageGreen("Creating workspace..."));
-    });
-    workspace.on("clone-start", ({ repoUrl: url, dir }: { repoUrl: string; dir: string }) => {
-      if (verbose) display.print(c.sageGreen(`Cloning ${url} → ${dir}`));
-    });
-    workspace.on("npm-install", ({ dir }: { dir: string }) => {
-      if (verbose) display.print(c.sageGreen(`Installing dependencies in ${dir}`));
-    });
-    workspace.on("reset-start", ({ dir }: { dir: string }) => {
-      display.print(c.sageGreen(verbose ? `Resetting ${dir}` : "Resetting workspace..."));
-    });
-    workspace.on("reset-retry", ({ error }: { dir: string; error: string }) => {
-      display.print(c.amber(`Reset failed, retrying: ${error}`));
-    });
-    workspace.on("reset-reclone", ({ dir, error }: { dir: string; error: string; repoUrl: string }) => {
-      display.print(c.amber(verbose ? `Reset failed again, re-cloning ${dir}: ${error}` : `Reset failed again, re-cloning: ${error}`));
-    });
-    workspace.on("destroy", ({ dir }: { dir: string }) => {
-      display.print(c.sageGreen(verbose ? `Destroying ${dir}` : "Destroying workspace..."));
-    });
-    workspace.on("prune-start", ({ workspaceDir: dir }: { workspaceDir: string }) => {
-      display.print(c.sageGreen(verbose ? `Pruning orphaned workspaces in ${dir}` : "Pruning orphaned workspaces..."));
-    });
-    workspace.on("prune-remove", ({ dir }: { dir: string }) => {
-      display.print(c.darkGray(`  Removed: ${dir}`));
-    });
-
     await workspace.create();
     process.chdir(workspace.dir);
   }

--- a/src/agent/models/workspace.ts
+++ b/src/agent/models/workspace.ts
@@ -63,7 +63,21 @@ export class Workspace extends EventEmitter {
       await this._npmInstall();
     }
     fs.writeFileSync(path.join(this.dir, ".brunel.lock"), String(process.pid));
+    // Keep .brunel.lock out of git status so it never triggers the data-loss
+    // warning in checkSafety() — even when the cloned repo's .gitignore omits it.
+    this._ensureLocallyIgnored(".brunel.lock");
     this.isCreated = true;
+  }
+
+  private _ensureLocallyIgnored(pattern: string): void {
+    const infoDir = path.join(this.dir, ".git", "info");
+    fs.mkdirSync(infoDir, { recursive: true });
+    const excludesPath = path.join(infoDir, "exclude");
+    const existing = fs.existsSync(excludesPath) ? fs.readFileSync(excludesPath, "utf8") : "";
+    const lines = existing.split("\n").map(l => l.trim());
+    if (lines.includes(pattern)) return;
+    const sep = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
+    fs.appendFileSync(excludesPath, sep + pattern + "\n");
   }
 
   /**

--- a/tests/repl.workspace.test.ts
+++ b/tests/repl.workspace.test.ts
@@ -238,6 +238,24 @@ describe("WorkspaceController.onCreate", () => {
   });
 });
 
+// ── onCreate: double-listener regression ─────────────────────────────────────
+
+describe("WorkspaceController double-start regression", () => {
+  it("prints 'Destroying workspace...' exactly once even when onCreate is called twice", async () => {
+    const ws = makeWorkspace();
+    ws.isCreated = true;
+    const controller = new WorkspaceController(ws, testDisplay, testConfig);
+    await controller.onCreate();
+    await controller.onCreate(); // simulate stop → /worker:start again
+    testDisplay.print.mockClear();
+    ws.emit("destroy", { dir: ws.dir });
+    const destroyMessages = testDisplay.print.mock.calls
+      .map(([l]: [string]) => stripAnsi(l))
+      .filter((m: string) => m.includes("Destroying workspace"));
+    expect(destroyMessages).toHaveLength(1);
+  });
+});
+
 // ── workspace:prune ───────────────────────────────────────────────────────────
 
 describe("workspace:prune", () => {

--- a/tests/workspace.test.ts
+++ b/tests/workspace.test.ts
@@ -302,6 +302,26 @@ describe("confirmIfUnsafe", () => {
   });
 });
 
+// ── create: git excludes ────────────────────────────────────────────────────
+
+describe("Workspace.create git excludes", () => {
+  it("adds .brunel.lock to .git/info/exclude so it never appears in git status", async () => {
+    const ws = await makeWorkspace();
+    const excludePath = path.join(ws.dir, ".git", "info", "exclude");
+    expect(fs.existsSync(excludePath)).toBe(true);
+    const lines = fs.readFileSync(excludePath, "utf8").split("\n").map(l => l.trim());
+    expect(lines).toContain(".brunel.lock");
+  });
+
+  it("does not duplicate .brunel.lock in .git/info/exclude when create is called again", async () => {
+    const ws = await makeWorkspace();
+    await ws.create(); // second call (simulate stop → start cycle)
+    const excludePath = path.join(ws.dir, ".git", "info", "exclude");
+    const lines = fs.readFileSync(excludePath, "utf8").split("\n").map(l => l.trim()).filter(Boolean);
+    expect(lines.filter(l => l === ".brunel.lock")).toHaveLength(1);
+  });
+});
+
 // ── prune ──────────────────────────────────────────────────────────────────
 
 function makeWorkspaceForPrune(workspaceDir: string): Workspace {


### PR DESCRIPTION
## Summary

- **Bug 1 (Repro A & B)**: `.brunel.lock` showed as `??` in `git status --porcelain` for repos that don't have it in their `.gitignore`, causing a spurious "Potential data loss" confirmation on clean exit. Fix: `Workspace.create()` now appends `.brunel.lock` to `.git/info/exclude` so it is always locally git-ignored, without touching any tracked file.

- **Bug 2 (Repro B)**: `WorkspaceController.onCreate()` called `workspace.on("destroy", ...)` each time it ran. Starting worker mode twice added a second listener, so "Destroying workspace..." printed twice on exit. Fix: event listener registration moved to the constructor, where it runs exactly once per `WorkspaceController` instance.

## Test plan

- [ ] `npm test` passes (all non-DB tests green)
- [ ] `npx tsc --noEmit` passes
- New test: `Workspace.create git excludes` — verifies `.brunel.lock` is written to `.git/info/exclude` and not duplicated on repeated `create()` calls
- New test: `WorkspaceController double-start regression` — verifies only one "Destroying workspace..." message when `onCreate()` is called twice

Closes #901

🤖 Generated with [Claude Code](https://claude.com/claude-code)