### PR TITLE
fix: atomically complete task in worker_goodbye to prevent orphaned tasks

### DIFF
--- a/shared/wire.ts
+++ b/shared/wire.ts
@@ -97,7 +97,7 @@ export interface TaskIssue {
 export type WorkerMessage =
   | { type: "worker_hello"; workerId: string; repo: string; taskId?: string; claimTaskId?: string; status: "idle" | "busy"; workerSecret?: string }
   | { type: "task_complete"; workerId: string; taskId: string; stats?: { inputTokens: number; outputTokens: number; costUsd?: number } }
-  | { type: "worker_goodbye"; workerId: string; taskId?: string }
+  | { type: "worker_goodbye"; workerId: string; taskId?: string; task_complete?: boolean; stats?: { inputTokens: number; outputTokens: number; costUsd?: number } }
   | { type: "activate_repo"; workerId: string }
   | { type: "claim_task"; workerId: string; taskId: string };
 

--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -241,14 +241,33 @@ export class WorkerController extends EventEmitter {
    * Called before clean exits (SIGTERM, /quit) so the foreman can immediately
    * revert the task to pending without waiting for the reclaim timeout.
    */
-  sendGoodbye(): void {
+  sendGoodbye(opts?: { task_complete?: boolean; stats?: { inputTokens: number; outputTokens: number; costUsd?: number } }): void {
     if (this.ws?.readyState === WebSocket.OPEN) {
-      this.ws.send(JSON.stringify({
+      const msg: Record<string, unknown> = {
         type: "worker_goodbye",
         workerId: this.agentStatus.agentId,
         taskId: this.currentTaskId,
-      }));
+      };
+      if (opts?.task_complete) msg.task_complete = true;
+      if (opts?.stats) msg.stats = opts.stats;
+      this.ws.send(JSON.stringify(msg));
     }
+  }
+
+  private async buildCompleteGoodbyeOpts(): Promise<{ task_complete: true; stats?: { inputTokens: number; outputTokens: number; costUsd?: number } }> {
+    if (this._activeAfterTask) {
+      try { await this._activeAfterTask(); } catch (err) {
+        this.display.print(c.amber(`afterTask failed: ${fmtError(err)}`));
+      }
+    }
+    const { taskInputTokens, taskOutputTokens, taskCostUsd } = this.agentStatus;
+    const hasStats = taskInputTokens > 0 || taskOutputTokens > 0 || taskCostUsd != null;
+    const statsStr = fmtTaskStats(taskInputTokens, taskOutputTokens, taskCostUsd);
+    this.display.print(c.sageGreen(`Task #${this.currentIssue?.number} complete, ${statsStr}`));
+    return {
+      task_complete: true,
+      ...(hasStats && { stats: { inputTokens: taskInputTokens, outputTokens: taskOutputTokens, costUsd: taskCostUsd } }),
+    };
   }
 
   /**
@@ -363,13 +382,14 @@ export class WorkerController extends EventEmitter {
   async stop(): Promise<void> {
     if (!this._isActive) return;
     const taskInfo = this.getTaskQuitInfo();
+    let goodbyeOpts: { task_complete?: boolean; stats?: { inputTokens: number; outputTokens: number; costUsd?: number } } | undefined;
     if (taskInfo) {
       const choice = await this.confirmTaskQuit(taskInfo);
       if (choice === "cancel") return;
-      if (choice === "complete-and-quit") await this.completeCurrentTask();
+      if (choice === "complete-and-quit") goodbyeOpts = await this.buildCompleteGoodbyeOpts();
     }
     this._stopped = true;
-    this.sendGoodbye();
+    this.sendGoodbye(goodbyeOpts);
     this.ws?.close();
     if (this.debounceTimer) {
       clearTimeout(this.debounceTimer);

--- a/src/foreman/controllers/wss.ts
+++ b/src/foreman/controllers/wss.ts
@@ -367,14 +367,21 @@ export class ForemanWss {
   }
 
   async handleWorkerGoodbye(workerId: string, msg: Extract<Wire.WorkerMessage, { type: "worker_goodbye" }>): Promise<void> {
-    this.workerLog(workerId, `worker_goodbye (task=${msg.taskId ?? "none"})`);
+    this.workerLog(workerId, `worker_goodbye (task=${msg.taskId ?? "none"}, complete=${msg.task_complete ?? false})`);
     if (msg.taskId) {
       const task = await Task.get(msg.taskId);
       if (task) {
-        this.workerLog(workerId, `reverting task #${task.issueNumber} to pending (worker_goodbye)`);
-        await task.revert().catch((err: unknown) =>
-          log(`ERROR Failed to revert task #${msg.taskId} to pending: ${fmtError(err)}`)
-        );
+        if (msg.task_complete) {
+          this.workerLog(workerId, `completing task #${task.issueNumber} via worker_goodbye`);
+          await task.complete(msg.stats).catch((err: unknown) =>
+            log(`ERROR Failed to complete task #${msg.taskId}: ${fmtError(err)}`)
+          );
+        } else {
+          this.workerLog(workerId, `reverting task #${task.issueNumber} to pending (worker_goodbye)`);
+          await task.revert().catch((err: unknown) =>
+            log(`ERROR Failed to revert task #${msg.taskId} to pending: ${fmtError(err)}`)
+          );
+        }
       }
     }
     Worker.fromRegistry(workerId)?.remove();

--- a/tests/foreman.websocket.test.ts
+++ b/tests/foreman.websocket.test.ts
@@ -1008,6 +1008,77 @@ describe("worker_goodbye — revert persistence", () => {
   });
 });
 
+describe("worker_goodbye with task_complete: true", () => {
+  it("marks the task complete instead of reverting it to pending", async () => {
+    await makeTask(taskManager, 1);
+    const ws = await connect();
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    await nextMsg(ws); // task_assigned
+
+    send(ws, { type: "worker_goodbye", workerId: "w1", taskId: "1", task_complete: true });
+    await waitUntil(() => !Worker.fromRegistry("w1"));
+
+    expect(Worker.fromRegistry("w1")).toBeUndefined();
+    expect((await Task.get("1"))?.status).toBe("complete");
+  });
+
+  it("persists stats when task_complete: true with stats provided", async () => {
+    await makeTask(taskManager, 1);
+    const ws = await connect();
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    await nextMsg(ws); // task_assigned
+
+    send(ws, { type: "worker_goodbye", workerId: "w1", taskId: "1", task_complete: true, stats: { inputTokens: 100, outputTokens: 50, costUsd: 0.01 } });
+    await waitUntil(() => !Worker.fromRegistry("w1"));
+
+    const task = await Task.get("1");
+    expect(task?.status).toBe("complete");
+    expect(task?.inputTokens).toBe(100);
+    expect(task?.outputTokens).toBe(50);
+    expect(task?.costUsd).toBe(0.01);
+  });
+
+  it("does not assign a new task to the completing worker (never enters idle pool)", async () => {
+    await makeTask(taskManager, 1001);
+    await new Promise(r => setTimeout(r, 10));
+    await makeTask(taskManager, 1002);
+
+    const ws = await connect();
+    const q = makeQueue(ws);
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    await q.next(); // hello_ack
+    await q.next(); // task_assigned (task 1002, most recent)
+
+    send(ws, { type: "worker_goodbye", workerId: "w1", taskId: "1002", task_complete: true });
+    // Give assignWork() time to run — worker should NOT get a second task_assigned
+    const raceResult = await Promise.race([
+      q.next().then(() => "message" as const),
+      new Promise<"timeout">((r) => setTimeout(() => r("timeout"), 100)),
+    ]);
+    expect(raceResult).toBe("timeout");
+    expect(Worker.fromRegistry("w1")).toBeUndefined();
+  });
+
+  it("calls task.complete when goodbye carries task_complete: true", async () => {
+    await makeTask(taskManager, 1);
+    const t = await Task.get("1");
+    const spyComplete = vi.spyOn(t!, "complete");
+    vi.spyOn(Task, "get").mockImplementation(async (id) => {
+      if (id === "1") return t!;
+      return null;
+    });
+
+    const ws = await connect();
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    await waitUntil(() => Worker.fromRegistry("w1")?.status === "busy");
+
+    send(ws, { type: "worker_goodbye", workerId: "w1", taskId: "1", task_complete: true });
+    await waitUntil(() => Worker.fromRegistry("w1") === undefined);
+
+    expect(spyComplete).toHaveBeenCalled();
+  });
+});
+
 describe("issues/closed — close persistence", () => {
   it("calls task.close when an issue is closed while a worker is active", async () => {
     await Task.upsert("1", 1, "test/repo", "T", "b", []);

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1600,6 +1600,84 @@ describe("sendGoodbye", () => {
     session.sendGoodbye();
     expect(fakeWs.send).not.toHaveBeenCalled();
   });
+
+  it("includes task_complete: true when opts.task_complete is true", async () => {
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue: makeIssue() });
+    session.takeNextPrompt();
+    fakeWs.send.mockClear();
+    session.sendGoodbye({ task_complete: true });
+    const sent = JSON.parse(fakeWs.send.mock.calls[0][0]);
+    expect(sent.task_complete).toBe(true);
+    expect(sent.taskId).toBe("42");
+  });
+
+  it("includes stats in goodbye when provided", async () => {
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue: makeIssue() });
+    session.takeNextPrompt();
+    fakeWs.send.mockClear();
+    session.sendGoodbye({ task_complete: true, stats: { inputTokens: 100, outputTokens: 50, costUsd: 0.01 } });
+    const sent = JSON.parse(fakeWs.send.mock.calls[0][0]);
+    expect(sent.stats).toEqual({ inputTokens: 100, outputTokens: 50, costUsd: 0.01 });
+  });
+
+  it("omits task_complete and stats when opts not provided", async () => {
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue: makeIssue() });
+    session.takeNextPrompt();
+    fakeWs.send.mockClear();
+    session.sendGoodbye();
+    const sent = JSON.parse(fakeWs.send.mock.calls[0][0]);
+    expect(sent.task_complete).toBeUndefined();
+    expect(sent.stats).toBeUndefined();
+  });
+});
+
+// ── stop — complete-and-quit ──────────────────────────────────────────────────
+
+describe("stop — complete-and-quit", () => {
+  it("sends worker_goodbye with task_complete: true instead of a separate task_complete message", async () => {
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue: makeIssue() });
+    session.takeNextPrompt();
+    vi.spyOn(session, "confirmTaskQuit").mockResolvedValue("complete-and-quit");
+
+    fakeWs.send.mockClear();
+    await session.stop();
+
+    const msgs = fakeWs.send.mock.calls.map(([d]: [string]) => JSON.parse(d));
+    const goodbye = msgs.find((m: { type: string }) => m.type === "worker_goodbye");
+    const taskComplete = msgs.find((m: { type: string }) => m.type === "task_complete");
+
+    expect(goodbye).toBeDefined();
+    expect(goodbye.task_complete).toBe(true);
+    expect(goodbye.taskId).toBe("42");
+    expect(taskComplete).toBeUndefined();
+  });
+
+  it("includes token stats in the goodbye when tokens were used", async () => {
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue: makeIssue() });
+    session.takeNextPrompt();
+    sb.addQueryStats(1000, 500, 0.05);
+    vi.spyOn(session, "confirmTaskQuit").mockResolvedValue("complete-and-quit");
+
+    fakeWs.send.mockClear();
+    await session.stop();
+
+    const msgs = fakeWs.send.mock.calls.map(([d]: [string]) => JSON.parse(d));
+    const goodbye = msgs.find((m: { type: string }) => m.type === "worker_goodbye");
+    expect(goodbye.stats).toEqual({ inputTokens: 1000, outputTokens: 500, costUsd: 0.05 });
+  });
+
+  it("omits stats from goodbye when no tokens were used", async () => {
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue: makeIssue() });
+    session.takeNextPrompt();
+    vi.spyOn(session, "confirmTaskQuit").mockResolvedValue("complete-and-quit");
+
+    fakeWs.send.mockClear();
+    await session.stop();
+
+    const msgs = fakeWs.send.mock.calls.map(([d]: [string]) => JSON.parse(d));
+    const goodbye = msgs.find((m: { type: string }) => m.type === "worker_goodbye");
+    expect(goodbye.stats).toBeUndefined();
+  });
 });
 
 // ── Heartbeat / ping-pong ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Extends `worker_goodbye` wire type with `task_complete?: boolean` and `stats?` fields
- Foreman `handleWorkerGoodbye` now completes the task (with optional stats) when `task_complete: true`, rather than reverting it to pending — and never releases the worker to idle
- Worker `stop()` complete-and-quit path now sends a single `worker_goodbye` with `task_complete: true` instead of separate `task_complete` + `worker_goodbye` messages

This closes the race window where `assignWork()` could assign a new task to the exiting worker between the two messages, leaving that task orphaned.

## Test plan

- [x] New foreman tests: goodbye with `task_complete: true` marks task complete, persists stats, removes worker from registry, never assigns a second task to the exiting worker
- [x] New worker tests: `stop()` complete-and-quit sends goodbye with `task_complete: true` (not a separate `task_complete`), includes/omits stats correctly; `sendGoodbye()` opts respected
- [x] All existing tests still pass (1577 tests)
- [x] Type check clean (`npx tsc --noEmit`)

Closes #912

🤖 Generated with [Claude Code](https://claude.com/claude-code)