### PR TITLE
feat: auto-recover from connection stalls before first response

### DIFF
--- a/src/agent/controllers/agent-controller.ts
+++ b/src/agent/controllers/agent-controller.ts
@@ -69,7 +69,7 @@ export class AgentController {
     prompt: string,
     sessionId: string | undefined,
     abortController?: AbortController,
-  ): Promise<{ sessionId: string | undefined; stats: QueryStats }> {
+  ): Promise<{ sessionId: string | undefined; stats: QueryStats; stallRetry: boolean }> {
     logFull("QUERY", { prompt, sessionId });
     const { display } = this;
     // Save and clear the input callbacks while the query runs. In worker
@@ -143,9 +143,12 @@ export class AgentController {
 
     let capturedSessionId = sessionId;
     let resultReceived = false;
+    let receivedSubstantiveContent = false;
+    let stallRetry = false;
 
     // Log a single warning when no SDK message has arrived for STALL_THRESHOLD_SECS.
     // This fires via a watchdog so it captures hangs inside the for-await wait itself.
+    // If no substantive content has arrived yet, auto-abort and signal the caller to retry.
     let stallLogged = false;
     const stallWatcher = setInterval(() => {
       if (!stallLogged && stats.secsSinceLastActivity >= STALL_THRESHOLD_SECS) {
@@ -154,12 +157,19 @@ export class AgentController {
           secsSinceLastActivity: stats.secsSinceLastActivity,
           totalElapsedSecs: stats.elapsedSecs,
         });
+        if (!receivedSubstantiveContent) {
+          stallRetry = true;
+          display.print(c.amber("\n⚠ Connection stalled before receiving a response — retrying…"));
+          (iterable as unknown as { close?: () => void }).close?.();
+          ac.abort();
+        }
       }
     }, 10_000);
 
     try {
       for await (const message of iterable) {
         stats.noteActivity();
+        if (message.type !== "system") receivedSubstantiveContent = true;
 
         if (!(message.type === "stream_event" && (message.event as { type?: string }).type === "content_block_delta")) {
           logFull("MESSAGE", message);
@@ -194,7 +204,7 @@ export class AgentController {
 
     display.stopBar();
 
-    if (!resultReceived) {
+    if (!resultReceived && !stallRetry) {
       display.print(c.darkGray("\nInterrupted. What should the agent do instead?"));
     }
 
@@ -203,7 +213,7 @@ export class AgentController {
     display.inputClear = savedClearCallback;
     savedInputCallback?.();
 
-    return { sessionId: capturedSessionId, stats };
+    return { sessionId: capturedSessionId, stats, stallRetry };
   }
 
   // ── Private helpers ────────────────────────────────────────────────────────

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -230,24 +230,36 @@ export class BrunelAgent {
      * before/after so it can track the AbortController for interrupt() and drain
      * pending events when the query finishes. Returns true if the query completed
      * normally, false if interrupted or errored (caller should stop draining).
+     *
+     * If runQuery detects a first-message stall (stallRetry: true), retries the
+     * same prompt up to MAX_STALL_RETRIES times before giving up.
      */
+    const MAX_STALL_RETRIES = 2;
     const runPrompt = async (prompt: string): Promise<boolean> => {
-      const ac = new AbortController();
-      workerController.notifyQueryStart(ac);
-      try {
-        const { sessionId: newId, stats } = await this.agentController.runQuery(prompt, sessionId, ac);
-        sessionId = newId ?? sessionId;
-        if (workerController.isActive) {
-          this.agentStatus.addQueryStats(stats.inputTokens, stats.outputTokens, stats.costUsd);
+      for (let attempt = 0; attempt <= MAX_STALL_RETRIES; attempt++) {
+        const ac = new AbortController();
+        workerController.notifyQueryStart(ac);
+        try {
+          const { sessionId: newId, stats, stallRetry } = await this.agentController.runQuery(prompt, sessionId, ac);
+          if (stallRetry && attempt < MAX_STALL_RETRIES) {
+            // Stall before first response: retry with the same prompt. Don't
+            // update sessionId — the stalled session may be in a broken state.
+            continue;
+          }
+          sessionId = newId ?? sessionId;
+          if (workerController.isActive) {
+            this.agentStatus.addQueryStats(stats.inputTokens, stats.outputTokens, stats.costUsd);
+          }
+          return stallRetry ? false : !ac.signal.aborted;
+        } catch (err) {
+          console.error(c.boldRed(`\nERROR: ${fmtError(err)}`));
+          logFull("ERROR", err instanceof Error ? { message: err.message, stack: err.stack } : err);
+          return false;
+        } finally {
+          workerController.notifyQueryEnd(ac.signal.aborted);
         }
-        return !ac.signal.aborted;
-      } catch (err) {
-        console.error(c.boldRed(`\nERROR: ${fmtError(err)}`));
-        logFull("ERROR", err instanceof Error ? { message: err.message, stack: err.stack } : err);
-        return false;
-      } finally {
-        workerController.notifyQueryEnd(ac.signal.aborted);
       }
+      return false;
     };
 
     /**

--- a/tests/repl.query.test.ts
+++ b/tests/repl.query.test.ts
@@ -840,3 +840,97 @@ describe("runQuery - stall detection", () => {
     cap.restore();
   });
 });
+
+describe("runQuery - first-message stall auto-retry", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns stallRetry: true when stall fires before any substantive content", async () => {
+    vi.useFakeTimers();
+
+    (query as any).mockImplementation((opts: any) => {
+      return (async function* () {
+        // Only a system message arrives — not substantive
+        yield { type: "system", subtype: "status", status: "requesting" };
+        // Then silence until abort
+        await new Promise<void>((resolve) => {
+          opts.options.abortController.signal.addEventListener("abort", resolve, { once: true });
+        });
+      })();
+    });
+
+    const cap = captureConsole();
+    const queryPromise = testController.runQuery("test", undefined);
+
+    await vi.advanceTimersByTimeAsync(130_000);
+
+    const result = await queryPromise;
+    cap.restore();
+
+    expect(result.stallRetry).toBe(true);
+  });
+
+  it("prints the stall-retry warning message before aborting", async () => {
+    vi.useFakeTimers();
+
+    (query as any).mockImplementation((opts: any) => {
+      return (async function* () {
+        yield { type: "system", subtype: "status", status: "requesting" };
+        await new Promise<void>((resolve) => {
+          opts.options.abortController.signal.addEventListener("abort", resolve, { once: true });
+        });
+      })();
+    });
+
+    const cap = captureConsole();
+    const queryPromise = testController.runQuery("test", undefined);
+    await vi.advanceTimersByTimeAsync(130_000);
+    await queryPromise;
+    cap.restore();
+
+    const output = cap.lines.map(stripAnsi).join("\n");
+    expect(output).toContain("Connection stalled before receiving a response");
+  });
+
+  it("does NOT set stallRetry when stall fires after a non-system message was received", async () => {
+    vi.useFakeTimers();
+
+    (query as any).mockImplementation((opts: any) => {
+      return (async function* () {
+        yield { type: "system", subtype: "init", session_id: "s1" };
+        // Substantive content: a result message
+        yield { type: "result", duration_ms: 100, num_turns: 1, usage: { input_tokens: 5, output_tokens: 5 } };
+        // Then silence — loop will exit after result because generator is done
+      })();
+    });
+
+    const cap = captureConsole();
+    const result = await testController.runQuery("test", undefined);
+    cap.restore();
+
+    expect(result.stallRetry).toBeFalsy();
+  });
+
+  it("does not print the 'Interrupted' message when stallRetry fires", async () => {
+    vi.useFakeTimers();
+
+    (query as any).mockImplementation((opts: any) => {
+      return (async function* () {
+        yield { type: "system", subtype: "status", status: "requesting" };
+        await new Promise<void>((resolve) => {
+          opts.options.abortController.signal.addEventListener("abort", resolve, { once: true });
+        });
+      })();
+    });
+
+    const cap = captureConsole();
+    const queryPromise = testController.runQuery("test", undefined);
+    await vi.advanceTimersByTimeAsync(130_000);
+    await queryPromise;
+    cap.restore();
+
+    const output = cap.lines.map(stripAnsi).join("\n");
+    expect(output).not.toContain("Interrupted");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `receivedSubstantiveContent` flag in `AgentController.runQuery` that becomes `true` on the first non-`system` message
- When the stall watchdog fires and `!receivedSubstantiveContent`, the query is auto-aborted and `stallRetry: true` is returned to the caller along with a user-visible warning: `⚠ Connection stalled before receiving a response — retrying…`
- `runPrompt` in `index.ts` retries the same prompt up to 2 times on `stallRetry: true`; if all retries stall, returns `false` to stop draining

Mid-stream stalls (after substantive content is received) continue to only log `STALL_DETECTED` and show the existing status-bar warning — no change to that path.

## Test plan

- [x] `returns stallRetry: true when stall fires before any substantive content`
- [x] `prints the stall-retry warning message before aborting`
- [x] `does NOT set stallRetry when stall fires after a non-system message was received`
- [x] `does not print the 'Interrupted' message when stallRetry fires`
- [x] All 1597 unit tests pass; 4 DB tests skipped (require `supabase start`)
- [x] `npx tsc --noEmit` clean

Closes #925

🤖 Generated with [Claude Code](https://claude.com/claude-code)