### PR TITLE
diagnostics: detect and surface agent loop stalls

### DIFF
--- a/src/agent/controllers/agent-controller.ts
+++ b/src/agent/controllers/agent-controller.ts
@@ -7,7 +7,7 @@ import { Picker, PickerCancelledError } from "../views/picker.js";
 import type { PickQuestionResult } from "../views/picker.js";
 import { Settings } from "../models/settings.js";
 import type { ModelInfo } from "../models/settings.js";
-import { QueryStats } from "../models/query-stats.js";
+import { QueryStats, STALL_THRESHOLD_SECS } from "../models/query-stats.js";
 
 // ── Log file ──────────────────────────────────────────────────────────────────
 
@@ -144,8 +144,23 @@ export class AgentController {
     let capturedSessionId = sessionId;
     let resultReceived = false;
 
+    // Log a single warning when no SDK message has arrived for STALL_THRESHOLD_SECS.
+    // This fires via a watchdog so it captures hangs inside the for-await wait itself.
+    let stallLogged = false;
+    const stallWatcher = setInterval(() => {
+      if (!stallLogged && stats.secsSinceLastActivity >= STALL_THRESHOLD_SECS) {
+        stallLogged = true;
+        logFull("STALL_DETECTED", {
+          secsSinceLastActivity: stats.secsSinceLastActivity,
+          totalElapsedSecs: stats.elapsedSecs,
+        });
+      }
+    }, 10_000);
+
     try {
       for await (const message of iterable) {
+        stats.noteActivity();
+
         if (!(message.type === "stream_event" && (message.event as { type?: string }).type === "content_block_delta")) {
           logFull("MESSAGE", message);
         }
@@ -172,6 +187,7 @@ export class AgentController {
     } catch (err) {
       if (!(err instanceof Error && /aborted by user/i.test(err.message))) throw err;
     } finally {
+      clearInterval(stallWatcher);
       process.stdin.removeListener("data", onInterrupt);
       this.currentAbortController = null;
     }

--- a/src/agent/models/query-stats.ts
+++ b/src/agent/models/query-stats.ts
@@ -1,5 +1,10 @@
 import { EventEmitter } from "node:events";
 
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/** Seconds of SDK silence before the status bar shows a stall warning and the watchdog logs it. */
+export const STALL_THRESHOLD_SECS = 120;
+
 // ── Working verbs ─────────────────────────────────────────────────────────────
 
 const WORKING_VERBS = [
@@ -88,10 +93,12 @@ export class QueryStats extends EventEmitter {
   private _costUsd: number | undefined;
   private readonly _startTime: number;
   private readonly _workingVerb: string;
+  private _lastActivityTime: number;
 
   constructor(startTime = Date.now()) {
     super();
     this._startTime = startTime;
+    this._lastActivityTime = startTime;
     this._workingVerb = pickWorkingVerb();
   }
 
@@ -100,6 +107,12 @@ export class QueryStats extends EventEmitter {
   get outputTokens(): number { return this._completedOutputTokens + this._currentOutputTokens; }
   get costUsd(): number | undefined { return this._costUsd; }
   get elapsedSecs(): number { return Math.floor((Date.now() - this._startTime) / 1000); }
+  get secsSinceLastActivity(): number { return Math.floor((Date.now() - this._lastActivityTime) / 1000); }
+
+  /** Record that an SDK message was received; resets the stall timer. */
+  noteActivity(): void {
+    this._lastActivityTime = Date.now();
+  }
 
   /**
    * Process a single top-level stream event. Emits "change" for stat-bearing
@@ -126,6 +139,10 @@ export class QueryStats extends EventEmitter {
   getStatusText(): string {
     const secs = this.elapsedSecs;
     const outTokens = this.outputTokens;
-    return `${this._workingVerb}… ${fmtStats(secs, this._turns || undefined, outTokens || undefined, this._inputTokens || undefined, this._costUsd)}`;
+    const stalled = this.secsSinceLastActivity;
+    const stallSuffix = stalled >= STALL_THRESHOLD_SECS
+      ? ` ⚠ no activity ${fmtDuration(stalled)}`
+      : "";
+    return `${this._workingVerb}… ${fmtStats(secs, this._turns || undefined, outTokens || undefined, this._inputTokens || undefined, this._costUsd)}${stallSuffix}`;
   }
 }

--- a/tests/repl.query-stats.test.ts
+++ b/tests/repl.query-stats.test.ts
@@ -257,6 +257,52 @@ describe("QueryStats - cost from result message", () => {
   });
 });
 
+describe("QueryStats - activity tracking", () => {
+  it("secsSinceLastActivity is 0 at construction", () => {
+    vi.useFakeTimers();
+    const stats = new QueryStats(Date.now());
+    expect(stats.secsSinceLastActivity).toBe(0);
+  });
+
+  it("secsSinceLastActivity increases as time passes with no activity", () => {
+    vi.useFakeTimers();
+    const stats = new QueryStats(Date.now());
+    vi.advanceTimersByTime(90_000);
+    expect(stats.secsSinceLastActivity).toBe(90);
+  });
+
+  it("noteActivity resets secsSinceLastActivity to 0", () => {
+    vi.useFakeTimers();
+    const stats = new QueryStats(Date.now());
+    vi.advanceTimersByTime(90_000);
+    stats.noteActivity();
+    expect(stats.secsSinceLastActivity).toBe(0);
+  });
+
+  it("getStatusText does not show stall warning below threshold (119s)", () => {
+    vi.useFakeTimers();
+    const stats = new QueryStats(Date.now());
+    vi.advanceTimersByTime(119_000);
+    expect(stripAnsi(stats.getStatusText())).not.toContain("no activity");
+  });
+
+  it("getStatusText shows stall warning at threshold (120s)", () => {
+    vi.useFakeTimers();
+    const stats = new QueryStats(Date.now());
+    vi.advanceTimersByTime(120_000);
+    expect(stripAnsi(stats.getStatusText())).toContain("no activity");
+  });
+
+  it("getStatusText clears stall warning after noteActivity", () => {
+    vi.useFakeTimers();
+    const stats = new QueryStats(Date.now());
+    vi.advanceTimersByTime(130_000); // stalled
+    stats.noteActivity(); // reset
+    vi.advanceTimersByTime(30_000); // only 30s since last activity
+    expect(stripAnsi(stats.getStatusText())).not.toContain("no activity");
+  });
+});
+
 describe("QueryStats - integration with cost", () => {
   afterEach(() => {
     vi.useRealTimers();

--- a/tests/repl.query.test.ts
+++ b/tests/repl.query.test.ts
@@ -22,6 +22,7 @@ import { Input } from "../src/agent/views/input.js";
 import { Picker } from "../src/agent/views/picker.js";
 import { Display } from "../src/agent/views/display.js";
 import { AgentStatus } from "../src/agent/models/agent-status.js";
+import type { QueryStats } from "../src/agent/models/query-stats.js";
 
 let testDisplay: Display;
 let testSettings: Settings;
@@ -755,5 +756,87 @@ describe("runQuery - prompt redraw after query (worker mode integration)", () =>
       Object.defineProperty(process, "stdin", { value: origStdin, configurable: true });
       vi.restoreAllMocks();
     }
+  });
+});
+
+describe("runQuery - stall detection", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("secsSinceLastActivity is 0 after normal query (noteActivity called on each message)", async () => {
+    vi.useFakeTimers();
+    mockQueryMessages([
+      { type: "system", subtype: "init", session_id: "s1" },
+      { type: "result", duration_ms: 100, num_turns: 1, usage: { input_tokens: 5, output_tokens: 5 } },
+    ]);
+    const cap = captureConsole();
+    let returnedStats: QueryStats;
+    try {
+      ({ stats: returnedStats } = await testController.runQuery("test", undefined));
+    } finally {
+      cap.restore();
+    }
+    expect(returnedStats.secsSinceLastActivity).toBe(0);
+  });
+
+  it("stall watchdog logs STALL_DETECTED after 120s without any SDK messages", async () => {
+    vi.useFakeTimers();
+    const { default: fs } = await import("fs");
+
+    (query as any).mockImplementation((opts: any) => {
+      return (async function* () {
+        await new Promise<void>((resolve) => {
+          opts.options.abortController.signal.addEventListener("abort", resolve, { once: true });
+        });
+      })();
+    });
+
+    const ac = new AbortController();
+    const cap = captureConsole();
+    const queryPromise = testController.runQuery("test", undefined, ac);
+
+    // Advance past stall threshold (120s) plus watchdog check interval (10s)
+    await vi.advanceTimersByTimeAsync(130_000);
+
+    const stallCalls = (fs.appendFileSync as any).mock.calls.filter(
+      (call: any[]) => String(call[1]).includes("STALL_DETECTED")
+    );
+    expect(stallCalls.length).toBeGreaterThan(0);
+
+    // Clean up
+    ac.abort();
+    try { await queryPromise; } catch { /* aborted */ }
+    cap.restore();
+  });
+
+  it("stall watchdog does NOT log before threshold (90s)", async () => {
+    vi.useFakeTimers();
+    const { default: fs } = await import("fs");
+
+    (query as any).mockImplementation((opts: any) => {
+      return (async function* () {
+        await new Promise<void>((resolve) => {
+          opts.options.abortController.signal.addEventListener("abort", resolve, { once: true });
+        });
+      })();
+    });
+
+    const ac = new AbortController();
+    const cap = captureConsole();
+    const queryPromise = testController.runQuery("test", undefined, ac);
+
+    // Advance to just under threshold
+    await vi.advanceTimersByTimeAsync(90_000);
+
+    const stallCalls = (fs.appendFileSync as any).mock.calls.filter(
+      (call: any[]) => String(call[1]).includes("STALL_DETECTED")
+    );
+    expect(stallCalls.length).toBe(0);
+
+    // Clean up
+    ac.abort();
+    try { await queryPromise; } catch { /* aborted */ }
+    cap.restore();
   });
 });


### PR DESCRIPTION
## Summary

- **Root cause hypothesis**: The `for await` loop in `AgentController.runQuery()` can hang indefinitely if the Claude SDK's async iterator stops yielding (network zombie connection, API mid-stream stall). The status bar keeps updating elapsed time, so the hang looks like normal activity from the TUI.
- **Two diagnostics added**:
  1. **Visible stall warning in TUI** — `QueryStats` now tracks when each SDK message arrives (`noteActivity()`). If no message has been received for 120 s, `getStatusText()` appends `⚠ no activity Xm` to the status bar, making the stall visible without any user action.
  2. **Log entry in `repl.log`** — A watchdog `setInterval` in `runQuery()` writes a `STALL_DETECTED` entry (seconds since last activity + total elapsed) to `repl.log` the first time the threshold is crossed, providing a post-mortem breadcrumb if the user doesn't notice the TUI warning.

## What to look for in the next occurrence

If a worker hangs again:
- The status bar should show `⚠ no activity Xm` — if it does, the hang is confirmed to be in the SDK iterator (our hypothesis).
- `repl.log` will contain a `STALL_DETECTED` entry with timing details.
- If neither appears, the stall is elsewhere (e.g., picker awaiting user input) and we'll need more targeted investigation.

## Test plan

- [x] `QueryStats` unit tests: `noteActivity`, `secsSinceLastActivity`, stall warning in `getStatusText` at/below threshold, clears after `noteActivity`
- [x] `runQuery` integration tests: `secsSinceLastActivity` is 0 after normal query (confirming `noteActivity` is called); watchdog logs `STALL_DETECTED` after 120 s; watchdog does NOT log at 90 s
- [x] All 1567 non-DB tests pass; type check clean

Closes #908

🤖 Generated with [Claude Code](https://claude.com/claude-code)