### PR TITLE
fix: workspace git exclude and event listener deduplication

### DIFF
--- a/docs/superpowers/plans/2026-04-28-worker-state-model.md
+++ b/docs/superpowers/plans/2026-04-28-worker-state-model.md
@@ -55,7 +55,7 @@ Supersedes PR #906 and closes issue #901. Also fixes the re-clone path gap ident
 - Test: `tests/workspace.test.ts`
 - Test: `tests/repl.workspace.test.ts`
 
-- [ ] **Step 1: Write failing tests**
+- [x] **Step 1: Write failing tests**
 
 Add to `tests/workspace.test.ts`, after the existing `// ── create ──` describe block:
 
@@ -128,7 +128,7 @@ describe("WorkspaceController constructor listeners", () => {
 });
 ```
 
-- [ ] **Step 2: Run tests — expect them to fail**
+- [x] **Step 2: Run tests — expect them to fail**
 
 ```bash
 npm test -- workspace
@@ -136,7 +136,7 @@ npm test -- workspace
 
 Expected: FAIL — `_ensureLocallyIgnored` does not exist yet; double-listener test fails because two "Destroying workspace..." messages are printed.
 
-- [ ] **Step 3: Add `_ensureLocallyIgnored` to `workspace.ts`**
+- [x] **Step 3: Add `_ensureLocallyIgnored` to `workspace.ts`**
 
 In `src/agent/models/workspace.ts`, add this method after `_npmInstall()`:
 
@@ -174,7 +174,7 @@ this._ensureLocallyIgnored(".brunel.lock");
 await this._doReset();
 ```
 
-- [ ] **Step 4: Move event listeners to constructor in `workspace-controller.ts`**
+- [x] **Step 4: Move event listeners to constructor in `workspace-controller.ts`**
 
 Replace the entire constructor and `onCreate()` in `src/agent/controllers/workspace-controller.ts`:
 
@@ -229,7 +229,7 @@ async onCreate(): Promise<void> {
 
 Delete the old block of `workspace.on(…)` calls that were inside the old `onCreate()`.
 
-- [ ] **Step 5: Run tests — expect them to pass**
+- [x] **Step 5: Run tests — expect them to pass**
 
 ```bash
 npm test -- workspace
@@ -238,7 +238,7 @@ npx tsc --noEmit
 
 Expected: all workspace tests pass, no type errors.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add src/agent/models/workspace.ts src/agent/controllers/workspace-controller.ts tests/workspace.test.ts tests/repl.workspace.test.ts

--- a/src/agent/controllers/workspace-controller.ts
+++ b/src/agent/controllers/workspace-controller.ts
@@ -18,7 +18,37 @@ export class WorkspaceController {
     readonly workspace: Workspace | undefined,
     private display: WorkerDisplay,
     private config: { verbose: boolean },
-  ) {}
+  ) {
+    if (!workspace) return;
+    const { verbose } = config;
+    workspace.on("create-start", () => {
+      if (!verbose) display.print(c.sageGreen("Creating workspace..."));
+    });
+    workspace.on("clone-start", ({ repoUrl: url, dir }: { repoUrl: string; dir: string }) => {
+      if (verbose) display.print(c.sageGreen(`Cloning ${url} → ${dir}`));
+    });
+    workspace.on("npm-install", ({ dir }: { dir: string }) => {
+      if (verbose) display.print(c.sageGreen(`Installing dependencies in ${dir}`));
+    });
+    workspace.on("reset-start", ({ dir }: { dir: string }) => {
+      display.print(c.sageGreen(verbose ? `Resetting ${dir}` : "Resetting workspace..."));
+    });
+    workspace.on("reset-retry", ({ error }: { dir: string; error: string }) => {
+      display.print(c.amber(`Reset failed, retrying: ${error}`));
+    });
+    workspace.on("reset-reclone", ({ dir, error }: { dir: string; error: string; repoUrl: string }) => {
+      display.print(c.amber(verbose ? `Reset failed again, re-cloning ${dir}: ${error}` : `Reset failed again, re-cloning: ${error}`));
+    });
+    workspace.on("destroy", ({ dir }: { dir: string }) => {
+      display.print(c.sageGreen(verbose ? `Destroying ${dir}` : "Destroying workspace..."));
+    });
+    workspace.on("prune-start", ({ workspaceDir: dir }: { workspaceDir: string }) => {
+      display.print(c.sageGreen(verbose ? `Pruning orphaned workspaces in ${dir}` : "Pruning orphaned workspaces..."));
+    });
+    workspace.on("prune-remove", ({ dir }: { dir: string }) => {
+      display.print(c.darkGray(`  Removed: ${dir}`));
+    });
+  }
 
   /**
    * Register workspace commands into the given registry (which should already
@@ -91,46 +121,14 @@ export class WorkspaceController {
   }
 
   /**
-   * Subscribe to workspace events (for progress display) and create the
-   * workspace directory. Changes the process working directory to the workspace.
+   * Create the workspace directory and change into it.
+   * Event listeners are registered once in the constructor.
    * No-op if no workspace is configured.
    */
   async onCreate(): Promise<void> {
-    const { workspace, display } = this;
-    if (!workspace) return;
-
-    const verbose = this.config.verbose;
-
-    workspace.on("create-start", () => {
-      if (!verbose) display.print(c.sageGreen("Creating workspace..."));
-    });
-    workspace.on("clone-start", ({ repoUrl: url, dir }: { repoUrl: string; dir: string }) => {
-      if (verbose) display.print(c.sageGreen(`Cloning ${url} → ${dir}`));
-    });
-    workspace.on("npm-install", ({ dir }: { dir: string }) => {
-      if (verbose) display.print(c.sageGreen(`Installing dependencies in ${dir}`));
-    });
-    workspace.on("reset-start", ({ dir }: { dir: string }) => {
-      display.print(c.sageGreen(verbose ? `Resetting ${dir}` : "Resetting workspace..."));
-    });
-    workspace.on("reset-retry", ({ error }: { dir: string; error: string }) => {
-      display.print(c.amber(`Reset failed, retrying: ${error}`));
-    });
-    workspace.on("reset-reclone", ({ dir, error }: { dir: string; error: string; repoUrl: string }) => {
-      display.print(c.amber(verbose ? `Reset failed again, re-cloning ${dir}: ${error}` : `Reset failed again, re-cloning: ${error}`));
-    });
-    workspace.on("destroy", ({ dir }: { dir: string }) => {
-      display.print(c.sageGreen(verbose ? `Destroying ${dir}` : "Destroying workspace..."));
-    });
-    workspace.on("prune-start", ({ workspaceDir: dir }: { workspaceDir: string }) => {
-      display.print(c.sageGreen(verbose ? `Pruning orphaned workspaces in ${dir}` : "Pruning orphaned workspaces..."));
-    });
-    workspace.on("prune-remove", ({ dir }: { dir: string }) => {
-      display.print(c.darkGray(`  Removed: ${dir}`));
-    });
-
-    await workspace.create();
-    process.chdir(workspace.dir);
+    if (!this.workspace) return;
+    await this.workspace.create();
+    process.chdir(this.workspace.dir);
   }
 
   /**

--- a/src/agent/models/workspace.ts
+++ b/src/agent/models/workspace.ts
@@ -63,6 +63,7 @@ export class Workspace extends EventEmitter {
       await this._npmInstall();
     }
     fs.writeFileSync(path.join(this.dir, ".brunel.lock"), String(process.pid));
+    this._ensureLocallyIgnored(".brunel.lock");
     this.isCreated = true;
   }
 
@@ -89,6 +90,7 @@ export class Workspace extends EventEmitter {
       this.emit("clone-start", { repoUrl: this.repoUrl, dir: this.dir });
       await this.exec(["clone", this.repoUrl, this.dir], undefined);
       fs.writeFileSync(path.join(this.dir, ".brunel.lock"), String(process.pid));
+      this._ensureLocallyIgnored(".brunel.lock");
       await this._doReset(); // throws if still broken — propagates to caller
     }
   }
@@ -99,6 +101,17 @@ export class Workspace extends EventEmitter {
     await this.exec(["reset", "--hard", "origin/main"], this.dir);
     await this.exec(["clean", "-fdx", "-e", "node_modules", "-e", ".env", "-e", ".brunel.lock"], this.dir);
     await this._npmInstall();
+  }
+
+  private _ensureLocallyIgnored(pattern: string): void {
+    const infoDir = path.join(this.dir, ".git", "info");
+    fs.mkdirSync(infoDir, { recursive: true });
+    const excludesPath = path.join(infoDir, "exclude");
+    const existing = fs.existsSync(excludesPath) ? fs.readFileSync(excludesPath, "utf8") : "";
+    const lines = existing.split("\n").map(l => l.trim());
+    if (lines.includes(pattern)) return;
+    const sep = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
+    fs.appendFileSync(excludesPath, sep + pattern + "\n");
   }
 
   /** Run npm install if a package.json is present. */

--- a/tests/repl.workspace.test.ts
+++ b/tests/repl.workspace.test.ts
@@ -238,6 +238,24 @@ describe("WorkspaceController.onCreate", () => {
   });
 });
 
+// ── constructor: event listener deduplication ─────────────────────────────────
+
+describe("WorkspaceController constructor listeners", () => {
+  it("prints 'Destroying workspace...' exactly once even when onCreate is called twice", async () => {
+    const ws = makeWorkspace();
+    ws.isCreated = true;
+    const controller = new WorkspaceController(ws, testDisplay, testConfig);
+    await controller.onCreate();
+    await controller.onCreate(); // simulate stop → /worker:start again
+    testDisplay.print.mockClear();
+    ws.emit("destroy", { dir: WORKSPACE_DIR });
+    const destroyMsgs = testDisplay.print.mock.calls
+      .map(([l]: [string]) => stripAnsi(l))
+      .filter((m: string) => m.includes("Destroying workspace"));
+    expect(destroyMsgs).toHaveLength(1);
+  });
+});
+
 // ── workspace:prune ───────────────────────────────────────────────────────────
 
 describe("workspace:prune", () => {

--- a/tests/workspace.test.ts
+++ b/tests/workspace.test.ts
@@ -104,6 +104,51 @@ describe("Workspace.create", () => {
   });
 });
 
+// ── create: git excludes ──────────────────────────────────────────────────────
+
+describe("Workspace.create — git excludes", () => {
+  it("adds .brunel.lock to .git/info/exclude after create", async () => {
+    const ws = await makeWorkspace();
+    const excludePath = path.join(ws.dir, ".git", "info", "exclude");
+    expect(fs.existsSync(excludePath)).toBe(true);
+    const lines = fs.readFileSync(excludePath, "utf8").split("\n").map(l => l.trim());
+    expect(lines).toContain(".brunel.lock");
+  });
+
+  it("does not duplicate .brunel.lock in .git/info/exclude on repeated create", async () => {
+    const ws = await makeWorkspace();
+    await ws.create(); // second call — workspace dir already has .git
+    const excludePath = path.join(ws.dir, ".git", "info", "exclude");
+    const lines = fs.readFileSync(excludePath, "utf8").split("\n").map(l => l.trim()).filter(Boolean);
+    expect(lines.filter(l => l === ".brunel.lock")).toHaveLength(1);
+  });
+});
+
+// ── reset: re-clone path git excludes ────────────────────────────────────────
+
+describe("Workspace.reset — re-clone path", () => {
+  it("adds .brunel.lock to .git/info/exclude after a forced re-clone", async () => {
+    let fetchCalls = 0;
+    const exec = vi.fn().mockImplementation(async (args: string[]) => {
+      if (args[0] === "fetch") {
+        if (fetchCalls++ < 2) throw new Error("simulated network failure");
+      }
+      if (args[0] === "clone") {
+        // Simulate git clone creating a minimal repo structure
+        fs.mkdirSync(path.join(args[2], ".git", "info"), { recursive: true });
+        fs.writeFileSync(path.join(args[2], "package.json"), "{}");
+      }
+      return "";
+    });
+    const ws = await makeWorkspace(exec);
+    await ws.reset(); // fails twice, then re-clones
+    const excludePath = path.join(ws.dir, ".git", "info", "exclude");
+    expect(fs.existsSync(excludePath)).toBe(true);
+    const lines = fs.readFileSync(excludePath, "utf8").split("\n").map(l => l.trim());
+    expect(lines).toContain(".brunel.lock");
+  });
+});
+
 // ── destroy ────────────────────────────────────────────────────────────────
 
 describe("Workspace.destroy", () => {


### PR DESCRIPTION
## Summary

- Adds `Workspace._ensureLocallyIgnored(pattern)` — appends to `.git/info/exclude` idempotently — and calls it in `create()` and the re-clone path of `reset()`, so `.brunel.lock` never shows up in `git status` inside the workspace checkout.
- Moves all `workspace.on(…)` listener registrations from `WorkspaceController.onCreate()` to the constructor, so listeners are registered once per controller lifetime. Previously, calling `onCreate()` a second time (after `worker:stop` / `worker:start`) registered a second set of listeners, causing doubled output (e.g. two "Destroying workspace..." messages) on subsequent events.

## Test plan

- [ ] `Workspace.create — git excludes`: `.git/info/exclude` contains `.brunel.lock` after create; no duplicate on repeated create
- [ ] `Workspace.reset — re-clone path`: `.git/info/exclude` contains `.brunel.lock` after a forced re-clone
- [ ] `WorkspaceController constructor listeners`: "Destroying workspace..." prints exactly once even when `onCreate()` is called twice
- [ ] All 1584 non-DB unit tests pass; `npx tsc --noEmit` reports no errors

Closes #921

🤖 Generated with [Claude Code](https://claude.com/claude-code)