### PR TITLE
refactor: remove unreachable post-loop worker cleanup block

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -349,13 +349,6 @@ export class BrunelAgent {
       // Drain any foreman prompts that arrived during the user's query.
       await drainPendingPrompts();
     }
-
-    // Worker mode post-loop: send goodbye, destroy workspace, tear down I/O, exit.
-    if (workerController.isActive) {
-      workerController.sendGoodbye();
-      await doExit();
-      process.exit(0);
-    }
   }
 }
 


### PR DESCRIPTION
## Summary

- All the core keyboard-rule changes from Task 3 (`^D` no-op in idle state, `^C` at prompt calls `stop()`, simplified `__eof__`/`/exit` handlers) were already merged in PR #929
- The dead post-loop block (`if (workerController.isActive) { sendGoodbye(); doExit(); process.exit(0); }`) was left in the code — it was updated in PR #930 to replace `isCleanupPending`/`cleanup()` but never deleted
- This PR removes that unreachable block: every `break` path in the routing loop already calls `doExit()` before exiting, so `workerController.isActive` can never be `true` at that point

## Test plan

- [ ] All 1593 non-DB unit tests pass (`npm test`)
- [ ] `npx tsc --noEmit` — no type errors
- [ ] Existing `worker.main.test.ts` tests confirm clean exit (no `process.exit(0)`) for both `^D` and `/exit` paths

Closes #931