### PR TITLE
ci: fix supabase start flakiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
         with:
           version: latest
 
+      - run: npm ci
+
       - name: Start local Supabase
         run: supabase start
 
@@ -36,8 +38,6 @@ jobs:
             echo "SUPABASE_URL=http://127.0.0.1:54321"
             echo "SUPABASE_SERVICE_ROLE_KEY=${KEY}"
           } >> "$GITHUB_ENV"
-
-      - run: npm ci
 
       - run: npm test
         env:

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -19,3 +19,6 @@ site_url = "http://127.0.0.1:3000"
 [studio]
 enabled = true
 port = 54323
+
+[edge_runtime]
+enabled = false

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, waitFor } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { WebhookEvent } from "../src/foreman/models/webhook-event.js";
 import { ForemanMessage } from "../src/foreman/models/foreman-message.js";
 import { queryActivityLog } from "../src/foreman/models/activity-log.js";
@@ -36,7 +36,7 @@ describe("WebhookEvent.log", () => {
     });
 
     let data: Record<string, unknown>[] | null = null;
-    await waitFor(async () => {
+    await vi.waitFor(async () => {
       ({ data } = await supabase
         .from("webhook_events")
         .select("event_name, action, repo_id, sender, issue_number, task_id, payload")
@@ -84,7 +84,7 @@ describe("ForemanMessage.log", () => {
     });
 
     let data: Record<string, unknown>[] | null = null;
-    await waitFor(async () => {
+    await vi.waitFor(async () => {
       ({ data } = await supabase
         .from("foreman_messages")
         .select("direction, worker_id, task_id, msg_type")

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, waitFor } from "vitest";
 import { WebhookEvent } from "../src/foreman/models/webhook-event.js";
 import { ForemanMessage } from "../src/foreman/models/foreman-message.js";
 import { queryActivityLog } from "../src/foreman/models/activity-log.js";
@@ -35,14 +35,14 @@ describe("WebhookEvent.log", () => {
       payload: { foo: "bar" },
     });
 
-    // Fire-and-forget: give the insert a tick to land
-    await new Promise((r) => setTimeout(r, 50));
-
-    const { data } = await supabase
-      .from("webhook_events")
-      .select("event_name, action, repo_id, sender, issue_number, task_id, payload")
-      .eq("delivery_id", "abc");
-    expect(data).toHaveLength(1);
+    let data: Record<string, unknown>[] | null = null;
+    await waitFor(async () => {
+      ({ data } = await supabase
+        .from("webhook_events")
+        .select("event_name, action, repo_id, sender, issue_number, task_id, payload")
+        .eq("delivery_id", "abc"));
+      expect(data).toHaveLength(1);
+    });
     expect(data![0]).toMatchObject({
       event_name: "issues",
       action: "labeled",
@@ -83,13 +83,14 @@ describe("ForemanMessage.log", () => {
       payload: { type: "task_assigned" },
     });
 
-    await new Promise((r) => setTimeout(r, 50));
-
-    const { data } = await supabase
-      .from("foreman_messages")
-      .select("direction, worker_id, task_id, msg_type")
-      .eq("worker_id", "wid");
-    expect(data).toHaveLength(1);
+    let data: Record<string, unknown>[] | null = null;
+    await waitFor(async () => {
+      ({ data } = await supabase
+        .from("foreman_messages")
+        .select("direction, worker_id, task_id, msg_type")
+        .eq("worker_id", "wid"));
+      expect(data).toHaveLength(1);
+    });
     expect(data![0]).toMatchObject({
       direction: "sent",
       worker_id: "wid",


### PR DESCRIPTION
## Summary

- Disables the Supabase edge runtime in `config.toml` — it was starting up, failing its health check with a 502, and taking down the whole `supabase start`. The project has no Edge Functions so the service was running for nothing.
- Moves `npm ci` before `supabase start` in the CI workflow — defensive measure so that if Supabase infra ever flakes again, the always-run `npm run coverage` step won't cascade into a misleading `vitest: not found` error.

Root cause found by investigating the CI failure on PR #942 (a docs-only change).

## Test plan

- [ ] CI passes on this PR (especially the `test` job with `supabase start`)
- [ ] `npm run coverage` step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)