### PR TITLE
feat: distinct HTML titles for dashboard pages

### DIFF
--- a/frontend/src/hooks/usePageTitle.ts
+++ b/frontend/src/hooks/usePageTitle.ts
@@ -1,0 +1,8 @@
+import { useEffect } from "react";
+
+export function usePageTitle(title: string) {
+  useEffect(() => {
+    document.title = title;
+    return () => { document.title = "Brunel"; };
+  }, [title]);
+}

--- a/frontend/src/pages/EventLog.tsx
+++ b/frontend/src/pages/EventLog.tsx
@@ -1,12 +1,14 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { Link } from "react-router-dom";
 import { useAdminWs } from "../hooks/useAdminWs.ts";
+import { usePageTitle } from "../hooks/usePageTitle.ts";
 import type { LogEntry, AdminMessage } from "../types.ts";
 import { shortWorkerId } from "../../../shared/utils.ts";
 
 const PAGE_SIZE = 50;
 
 export default function EventLog() {
+  usePageTitle("Events \u2013 Brunel");
   const [entries, setEntries] = useState<LogEntry[]>([]);
   const [loading, setLoading] = useState(false);
   const [hasMore, setHasMore] = useState(true);

--- a/frontend/src/pages/RepoDetail.tsx
+++ b/frontend/src/pages/RepoDetail.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams, Link } from "react-router-dom";
 import { useAdminWs } from "../hooks/useAdminWs.ts";
+import { usePageTitle } from "../hooks/usePageTitle.ts";
 import type { Task, Worker, Repo, LogEntry, AdminMessage } from "../types.ts";
 import { shortWorkerId } from "../../../shared/utils.ts";
 
@@ -9,6 +10,7 @@ export default function RepoDetail() {
   const repoId = Number(id);
 
   const [repo, setRepo] = useState<Repo | null>(null);
+  usePageTitle(repo ? `${repo.fullName} \u2013 Brunel` : "Brunel");
   const [tasks, setTasks] = useState<Task[]>([]);
   const [workers, setWorkers] = useState<Worker[]>([]);
   const [recentLog, setRecentLog] = useState<LogEntry[]>([]);

--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -1,11 +1,13 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams, Link } from "react-router-dom";
 import { useAdminWs } from "../hooks/useAdminWs.ts";
+import { usePageTitle } from "../hooks/usePageTitle.ts";
 import type { LogEntry, AdminMessage, Task } from "../types.ts";
 import { shortWorkerId } from "../../../shared/utils.ts";
 
 export default function TaskDetail() {
   const { id } = useParams<{ id: string }>();
+  usePageTitle(`Task #${id} \u2013 Brunel`);
   const [events, setEvents] = useState<LogEntry[]>([]);
   const [task, setTask] = useState<Task | null>(null);
 

--- a/frontend/src/pages/TaskList.tsx
+++ b/frontend/src/pages/TaskList.tsx
@@ -1,10 +1,12 @@
 import { useState, useEffect, useCallback } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import { useAdminWs } from "../hooks/useAdminWs.ts";
+import { usePageTitle } from "../hooks/usePageTitle.ts";
 import type { AdminMessage, Task, TaskStatus } from "../types.ts";
 import { shortWorkerId } from "../../../shared/utils.ts";
 
 export default function TaskList() {
+  usePageTitle("Tasks \u2013 Brunel");
   const [searchParams, setSearchParams] = useSearchParams();
   const statusFilter = (searchParams.get("status") ?? "all") as "all" | TaskStatus;
   const [tasks, setTasks] = useState<Task[]>([]);

--- a/frontend/src/pages/WorkerDetail.tsx
+++ b/frontend/src/pages/WorkerDetail.tsx
@@ -7,7 +7,7 @@ import { shortWorkerId } from "../../../shared/utils.ts";
 
 export default function WorkerDetail() {
   const { id } = useParams<{ id: string }>();
-  usePageTitle(`${id} \u2013 Brunel`);
+  usePageTitle(id ? `${shortWorkerId(id)} \u2013 Brunel` : "Brunel");
   const [messages, setMessages] = useState<LogEntry[]>([]);
   const [worker, setWorker] = useState<Worker | null>(null);
 

--- a/frontend/src/pages/WorkerDetail.tsx
+++ b/frontend/src/pages/WorkerDetail.tsx
@@ -1,11 +1,13 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams, Link } from "react-router-dom";
 import { useAdminWs } from "../hooks/useAdminWs.ts";
+import { usePageTitle } from "../hooks/usePageTitle.ts";
 import type { LogEntry, Worker, AdminMessage } from "../types.ts";
 import { shortWorkerId } from "../../../shared/utils.ts";
 
 export default function WorkerDetail() {
   const { id } = useParams<{ id: string }>();
+  usePageTitle(`${id} \u2013 Brunel`);
   const [messages, setMessages] = useState<LogEntry[]>([]);
   const [worker, setWorker] = useState<Worker | null>(null);
 

--- a/frontend/tests/EventLog.test.tsx
+++ b/frontend/tests/EventLog.test.tsx
@@ -48,6 +48,12 @@ describe("EventLog", () => {
     vi.restoreAllMocks();
   });
 
+  it("sets document.title to 'Events – Brunel'", () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([]) }));
+    renderEventLog();
+    expect(document.title).toBe("Events \u2013 Brunel");
+  });
+
   it("fetches from /api/log on mount", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([]) }));
     renderEventLog();

--- a/frontend/tests/RepoDetail.test.tsx
+++ b/frontend/tests/RepoDetail.test.tsx
@@ -69,6 +69,17 @@ describe("RepoDetail", () => {
     vi.restoreAllMocks();
   });
 
+  it("sets document.title to repo fullName when data loads", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn()
+        .mockResolvedValueOnce({ json: () => Promise.resolve(mockRepo) })
+        .mockResolvedValueOnce({ json: () => Promise.resolve([]) })
+    );
+    renderRepoDetail("5");
+    await waitFor(() => expect(document.title).toBe("user/my-repo \u2013 Brunel"));
+  });
+
   it("fetches repo and log on mount", async () => {
     vi.stubGlobal(
       "fetch",

--- a/frontend/tests/TaskDetail.test.tsx
+++ b/frontend/tests/TaskDetail.test.tsx
@@ -58,6 +58,12 @@ describe("TaskDetail", () => {
     vi.restoreAllMocks();
   });
 
+  it("sets document.title to 'Task #99 – Brunel'", () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([]) }));
+    renderTaskDetail("99");
+    expect(document.title).toBe("Task #99 \u2013 Brunel");
+  });
+
   it("fetches from /api/tasks/:id/events on mount", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([]) }));
     renderTaskDetail("99");

--- a/frontend/tests/TaskList.test.tsx
+++ b/frontend/tests/TaskList.test.tsx
@@ -42,6 +42,12 @@ describe("TaskList", () => {
     vi.restoreAllMocks();
   });
 
+  it("sets document.title to 'Tasks – Brunel'", () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([]) }));
+    renderTaskList();
+    expect(document.title).toBe("Tasks \u2013 Brunel");
+  });
+
   it("fetches tasks from /api/tasks on mount", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([]) }));
     renderTaskList();

--- a/frontend/tests/WorkerDetail.test.tsx
+++ b/frontend/tests/WorkerDetail.test.tsx
@@ -58,6 +58,12 @@ describe("WorkerDetail", () => {
     vi.restoreAllMocks();
   });
 
+  it("sets document.title to worker id", () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([]) }));
+    renderWorkerDetail("worker-abc-def-123");
+    expect(document.title).toBe("worker-abc-def-123 \u2013 Brunel");
+  });
+
   it("fetches from /api/workers/:id/messages on mount", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([]) }));
     renderWorkerDetail("worker-abc-def-123");

--- a/frontend/tests/WorkerDetail.test.tsx
+++ b/frontend/tests/WorkerDetail.test.tsx
@@ -58,10 +58,10 @@ describe("WorkerDetail", () => {
     vi.restoreAllMocks();
   });
 
-  it("sets document.title to worker id", () => {
+  it("sets document.title to short worker id", () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([]) }));
-    renderWorkerDetail("worker-abc-def-123");
-    expect(document.title).toBe("worker-abc-def-123 \u2013 Brunel");
+    renderWorkerDetail("justice-a9bdda00-1234-5678-abcd-ef0123456789");
+    expect(document.title).toBe("justice-a9bdda00 \u2013 Brunel");
   });
 
   it("fetches from /api/workers/:id/messages on mount", async () => {


### PR DESCRIPTION
## Summary

- Added a `usePageTitle` hook (`frontend/src/hooks/usePageTitle.ts`) that sets `document.title` and resets to "Brunel" on unmount
- Each dashboard page now calls the hook with its specific title:
  - Repo detail: `{full repo name} – Brunel` (updates after data loads)
  - Task detail: `Task #N – Brunel` (N from URL param, set immediately)
  - Worker detail: `{worker id} – Brunel` (set immediately)
  - All tasks (`/tasks`): `Tasks – Brunel`
  - Event log (`/log`): `Events – Brunel`
  - Main dashboard stays `Brunel` (no change)
- Tests added to each page's test file asserting the correct `document.title`

## Test plan

- [x] `cd frontend && npm test` — all 48 tests pass
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run lint` — no new errors

Closes #936