### PR TITLE
fix: print 'Waiting for tasks...' in all idle worker paths

### DIFF
--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -677,7 +677,10 @@ export class WorkerController extends EventEmitter {
             this.display.print(c.boldRed(`Workspace reset failed: ${err instanceof Error ? err.message : String(err)}`));
           }).finally(() => {
             this._resetPromise = null;
+            this.display.print(c.sageGreen("Waiting for tasks..."));
           });
+        } else {
+          this.display.print(c.sageGreen("Waiting for tasks..."));
         }
       } else if (msg.repoStatus === "new") {
         // Show "Connected" in the status bar before waiting for user input — the
@@ -701,6 +704,9 @@ export class WorkerController extends EventEmitter {
       } else {
         // "idle" or "busy" with repoStatus 'active' (or no repoStatus for back-compat).
         this.transitionToRegistered();
+        if (msg.status === "idle") {
+          this.display.print(c.sageGreen("Waiting for tasks..."));
+        }
       }
       return;
     }

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -986,6 +986,102 @@ describe("hello_ack handshake — buffering", () => {
       expect.objectContaining({ type: "hello_ack", workerId: AGENT_ID, status: "idle" })
     );
   });
+
+  it("prints 'Waiting for tasks...' on hello_ack idle", () => {
+    display.print.mockClear();
+    sendMsg(fakeWs, { type: "hello_ack", workerId: AGENT_ID, status: "idle" });
+    const printed = display.print.mock.calls.map(args => stripAnsi(String(args[0]))).join("\n");
+    expect(printed).toContain("Waiting for tasks");
+  });
+
+  it("does not print 'Waiting for tasks...' on hello_ack busy (resuming task)", async () => {
+    const issue = makeIssue();
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
+    session.takeNextPrompt();
+
+    display.print.mockClear();
+    sendMsg(fakeWs, { type: "hello_ack", workerId: AGENT_ID, status: "busy" });
+    const printed = display.print.mock.calls.map(args => stripAnsi(String(args[0]))).join("\n");
+    expect(printed).not.toContain("Waiting for tasks");
+  });
+
+  it("prints 'Waiting for tasks...' on hello_ack cancelled (no workspace)", async () => {
+    vi.useFakeTimers();
+    try {
+      const issue = makeIssue();
+      sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
+      session.takeNextPrompt();
+
+      const newWs = reconnectWithNewWs();
+      newWs.emit("open");
+
+      display.print.mockClear();
+      sendMsg(newWs, { type: "hello_ack", workerId: AGENT_ID, status: "cancelled" });
+
+      const printed = display.print.mock.calls.map(args => stripAnsi(String(args[0]))).join("\n");
+      expect(printed).toContain("Waiting for tasks");
+    } finally {
+      vi.restoreAllMocks();
+      vi.useRealTimers();
+    }
+  });
+
+  it("prints 'Waiting for tasks...' after workspace reset on hello_ack cancelled", async () => {
+    vi.useFakeTimers();
+    const chdirSpy = vi.spyOn(process, "chdir").mockImplementation(() => {});
+    try {
+      let resolveReset!: () => void;
+      const resetPromise = new Promise<void>((resolve) => { resolveReset = resolve; });
+      const workspace = {
+        dir: "/tmp/test-workspace",
+        workspaceDir: "/tmp/workers",
+        sessionId: "test-agent",
+        originalCwd: "/original",
+        isCreated: true,
+        on: vi.fn(),
+        create: vi.fn().mockResolvedValue(undefined),
+        confirm: vi.fn(),
+        reset: vi.fn().mockReturnValue(resetPromise),
+        destroy: vi.fn().mockResolvedValue(undefined),
+        checkSafety: vi.fn().mockResolvedValue({ uncommittedFiles: [], unpushedCommits: [], noUpstream: false }),
+      } as unknown as import("../src/agent/models/workspace.js").Workspace;
+
+      const wsA = new FakeWs();
+      const wsB = new FakeWs();
+      let callCount = 0;
+      const wsFactoryWs = vi.fn().mockImplementation(() => callCount++ === 0 ? wsA : wsB);
+
+      const wc = new WorkspaceController(workspace, display, { verbose: false });
+      const sessionWithWs = new WorkerController(sb, display, undefined, wc, "", { wsFactory: wsFactoryWs });
+      await sessionWithWs.start();
+
+      const issue = makeIssue();
+      sendMsg(wsA, { type: "task_assigned", taskId: "42", issue });
+      sessionWithWs.takeNextPrompt();
+
+      vi.spyOn(Math, "random").mockReturnValue(0);
+      wsA.emit("close", 1006, Buffer.from(""));
+      vi.advanceTimersByTime(2001);
+      wsB.emit("open");
+
+      display.print.mockClear();
+      sendMsg(wsB, { type: "hello_ack", workerId: AGENT_ID, status: "cancelled" });
+
+      // "Waiting for tasks..." should NOT appear before reset completes
+      let printed = display.print.mock.calls.map(args => stripAnsi(String(args[0]))).join("\n");
+      expect(printed).not.toContain("Waiting for tasks");
+
+      // After reset completes, "Waiting for tasks..." should appear
+      resolveReset();
+      await vi.waitFor(() => {
+        printed = display.print.mock.calls.map(args => stripAnsi(String(args[0]))).join("\n");
+        expect(printed).toContain("Waiting for tasks");
+      });
+    } finally {
+      vi.restoreAllMocks();
+      vi.useRealTimers();
+    }
+  });
 });
 
 // ── log_only filtering ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- When the worker connects (or reconnects) and receives `hello_ack { status: "idle" }`, it now prints `Waiting for tasks...`
- When the worker receives `hello_ack { status: "cancelled" }` with no workspace to reset, it now prints `Waiting for tasks...` immediately after the cancellation message
- When the worker receives `hello_ack { status: "cancelled" }` and a workspace reset runs, it now prints `Waiting for tasks...` after the reset completes (in the `.finally()` handler)

The `hello_ack { status: "busy" }` path (resuming an existing task on reconnect) is correctly left alone — no message needed there.

## Test plan

- [x] New test: `hello_ack idle` → prints "Waiting for tasks..."
- [x] New test: `hello_ack busy` → does NOT print "Waiting for tasks..."
- [x] New test: `hello_ack cancelled` (no workspace) → prints "Waiting for tasks..."
- [x] New test: `hello_ack cancelled` (with workspace) → prints "Waiting for tasks..." after reset resolves, not before
- [x] All existing tests pass

Closes #898

🤖 Generated with [Claude Code](https://claude.com/claude-code)