### PR TITLE
refactor: add transitionToIdle() — canonical entry point for worker waiting state

### DIFF
--- a/docs/superpowers/plans/2026-04-28-worker-state-model.md
+++ b/docs/superpowers/plans/2026-04-28-worker-state-model.md
@@ -255,7 +255,7 @@ Any transition into "waiting for tasks" must go through `transitionToIdle()`. Su
 - Modify: `src/agent/controllers/worker-controller.ts`
 - Test: `tests/worker.test.ts`
 
-- [ ] **Step 1: Write failing tests**
+- [x] **Step 1: Write failing tests**
 
 Add a new describe block in `tests/worker.test.ts`, near the existing `hello_ack handshake` section:
 
@@ -315,7 +315,7 @@ describe("transitionToIdle — Waiting for tasks message", () => {
 });
 ```
 
-- [ ] **Step 2: Run failing tests**
+- [x] **Step 2: Run failing tests**
 
 ```bash
 npm test -- worker
@@ -323,7 +323,7 @@ npm test -- worker
 
 Expected: FAIL — the idle, cancelled, and repo_activated tests fail because the message is not printed in the current code.
 
-- [ ] **Step 3: Add `transitionToIdle()` to `worker-controller.ts`**
+- [x] **Step 3: Add `transitionToIdle()` to `worker-controller.ts`**
 
 Immediately after the existing `transitionToRegistered()` method, add:
 
@@ -334,7 +334,7 @@ private transitionToIdle(): void {
 }
 ```
 
-- [ ] **Step 4: Wire `hello_ack idle` to `transitionToIdle()`**
+- [x] **Step 4: Wire `hello_ack idle` to `transitionToIdle()`**
 
 In the `hello_ack` handler, find the final `else` branch (currently calls `this.transitionToRegistered()` unconditionally):
 
@@ -358,7 +358,7 @@ Replace with:
 }
 ```
 
-- [ ] **Step 5: Wire `hello_ack cancelled` to `transitionToIdle()`**
+- [x] **Step 5: Wire `hello_ack cancelled` to `transitionToIdle()`**
 
 In the `cancelled` branch, find the block starting with `const workspace = this.workspaceController?.workspace`. Replace it with:
 
@@ -382,7 +382,7 @@ if (workspace?.isCreated) {
 }
 ```
 
-- [ ] **Step 6: Wire `repo_activated` to `transitionToIdle()`**
+- [x] **Step 6: Wire `repo_activated` to `transitionToIdle()`**
 
 Find the `repo_activated` handler:
 
@@ -404,7 +404,7 @@ if (msg.type === "repo_activated") {
 }
 ```
 
-- [ ] **Step 7: Run tests — expect them to pass**
+- [x] **Step 7: Run tests — expect them to pass**
 
 ```bash
 npm test -- worker
@@ -413,7 +413,7 @@ npx tsc --noEmit
 
 Expected: all worker tests pass, no type errors.
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```bash
 git add src/agent/controllers/worker-controller.ts tests/worker.test.ts

--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -531,6 +531,11 @@ export class WorkerController extends EventEmitter {
     }
   }
 
+  private transitionToIdle(): void {
+    this.transitionToRegistered();
+    this.display.print(c.sageGreen("Waiting for tasks..."));
+  }
+
   /**
    * Send all buffered messages if registered and the socket is open.
    * No-ops if the handshake is still pending or the socket is not ready.
@@ -659,7 +664,7 @@ export class WorkerController extends EventEmitter {
     }
 
     if (msg.type === "repo_activated") {
-      this.transitionToRegistered();
+      this.transitionToIdle();
       // Re-start the main routing loop's stdin listening. The activation picker
       // cancelled the active ask(); without this, the loop stays blocked at
       // nextRoutingEvent() with no stdin listener until a task arrives.
@@ -691,13 +696,18 @@ export class WorkerController extends EventEmitter {
         if (workspace?.isCreated) {
           // Track the reset promise so that task_assigned prompts are deferred until
           // the workspace is clean — preventing a new task from running in a dirty state.
+          // "Waiting for tasks..." is deferred to .finally() so it only prints after reset.
           this._resetPromise = workspace.reset().then(() => {
             this.display.print(c.amber("Workspace reset."));
           }).catch((err: unknown) => {
             this.display.print(c.boldRed(`Workspace reset failed: ${err instanceof Error ? err.message : String(err)}`));
           }).finally(() => {
             this._resetPromise = null;
+            this.display.print(c.sageGreen("Waiting for tasks..."));
           });
+          this.transitionToRegistered(); // "Waiting for tasks..." is in .finally() above
+        } else {
+          this.transitionToIdle(); // immediate — no reset needed
         }
       } else if (msg.repoStatus === "new") {
         // Show "Connected" in the status bar before waiting for user input — the
@@ -720,7 +730,11 @@ export class WorkerController extends EventEmitter {
         this.emit("prompts_ready");
       } else {
         // "idle" or "busy" with repoStatus 'active' (or no repoStatus for back-compat).
-        this.transitionToRegistered();
+        if (msg.status === "idle") {
+          this.transitionToIdle();
+        } else {
+          this.transitionToRegistered();
+        }
       }
       return;
     }

--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -694,20 +694,18 @@ export class WorkerController extends EventEmitter {
         this.display.print(c.amber("Task cancelled (reassigned to another worker)."));
         const workspace = this.workspaceController?.workspace;
         if (workspace?.isCreated) {
-          // Track the reset promise so that task_assigned prompts are deferred until
-          // the workspace is clean — preventing a new task from running in a dirty state.
-          // "Waiting for tasks..." is deferred to .finally() so it only prints after reset.
+          this.transitionToRegistered();
+          this.display.print(c.amber("Resetting workspace..."));
           this._resetPromise = workspace.reset().then(() => {
             this.display.print(c.amber("Workspace reset."));
           }).catch((err: unknown) => {
             this.display.print(c.boldRed(`Workspace reset failed: ${err instanceof Error ? err.message : String(err)}`));
           }).finally(() => {
             this._resetPromise = null;
-            this.display.print(c.sageGreen("Waiting for tasks..."));
+            this.transitionToIdle();
           });
-          this.transitionToRegistered(); // "Waiting for tasks..." is in .finally() above
         } else {
-          this.transitionToIdle(); // immediate — no reset needed
+          this.transitionToIdle();
         }
       } else if (msg.repoStatus === "new") {
         // Show "Connected" in the status bar before waiting for user input — the

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -2152,4 +2152,64 @@ describe("transitionToIdle — Waiting for tasks message", () => {
     const printed = display.print.mock.calls.map(([l]: [string]) => stripAnsi(l)).join("\n");
     expect(printed).toContain("Waiting for tasks");
   });
+
+  it("does NOT print 'Waiting for tasks...' synchronously on hello_ack cancelled with workspace", async () => {
+    let resolveReset!: () => void;
+    const resetPromise = new Promise<void>((resolve) => { resolveReset = resolve; });
+    const workspace = {
+      isCreated: true,
+      on: vi.fn(),
+      create: vi.fn().mockResolvedValue(undefined),
+      reset: vi.fn().mockReturnValue(resetPromise),
+    } as unknown as Workspace;
+    const ws = new FakeWs();
+    const wc = new WorkspaceController(workspace, display, { verbose: false });
+    const s = new WorkerController(sb, display, undefined, wc, "owner/repo", {
+      wsFactory: vi.fn().mockReturnValue(ws),
+    });
+    const chdirSpy = vi.spyOn(process, "chdir").mockImplementation(() => {});
+    try {
+      await s.start();
+      sendMsg(ws, { type: "task_assigned", taskId: "42", issue: makeIssue() });
+      s.takeNextPrompt();
+      display.print.mockClear();
+      sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "cancelled" });
+      const printed = display.print.mock.calls.map(([l]: [string]) => stripAnsi(l)).join("\n");
+      expect(printed).not.toContain("Waiting for tasks");
+    } finally {
+      resolveReset();
+      chdirSpy.mockRestore();
+    }
+  });
+
+  it("prints 'Waiting for tasks...' after reset completes on hello_ack cancelled with workspace", async () => {
+    let resolveReset!: () => void;
+    const resetPromise = new Promise<void>((resolve) => { resolveReset = resolve; });
+    const workspace = {
+      isCreated: true,
+      on: vi.fn(),
+      create: vi.fn().mockResolvedValue(undefined),
+      reset: vi.fn().mockReturnValue(resetPromise),
+    } as unknown as Workspace;
+    const ws = new FakeWs();
+    const wc = new WorkspaceController(workspace, display, { verbose: false });
+    const s = new WorkerController(sb, display, undefined, wc, "owner/repo", {
+      wsFactory: vi.fn().mockReturnValue(ws),
+    });
+    const chdirSpy = vi.spyOn(process, "chdir").mockImplementation(() => {});
+    try {
+      await s.start();
+      sendMsg(ws, { type: "task_assigned", taskId: "42", issue: makeIssue() });
+      s.takeNextPrompt();
+      display.print.mockClear();
+      sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "cancelled" });
+      resolveReset();
+      await resetPromise;
+      await new Promise(r => setTimeout(r, 0)); // flush .finally() microtask
+      const printed = display.print.mock.calls.map(([l]: [string]) => stripAnsi(l)).join("\n");
+      expect(printed).toContain("Waiting for tasks");
+    } finally {
+      chdirSpy.mockRestore();
+    }
+  });
 });

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -2099,3 +2099,57 @@ describe("repo activation flow", () => {
   });
 
 });
+
+// ── transitionToIdle — single entry for state 2 ───────────────────────────────
+
+function makeSessionWithPickResult(pickResult: number): { s: WorkerController; ws: FakeWs } {
+  const ws = new FakeWs();
+  const localWsFactory = vi.fn().mockReturnValue(ws);
+  const s = new WorkerController(sb, display, undefined, undefined, "owner/repo", {
+    wsFactory: localWsFactory,
+    pickFn: async () => pickResult,
+  });
+  return { s, ws };
+}
+
+describe("transitionToIdle — Waiting for tasks message", () => {
+  it("prints 'Waiting for tasks...' on hello_ack idle", () => {
+    display.print.mockClear();
+    sendMsg(fakeWs, { type: "hello_ack", workerId: AGENT_ID, status: "idle" });
+    const printed = display.print.mock.calls.map(([l]: [string]) => stripAnsi(l)).join("\n");
+    expect(printed).toContain("Waiting for tasks");
+  });
+
+  it("does NOT print 'Waiting for tasks...' on hello_ack busy", () => {
+    const issue = makeIssue();
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
+    session.takeNextPrompt();
+    display.print.mockClear();
+    sendMsg(fakeWs, { type: "hello_ack", workerId: AGENT_ID, status: "busy" });
+    const printed = display.print.mock.calls.map(([l]: [string]) => stripAnsi(l)).join("\n");
+    expect(printed).not.toContain("Waiting for tasks");
+  });
+
+  it("prints 'Waiting for tasks...' on hello_ack cancelled with no workspace", () => {
+    const issue = makeIssue();
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
+    session.takeNextPrompt();
+    display.print.mockClear();
+    sendMsg(fakeWs, { type: "hello_ack", workerId: AGENT_ID, status: "cancelled" });
+    const printed = display.print.mock.calls.map(([l]: [string]) => stripAnsi(l)).join("\n");
+    expect(printed).toContain("Waiting for tasks");
+  });
+
+  it("prints 'Waiting for tasks...' on repo_activated", async () => {
+    const { s, ws } = makeSessionWithPickResult(0); // 0 = "Yes, activate"
+    await s.start();
+    ws.emit("open");
+    sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "idle", repoStatus: "new" });
+    await new Promise(r => setTimeout(r, 0)); // let async pick resolve
+    display.print.mockClear();
+    sendMsg(ws, { type: "repo_activated", workerId: AGENT_ID });
+    await new Promise(r => setTimeout(r, 0));
+    const printed = display.print.mock.calls.map(([l]: [string]) => stripAnsi(l)).join("\n");
+    expect(printed).toContain("Waiting for tasks");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `private transitionToIdle()` to `WorkerController` that calls `transitionToRegistered()` then prints `"Waiting for tasks..."`
- Wires `hello_ack idle` and `repo_activated` to call `transitionToIdle()`
- Wires `hello_ack cancelled` (no workspace) to call `transitionToIdle()` immediately; with workspace, defers the print to `.finally()` after the reset completes
- `hello_ack busy` continues to call `transitionToRegistered()` (no message — worker already has a task)

## Test plan

- [ ] New describe block `"transitionToIdle — Waiting for tasks message"` with 4 tests covering all call sites
- [ ] `hello_ack idle` → prints "Waiting for tasks..."
- [ ] `hello_ack busy` → does NOT print "Waiting for tasks..."
- [ ] `hello_ack cancelled` (no workspace) → prints "Waiting for tasks..."
- [ ] `repo_activated` → prints "Waiting for tasks..."
- [ ] All 318 existing + new tests pass; `tsc --noEmit` clean

Closes #922

🤖 Generated with [Claude Code](https://claude.com/claude-code)