### PR TITLE
feat: infinite scroll pagination for event log

### DIFF
--- a/frontend/src/pages/EventLog.tsx
+++ b/frontend/src/pages/EventLog.tsx
@@ -57,7 +57,7 @@ export default function EventLog() {
     if (!sentinel) return;
     const observer = new IntersectionObserver(
       ([entry]) => { if (entry.isIntersecting) loadMore(); },
-      { threshold: 0.1 },
+      { rootMargin: "0px 0px 200px 0px", threshold: 0 },
     );
     observer.observe(sentinel);
     return () => observer.disconnect();

--- a/frontend/src/pages/EventLog.tsx
+++ b/frontend/src/pages/EventLog.tsx
@@ -1,31 +1,72 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { Link } from "react-router-dom";
 import { useAdminWs } from "../hooks/useAdminWs.ts";
 import type { LogEntry, AdminMessage } from "../types.ts";
 import { shortWorkerId } from "../../../shared/utils.ts";
 
+const PAGE_SIZE = 50;
+
 export default function EventLog() {
   const [entries, setEntries] = useState<LogEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  const fetchPage = useCallback(async (before?: string) => {
+    setLoading(true);
+    try {
+      const url = before ? `/api/log?before=${encodeURIComponent(before)}` : "/api/log";
+      const data = await fetch(url).then((r) => r.json() as Promise<LogEntry[]>);
+      setEntries((prev) => {
+        const seen = new Set(prev.map((e) => `${e.kind}-${e.id}`));
+        const fresh = data.filter((e) => !seen.has(`${e.kind}-${e.id}`));
+        return [...prev, ...fresh];
+      });
+      setHasMore(data.length === PAGE_SIZE);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
-    fetch("/api/log")
-      .then((r) => r.json() as Promise<LogEntry[]>)
-      .then(setEntries)
-      .catch(console.error);
-  }, []);
+    fetchPage();
+  }, [fetchPage]);
 
   const handleMessage = useCallback((msg: AdminMessage) => {
     if (msg.type === "log_event") {
-      setEntries((prev) => [msg.entry, ...prev]);
+      setEntries((prev) => {
+        const key = `${msg.entry.kind}-${msg.entry.id}`;
+        if (prev.some((e) => `${e.kind}-${e.id}` === key)) return prev;
+        return [msg.entry, ...prev];
+      });
     }
   }, []);
 
   useAdminWs(handleMessage);
 
+  const loadMore = useCallback(() => {
+    if (loading || !hasMore || entries.length === 0) return;
+    fetchPage(entries[entries.length - 1].timestamp);
+  }, [loading, hasMore, entries, fetchPage]);
+
+  useEffect(() => {
+    if (!hasMore || loading) return;
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => { if (entry.isIntersecting) loadMore(); },
+      { threshold: 0.1 },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasMore, loading, loadMore]);
+
   return (
     <div>
       <h2>Event Log</h2>
-      {entries.length === 0 ? <p>No events.</p> : (
+      {entries.length === 0 && !loading ? <p>No events.</p> : (
         <table style={{ width: "100%", borderCollapse: "collapse", fontFamily: "monospace", fontSize: "0.85em" }}>
           <thead>
             <tr>
@@ -51,9 +92,22 @@ export default function EventLog() {
           </tbody>
         </table>
       )}
+      {hasMore && (
+        <div ref={sentinelRef} style={{ padding: "8px", textAlign: "center" }}>
+          {loading
+            ? <span style={{ color: "#888", fontFamily: "monospace", fontSize: "0.85em" }}>Loading…</span>
+            : <button onClick={loadMore} style={loadMoreBtn}>Load more</button>}
+        </div>
+      )}
     </div>
   );
 }
 
 const th: React.CSSProperties = { textAlign: "left", borderBottom: "1px solid #ccc", padding: "4px 8px" };
 const td: React.CSSProperties = { padding: "4px 8px", borderBottom: "1px solid #eee" };
+const loadMoreBtn: React.CSSProperties = {
+  padding: "4px 16px",
+  fontFamily: "monospace",
+  fontSize: "0.85em",
+  cursor: "pointer",
+};

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -1,6 +1,15 @@
-import { expect, afterEach } from "vitest";
+import { expect, afterEach, vi } from "vitest";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { cleanup } from "@testing-library/react";
 
 expect.extend(matchers);
 afterEach(cleanup);
+
+// jsdom doesn't implement IntersectionObserver
+class IntersectionObserverStub {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+  constructor(_cb: unknown, _opts?: unknown) {}
+}
+vi.stubGlobal("IntersectionObserver", IntersectionObserverStub);

--- a/src/foreman/controllers/http-server.ts
+++ b/src/foreman/controllers/http-server.ts
@@ -64,7 +64,8 @@ export class HttpServer {
   // ── REST API ───────────────────────────────────────────────────────────────
   app.get("/api/log", async (c) => {
     try {
-      const entries = await queryActivityLog({ limit: 100 });
+      const before = c.req.query("before");
+      const entries = await queryActivityLog({ limit: 50, ...(before ? { before } : {}) });
       return c.json(entries);
     } catch (err) {
       log(`ERROR API query failed: ${fmtError(err)}`);

--- a/src/foreman/models/activity-log.ts
+++ b/src/foreman/models/activity-log.ts
@@ -8,6 +8,7 @@ import { Repo } from "./repo.js";
 
 export interface QueryActivityLogOpts {
   limit?: number;
+  before?: string;
   taskId?: string;
   workerId?: string;
   repoId?: number;
@@ -35,8 +36,8 @@ export async function queryActivityLog(opts: QueryActivityLogOpts = {}): Promise
     ]);
   } else {
     [webhooks, messages] = await Promise.all([
-      WebhookEvent.list({ limit }),
-      ForemanMessage.list({ limit }),
+      WebhookEvent.list({ limit, before: opts.before }),
+      ForemanMessage.list({ limit, before: opts.before }),
     ]);
   }
 

--- a/src/foreman/models/foreman-message.ts
+++ b/src/foreman/models/foreman-message.ts
@@ -78,10 +78,10 @@ export class ForemanMessage extends ActiveRecord {
     return (data ?? []).map((r: DbRow) => new ForemanMessage(r));
   }
 
-  static async list(opts: { limit?: number } = {}): Promise<ForemanMessage[]> {
-    const { data } = await ForemanMessage.select()
-      .order("created_at", { ascending: false })
-      .limit(opts.limit ?? 100);
+  static async list(opts: { limit?: number; before?: string } = {}): Promise<ForemanMessage[]> {
+    let query = ForemanMessage.select().order("created_at", { ascending: false });
+    if (opts.before) query = query.lt("created_at", opts.before);
+    const { data } = await query.limit(opts.limit ?? 100);
     return (data ?? []).map((r: DbRow) => new ForemanMessage(r));
   }
 

--- a/src/foreman/models/webhook-event.ts
+++ b/src/foreman/models/webhook-event.ts
@@ -129,10 +129,10 @@ export class WebhookEvent extends ActiveRecord {
     return (data ?? []).map((r: Row) => new WebhookEvent(r));
   }
 
-  static async list(opts: { limit?: number } = {}): Promise<WebhookEvent[]> {
-    const { data } = await WebhookEvent.select()
-      .order("received_at", { ascending: false })
-      .limit(opts.limit ?? 100);
+  static async list(opts: { limit?: number; before?: string } = {}): Promise<WebhookEvent[]> {
+    let query = WebhookEvent.select().order("received_at", { ascending: false });
+    if (opts.before) query = query.lt("received_at", opts.before);
+    const { data } = await query.limit(opts.limit ?? 100);
     return (data ?? []).map((r: Row) => new WebhookEvent(r));
   }
 

--- a/tests/browser/event-log.spec.ts
+++ b/tests/browser/event-log.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * Browser tests for the event log page (/log).
+ *
+ * Uses Playwright's route interception to mock /api/log responses so
+ * pagination can be tested without a real database.
+ */
+import { test, expect } from "@playwright/test";
+
+function makeEntries(startId: number, count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    kind: "webhook",
+    id: startId + i,
+    timestamp: new Date(Date.now() - (startId + i) * 1000).toISOString(),
+    taskId: null,
+    workerId: null,
+    repo: "owner/repo",
+    summary: `entry-${startId + i}`,
+  }));
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test("event log: shows initial entries on load", async ({ page }) => {
+  await page.route("**/api/log**", async (route) => {
+    await route.fulfill({ json: makeEntries(0, 10) });
+  });
+
+  await page.goto("/log");
+
+  await expect(page.getByRole("heading", { name: "Event Log" })).toBeVisible();
+  await expect(page.getByText("entry-0")).toBeVisible();
+  await expect(page.getByText("entry-9")).toBeVisible();
+});
+
+test("event log: load-more button appears when page is full and disappears after last page", async ({ page }) => {
+  const PAGE_SIZE = 50;
+
+  await page.route("**/api/log**", async (route) => {
+    const url = new URL(route.request().url());
+    const hasBefore = url.searchParams.has("before");
+    await route.fulfill({
+      json: hasBefore ? makeEntries(PAGE_SIZE, 5) : makeEntries(0, PAGE_SIZE),
+    });
+  });
+
+  await page.goto("/log");
+
+  // First entry visible
+  await expect(page.getByText("entry-0")).toBeVisible();
+
+  // Load-more button present (50 = PAGE_SIZE → more pages may exist)
+  const loadMoreBtn = page.getByRole("button", { name: "Load more" });
+  await expect(loadMoreBtn).toBeVisible();
+
+  // Click load-more
+  await loadMoreBtn.click();
+
+  // Second page entries appended
+  await expect(page.getByText(`entry-${PAGE_SIZE}`)).toBeVisible();
+
+  // Load-more gone (5 < PAGE_SIZE → no more pages)
+  await expect(loadMoreBtn).not.toBeVisible();
+});
+
+test("event log: passes before cursor from last entry of current page", async ({ page }) => {
+  const PAGE_SIZE = 50;
+  const firstPageEntries = makeEntries(0, PAGE_SIZE);
+  const expectedCursor = firstPageEntries[firstPageEntries.length - 1].timestamp;
+
+  let capturedBefore: string | null = null;
+  await page.route("**/api/log**", async (route) => {
+    const url = new URL(route.request().url());
+    capturedBefore = url.searchParams.get("before");
+    await route.fulfill({ json: capturedBefore ? makeEntries(PAGE_SIZE, 3) : firstPageEntries });
+  });
+
+  await page.goto("/log");
+  await expect(page.getByText("entry-0")).toBeVisible();
+
+  await page.getByRole("button", { name: "Load more" }).click();
+
+  await expect(page.getByText(`entry-${PAGE_SIZE}`)).toBeVisible();
+  expect(capturedBefore).toBe(expectedCursor);
+});

--- a/tests/browser/event-log.spec.ts
+++ b/tests/browser/event-log.spec.ts
@@ -32,53 +32,51 @@ test("event log: shows initial entries on load", async ({ page }) => {
   await expect(page.getByText("entry-9")).toBeVisible();
 });
 
-test("event log: load-more button appears when page is full and disappears after last page", async ({ page }) => {
+test("event log: appends next page and removes load-more after last page", async ({ page }) => {
   const PAGE_SIZE = 50;
 
   await page.route("**/api/log**", async (route) => {
     const url = new URL(route.request().url());
-    const hasBefore = url.searchParams.has("before");
     await route.fulfill({
-      json: hasBefore ? makeEntries(PAGE_SIZE, 5) : makeEntries(0, PAGE_SIZE),
+      json: url.searchParams.has("before") ? makeEntries(PAGE_SIZE, 5) : makeEntries(0, PAGE_SIZE),
     });
   });
 
   await page.goto("/log");
-
-  // First entry visible
   await expect(page.getByText("entry-0")).toBeVisible();
 
-  // Load-more button present (50 = PAGE_SIZE → more pages may exist)
-  const loadMoreBtn = page.getByRole("button", { name: "Load more" });
-  await expect(loadMoreBtn).toBeVisible();
+  // Scroll to bottom — triggers IntersectionObserver if it hasn't already fired
+  // (on short CI viewports it may auto-fire; on taller ones the scroll triggers it)
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
 
-  // Click load-more
-  await loadMoreBtn.click();
-
-  // Second page entries appended
+  // Next-page entries appear (5 entries appended)
   await expect(page.getByText(`entry-${PAGE_SIZE}`)).toBeVisible();
 
-  // Load-more gone (5 < PAGE_SIZE → no more pages)
-  await expect(loadMoreBtn).not.toBeVisible();
+  // 5 < PAGE_SIZE → no more pages → load-more sentinel gone
+  await expect(page.getByRole("button", { name: "Load more" })).not.toBeVisible();
 });
 
 test("event log: passes before cursor from last entry of current page", async ({ page }) => {
   const PAGE_SIZE = 50;
-  const firstPageEntries = makeEntries(0, PAGE_SIZE);
-  const expectedCursor = firstPageEntries[firstPageEntries.length - 1].timestamp;
+  const firstPage = makeEntries(0, PAGE_SIZE);
+  const expectedCursor = firstPage[firstPage.length - 1].timestamp;
 
   let capturedBefore: string | null = null;
   await page.route("**/api/log**", async (route) => {
     const url = new URL(route.request().url());
-    capturedBefore = url.searchParams.get("before");
-    await route.fulfill({ json: capturedBefore ? makeEntries(PAGE_SIZE, 3) : firstPageEntries });
+    const before = url.searchParams.get("before");
+    if (before) capturedBefore = before;
+    await route.fulfill({ json: before ? makeEntries(PAGE_SIZE, 3) : firstPage });
   });
 
   await page.goto("/log");
   await expect(page.getByText("entry-0")).toBeVisible();
 
-  await page.getByRole("button", { name: "Load more" }).click();
+  // Scroll to bottom to ensure load-more fires (auto or manual)
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
 
   await expect(page.getByText(`entry-${PAGE_SIZE}`)).toBeVisible();
+
+  // The before cursor must equal the timestamp of the last entry on page 1
   expect(capturedBefore).toBe(expectedCursor);
 });

--- a/tests/browser/repo.spec.ts
+++ b/tests/browser/repo.spec.ts
@@ -49,7 +49,7 @@ test("repo detail page: shows repo name and tasks", async ({ page }) => {
     action: "labeled",
     label: { name: "brunel:ready" },
     issue: {
-      number: 5001,
+      number: 5002,
       title: "Repo detail test task",
       body: "",
       labels: [{ name: "brunel:ready" }],
@@ -65,7 +65,7 @@ test("repo detail page: shows repo name and tasks", async ({ page }) => {
   // Should be on a /repos/:id page showing the repo name
   await expect(page.getByRole("heading", { name: "owner/repo" })).toBeVisible();
   // The task should be visible
-  await expect(page.getByRole("link", { name: "#5001" }).first()).toBeVisible();
+  await expect(page.getByRole("link", { name: "#5002" }).first()).toBeVisible();
   await expect(page.getByText("Repo detail test task")).toBeVisible();
 });
 

--- a/tests/foreman.http.test.ts
+++ b/tests/foreman.http.test.ts
@@ -134,13 +134,21 @@ describe("GET /api/log", () => {
     expect(JSON.parse(res.body)).toEqual([]);
   });
 
-  it("returns log entries from queryActivityLog", async () => {
+  it("returns log entries from queryActivityLog with default limit", async () => {
     const entries = [{ id: 1, summary: "test" }];
     vi.mocked(queryActivityLog).mockResolvedValue(entries as never);
     const res = await request(port, "GET", "/api/log");
     expect(res.status).toBe(200);
     expect(JSON.parse(res.body)).toEqual(entries);
-    expect(queryActivityLog).toHaveBeenCalledWith({ limit: 100 });
+    expect(queryActivityLog).toHaveBeenCalledWith({ limit: 50 });
+  });
+
+  it("passes before cursor to queryActivityLog when provided", async () => {
+    const before = "2024-06-01T12:00:00.000Z";
+    vi.mocked(queryActivityLog).mockResolvedValue([]);
+    const res = await request(port, "GET", `/api/log?before=${encodeURIComponent(before)}`);
+    expect(res.status).toBe(200);
+    expect(queryActivityLog).toHaveBeenCalledWith({ limit: 50, before });
   });
 });
 

--- a/tests/helpers/memory-db.ts
+++ b/tests/helpers/memory-db.ts
@@ -259,6 +259,7 @@ export function createMemoryTaskDb(): SupabaseClient<Database> {
     select(_cols?: string) { return emptyBuilder; },
     eq(_col: string, _val: unknown) { return emptyBuilder; },
     is(_col: string, _val: unknown) { return emptyBuilder; },
+    lt(_col: string, _val: unknown) { return emptyBuilder; },
     order(_col: string, _opts?: unknown) { return emptyBuilder; },
     limit(_n: number) { return ok([] as DbRow[]); },
     maybeSingle() { return ok(null as DbRow | null); },


### PR DESCRIPTION
## Summary

- Adds cursor-based (`before` timestamp) pagination to `GET /api/log` — page size 50
- Adds `before?: string` filter to `WebhookEvent.list()` and `ForemanMessage.list()` so each DB query only fetches records older than the cursor
- `EventLog.tsx` uses `IntersectionObserver` to auto-load the next page when the sentinel div at the bottom scrolls into view; a visible "Load more" button serves as a fallback for fast scrollers
- New real-time WebSocket events still prepend to the top, deduped by `kind+id`

## Test plan

- [x] Updated existing HTTP test: `GET /api/log` now calls `queryActivityLog` with `{ limit: 50 }` 
- [x] New HTTP test: `GET /api/log?before=<timestamp>` passes `{ limit: 50, before }` to `queryActivityLog`
- [x] All 1594 unit tests pass (4 DB-only tests skipped without Supabase, pre-existing)
- [ ] Manual: open Event Log page, scroll to bottom — next 50 events load automatically
- [ ] Manual: scrolling fast shows "Load more" button briefly, clicking it loads the next page
- [ ] Manual: "Load more" / sentinel disappears after the last page

Closes #932

🤖 Generated with [Claude Code](https://claude.com/claude-code)