### PR TITLE
feat: add pagination to task/worker-scoped event log views

### DIFF
--- a/frontend/src/pages/TaskDetail.tsx
+++ b/frontend/src/pages/TaskDetail.tsx
@@ -1,26 +1,51 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useParams, Link } from "react-router-dom";
 import { useAdminWs } from "../hooks/useAdminWs.ts";
 import { usePageTitle } from "../hooks/usePageTitle.ts";
 import type { LogEntry, AdminMessage, Task } from "../types.ts";
 import { shortWorkerId } from "../../../shared/utils.ts";
 
+const PAGE_SIZE = 50;
+
 export default function TaskDetail() {
   const { id } = useParams<{ id: string }>();
   usePageTitle(`Task #${id} \u2013 Brunel`);
   const [events, setEvents] = useState<LogEntry[]>([]);
   const [task, setTask] = useState<Task | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  const fetchPage = useCallback(async (before?: string) => {
+    setLoading(true);
+    try {
+      const url = before
+        ? `/api/tasks/${id}/events?before=${encodeURIComponent(before)}`
+        : `/api/tasks/${id}/events`;
+      const data = await fetch(url).then((r) => r.json() as Promise<LogEntry[]>);
+      setEvents((prev) => {
+        const seen = new Set(prev.map((e) => `${e.kind}-${e.id}`));
+        const fresh = data.filter((e) => !seen.has(`${e.kind}-${e.id}`));
+        return [...prev, ...fresh];
+      });
+      setHasMore(data.length === PAGE_SIZE);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
 
   useEffect(() => {
     fetch(`/api/tasks/${id}`)
       .then((r) => r.json() as Promise<Task>)
       .then(setTask)
       .catch(console.error);
-    fetch(`/api/tasks/${id}/events`)
-      .then((r) => r.json() as Promise<LogEntry[]>)
-      .then(setEvents)
-      .catch(console.error);
   }, [id]);
+
+  useEffect(() => {
+    fetchPage();
+  }, [fetchPage]);
 
   const handleMessage = useCallback((msg: AdminMessage) => {
     if (msg.type === "snapshot") {
@@ -32,6 +57,23 @@ export default function TaskDetail() {
   }, [id]);
 
   useAdminWs(handleMessage);
+
+  const loadMore = useCallback(() => {
+    if (loading || !hasMore || events.length === 0) return;
+    fetchPage(events[events.length - 1].timestamp);
+  }, [loading, hasMore, events, fetchPage]);
+
+  useEffect(() => {
+    if (!hasMore || loading) return;
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => { if (entry.isIntersecting) loadMore(); },
+      { rootMargin: "0px 0px 200px 0px", threshold: 0 },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasMore, loading, loadMore]);
 
   return (
     <div>
@@ -64,7 +106,7 @@ export default function TaskDetail() {
         </section>
       )}
 
-      {events.length === 0 ? <p>No events for this task.</p> : (
+      {events.length === 0 && !loading ? <p>No events for this task.</p> : (
         <table style={{ width: "100%", borderCollapse: "collapse", fontFamily: "monospace", fontSize: "0.85em" }}>
           <thead>
             <tr>
@@ -86,6 +128,13 @@ export default function TaskDetail() {
           </tbody>
         </table>
       )}
+      {hasMore && (
+        <div ref={sentinelRef} style={{ padding: "8px", textAlign: "center" }}>
+          {loading
+            ? <span style={{ color: "#888", fontFamily: "monospace", fontSize: "0.85em" }}>Loading…</span>
+            : <button onClick={loadMore} style={loadMoreBtn}>Load more</button>}
+        </div>
+      )}
     </div>
   );
 }
@@ -94,3 +143,9 @@ const th: React.CSSProperties = { textAlign: "left", borderBottom: "1px solid #c
 const td: React.CSSProperties = { padding: "4px 8px", borderBottom: "1px solid #eee" };
 const blockerOpen: React.CSSProperties = { color: "#c00" };
 const blockerClosed: React.CSSProperties = { color: "#999", textDecoration: "line-through" };
+const loadMoreBtn: React.CSSProperties = {
+  padding: "4px 16px",
+  fontFamily: "monospace",
+  fontSize: "0.85em",
+  cursor: "pointer",
+};

--- a/frontend/src/pages/WorkerDetail.tsx
+++ b/frontend/src/pages/WorkerDetail.tsx
@@ -1,28 +1,52 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useParams, Link } from "react-router-dom";
 import { useAdminWs } from "../hooks/useAdminWs.ts";
 import { usePageTitle } from "../hooks/usePageTitle.ts";
 import type { LogEntry, Worker, AdminMessage } from "../types.ts";
 import { shortWorkerId } from "../../../shared/utils.ts";
 
+const PAGE_SIZE = 50;
+
 export default function WorkerDetail() {
   const { id } = useParams<{ id: string }>();
   usePageTitle(id ? `${shortWorkerId(id)} \u2013 Brunel` : "Brunel");
   const [messages, setMessages] = useState<LogEntry[]>([]);
   const [worker, setWorker] = useState<Worker | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  const fetchPage = useCallback(async (before?: string) => {
+    setLoading(true);
+    try {
+      const url = before
+        ? `/api/workers/${id}/messages?before=${encodeURIComponent(before)}`
+        : `/api/workers/${id}/messages`;
+      const data = await fetch(url).then((r) => r.json() as Promise<LogEntry[]>);
+      setMessages((prev) => {
+        const seen = new Set(prev.map((e) => `${e.kind}-${e.id}`));
+        const fresh = data.filter((e) => !seen.has(`${e.kind}-${e.id}`));
+        return [...prev, ...fresh];
+      });
+      setHasMore(data.length === PAGE_SIZE);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
 
   useEffect(() => {
-    fetch(`/api/workers/${id}/messages`)
-      .then((r) => r.json() as Promise<LogEntry[]>)
-      .then(setMessages)
-      .catch(console.error);
-
     // Fetch worker data from DB — works for disconnected workers too
     fetch(`/api/workers/${id}`)
       .then((r) => (r.ok ? (r.json() as Promise<Worker>) : Promise.resolve(null)))
       .then((data) => { if (data) setWorker(data); })
       .catch(console.error);
   }, [id]);
+
+  useEffect(() => {
+    fetchPage();
+  }, [fetchPage]);
 
   const handleMessage = useCallback((msg: AdminMessage) => {
     if (msg.type === "snapshot") {
@@ -34,6 +58,23 @@ export default function WorkerDetail() {
   }, [id]);
 
   useAdminWs(handleMessage);
+
+  const loadMore = useCallback(() => {
+    if (loading || !hasMore || messages.length === 0) return;
+    fetchPage(messages[messages.length - 1].timestamp);
+  }, [loading, hasMore, messages, fetchPage]);
+
+  useEffect(() => {
+    if (!hasMore || loading) return;
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => { if (entry.isIntersecting) loadMore(); },
+      { rootMargin: "0px 0px 200px 0px", threshold: 0 },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasMore, loading, loadMore]);
 
   return (
     <div>
@@ -54,7 +95,7 @@ export default function WorkerDetail() {
         </p>
       )}
 
-      {messages.length === 0 ? <p>No messages for this worker.</p> : (
+      {messages.length === 0 && !loading ? <p>No messages for this worker.</p> : (
         <table style={{ width: "100%", borderCollapse: "collapse", fontFamily: "monospace", fontSize: "0.85em" }}>
           <thead>
             <tr>
@@ -76,9 +117,22 @@ export default function WorkerDetail() {
           </tbody>
         </table>
       )}
+      {hasMore && (
+        <div ref={sentinelRef} style={{ padding: "8px", textAlign: "center" }}>
+          {loading
+            ? <span style={{ color: "#888", fontFamily: "monospace", fontSize: "0.85em" }}>Loading…</span>
+            : <button onClick={loadMore} style={loadMoreBtn}>Load more</button>}
+        </div>
+      )}
     </div>
   );
 }
 
 const th: React.CSSProperties = { textAlign: "left", borderBottom: "1px solid #ccc", padding: "4px 8px" };
 const td: React.CSSProperties = { padding: "4px 8px", borderBottom: "1px solid #eee" };
+const loadMoreBtn: React.CSSProperties = {
+  padding: "4px 16px",
+  fontFamily: "monospace",
+  fontSize: "0.85em",
+  cursor: "pointer",
+};

--- a/frontend/tests/TaskDetail.test.tsx
+++ b/frontend/tests/TaskDetail.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, act } from "@testing-library/react";
+import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import TaskDetail from "../src/pages/TaskDetail.tsx";
@@ -126,5 +126,92 @@ describe("TaskDetail", () => {
     });
 
     expect(screen.getAllByRole("row")).toHaveLength(2); // header + 1 only
+  });
+
+  it("shows load-more button when first page is full (PAGE_SIZE entries)", async () => {
+    const PAGE_SIZE = 50;
+    const fullPage: LogEntry[] = Array.from({ length: PAGE_SIZE }, (_, i) => ({
+      kind: "webhook",
+      id: i + 1,
+      timestamp: new Date(Date.now() - i * 1000).toISOString(),
+      taskId: "99",
+      workerId: null,
+      summary: `event-${i}`,
+    }));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve(fullPage) }));
+    renderTaskDetail("99");
+    await waitFor(() => expect(screen.getByRole("button", { name: "Load more" })).toBeInTheDocument());
+  });
+
+  it("does not show load-more button when first page is partial", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([event1, event2]) }));
+    renderTaskDetail("99");
+    await waitFor(() => expect(screen.getByText("issue labeled")).toBeInTheDocument());
+    expect(screen.queryByRole("button", { name: "Load more" })).not.toBeInTheDocument();
+  });
+
+  it("clicking load-more fetches next page with before cursor", async () => {
+    const PAGE_SIZE = 50;
+    const firstPage: LogEntry[] = Array.from({ length: PAGE_SIZE }, (_, i) => ({
+      kind: "webhook",
+      id: i + 1,
+      timestamp: new Date(Date.now() - i * 1000).toISOString(),
+      taskId: "99",
+      workerId: null,
+      summary: `event-${i}`,
+    }));
+    const secondPage: LogEntry[] = [
+      { kind: "webhook", id: PAGE_SIZE + 1, timestamp: new Date(Date.now() - PAGE_SIZE * 1000).toISOString(), taskId: "99", workerId: null, summary: "older-event" },
+    ];
+    const expectedCursor = firstPage[firstPage.length - 1].timestamp;
+
+    vi.stubGlobal("fetch", vi.fn().mockImplementation((url: string) => {
+      if (String(url).includes("before")) {
+        return Promise.resolve({ json: () => Promise.resolve(secondPage) });
+      }
+      return Promise.resolve({ json: () => Promise.resolve(firstPage) });
+    }));
+
+    renderTaskDetail("99");
+    const btn = await screen.findByRole("button", { name: "Load more" });
+
+    act(() => { fireEvent.click(btn); });
+
+    await waitFor(() => expect(screen.getByText("older-event")).toBeInTheDocument());
+    expect(fetch).toHaveBeenCalledWith(
+      `/api/tasks/99/events?before=${encodeURIComponent(expectedCursor)}`
+    );
+  });
+
+  it("appends second page entries after first page", async () => {
+    const PAGE_SIZE = 50;
+    const firstPage: LogEntry[] = Array.from({ length: PAGE_SIZE }, (_, i) => ({
+      kind: "webhook",
+      id: i + 1,
+      timestamp: new Date(Date.now() - i * 1000).toISOString(),
+      taskId: "99",
+      workerId: null,
+      summary: `event-${i}`,
+    }));
+    const secondPage: LogEntry[] = [
+      { kind: "webhook", id: PAGE_SIZE + 1, timestamp: new Date(Date.now() - PAGE_SIZE * 1000).toISOString(), taskId: "99", workerId: null, summary: "page-two-event" },
+    ];
+
+    vi.stubGlobal("fetch", vi.fn().mockImplementation((url: string) => {
+      if (String(url).includes("before")) {
+        return Promise.resolve({ json: () => Promise.resolve(secondPage) });
+      }
+      return Promise.resolve({ json: () => Promise.resolve(firstPage) });
+    }));
+
+    renderTaskDetail("99");
+    const btn = await screen.findByRole("button", { name: "Load more" });
+    act(() => { fireEvent.click(btn); });
+
+    await waitFor(() => expect(screen.getByText("page-two-event")).toBeInTheDocument());
+    // All first-page entries still present
+    expect(screen.getByText("event-0")).toBeInTheDocument();
+    // Load-more gone after partial second page
+    expect(screen.queryByRole("button", { name: "Load more" })).not.toBeInTheDocument();
   });
 });

--- a/frontend/tests/WorkerDetail.test.tsx
+++ b/frontend/tests/WorkerDetail.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, act } from "@testing-library/react";
+import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import WorkerDetail from "../src/pages/WorkerDetail.tsx";
@@ -131,5 +131,90 @@ describe("WorkerDetail", () => {
     });
 
     expect(screen.getAllByRole("row")).toHaveLength(2); // header + 1 only
+  });
+
+  it("shows load-more button when first page is full (PAGE_SIZE messages)", async () => {
+    const PAGE_SIZE = 50;
+    const fullPage: LogEntry[] = Array.from({ length: PAGE_SIZE }, (_, i) => ({
+      kind: "message",
+      id: i + 1,
+      timestamp: new Date(Date.now() - i * 1000).toISOString(),
+      taskId: null,
+      workerId: "worker-abc-def-123",
+      summary: `msg-${i}`,
+    }));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve(fullPage) }));
+    renderWorkerDetail("worker-abc-def-123");
+    await waitFor(() => expect(screen.getByRole("button", { name: "Load more" })).toBeInTheDocument());
+  });
+
+  it("does not show load-more button when first page is partial", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: () => Promise.resolve([msg1, msg2]) }));
+    renderWorkerDetail("worker-abc-def-123");
+    await waitFor(() => expect(screen.getByText("→ assign task 42")).toBeInTheDocument());
+    expect(screen.queryByRole("button", { name: "Load more" })).not.toBeInTheDocument();
+  });
+
+  it("clicking load-more fetches next page with before cursor", async () => {
+    const PAGE_SIZE = 50;
+    const firstPage: LogEntry[] = Array.from({ length: PAGE_SIZE }, (_, i) => ({
+      kind: "message",
+      id: i + 1,
+      timestamp: new Date(Date.now() - i * 1000).toISOString(),
+      taskId: null,
+      workerId: "worker-abc-def-123",
+      summary: `msg-${i}`,
+    }));
+    const secondPage: LogEntry[] = [
+      { kind: "message", id: PAGE_SIZE + 1, timestamp: new Date(Date.now() - PAGE_SIZE * 1000).toISOString(), taskId: null, workerId: "worker-abc-def-123", summary: "older-msg" },
+    ];
+    const expectedCursor = firstPage[firstPage.length - 1].timestamp;
+
+    vi.stubGlobal("fetch", vi.fn().mockImplementation((url: string) => {
+      if (String(url).includes("before")) {
+        return Promise.resolve({ json: () => Promise.resolve(secondPage) });
+      }
+      return Promise.resolve({ json: () => Promise.resolve(firstPage) });
+    }));
+
+    renderWorkerDetail("worker-abc-def-123");
+    const btn = await screen.findByRole("button", { name: "Load more" });
+
+    act(() => { fireEvent.click(btn); });
+
+    await waitFor(() => expect(screen.getByText("older-msg")).toBeInTheDocument());
+    expect(fetch).toHaveBeenCalledWith(
+      `/api/workers/worker-abc-def-123/messages?before=${encodeURIComponent(expectedCursor)}`
+    );
+  });
+
+  it("appends second page entries after first page", async () => {
+    const PAGE_SIZE = 50;
+    const firstPage: LogEntry[] = Array.from({ length: PAGE_SIZE }, (_, i) => ({
+      kind: "message",
+      id: i + 1,
+      timestamp: new Date(Date.now() - i * 1000).toISOString(),
+      taskId: null,
+      workerId: "worker-abc-def-123",
+      summary: `msg-${i}`,
+    }));
+    const secondPage: LogEntry[] = [
+      { kind: "message", id: PAGE_SIZE + 1, timestamp: new Date(Date.now() - PAGE_SIZE * 1000).toISOString(), taskId: null, workerId: "worker-abc-def-123", summary: "page-two-msg" },
+    ];
+
+    vi.stubGlobal("fetch", vi.fn().mockImplementation((url: string) => {
+      if (String(url).includes("before")) {
+        return Promise.resolve({ json: () => Promise.resolve(secondPage) });
+      }
+      return Promise.resolve({ json: () => Promise.resolve(firstPage) });
+    }));
+
+    renderWorkerDetail("worker-abc-def-123");
+    const btn = await screen.findByRole("button", { name: "Load more" });
+    act(() => { fireEvent.click(btn); });
+
+    await waitFor(() => expect(screen.getByText("page-two-msg")).toBeInTheDocument());
+    expect(screen.getByText("msg-0")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Load more" })).not.toBeInTheDocument();
   });
 });

--- a/src/foreman/controllers/http-server.ts
+++ b/src/foreman/controllers/http-server.ts
@@ -87,7 +87,8 @@ export class HttpServer {
   app.get("/api/tasks/:id/events", async (c) => {
     try {
       const taskId = c.req.param("id");
-      const entries = await queryActivityLog({ taskId });
+      const before = c.req.query("before");
+      const entries = await queryActivityLog({ taskId, limit: 50, ...(before ? { before } : {}) });
       return c.json(entries);
     } catch (err) {
       log(`ERROR API query failed: ${fmtError(err)}`);
@@ -110,7 +111,8 @@ export class HttpServer {
   app.get("/api/workers/:id/messages", async (c) => {
     try {
       const workerId = c.req.param("id");
-      const entries = await queryActivityLog({ workerId });
+      const before = c.req.query("before");
+      const entries = await queryActivityLog({ workerId, limit: 50, ...(before ? { before } : {}) });
       return c.json(entries);
     } catch (err) {
       log(`ERROR API query failed: ${fmtError(err)}`);
@@ -156,7 +158,8 @@ export class HttpServer {
   app.get("/api/repos/:id/log", async (c) => {
     try {
       const repoId = Number(c.req.param("id"));
-      const entries = await queryActivityLog({ repoId });
+      const before = c.req.query("before");
+      const entries = await queryActivityLog({ repoId, limit: 50, ...(before ? { before } : {}) });
       return c.json(entries);
     } catch (err) {
       log(`ERROR API query failed: ${fmtError(err)}`);

--- a/src/foreman/models/activity-log.ts
+++ b/src/foreman/models/activity-log.ts
@@ -21,18 +21,18 @@ export async function queryActivityLog(opts: QueryActivityLogOpts = {}): Promise
 
   if (opts.taskId) {
     [webhooks, messages] = await Promise.all([
-      WebhookEvent.queryForTask(opts.taskId),
-      ForemanMessage.queryForTask(opts.taskId),
+      WebhookEvent.queryForTask(opts.taskId, { limit, before: opts.before }),
+      ForemanMessage.queryForTask(opts.taskId, { limit, before: opts.before }),
     ]);
   } else if (opts.workerId) {
     [webhooks, messages] = await Promise.all([
-      WebhookEvent.queryForWorker(opts.workerId),
-      ForemanMessage.queryForWorker(opts.workerId),
+      WebhookEvent.queryForWorker(opts.workerId, { limit, before: opts.before }),
+      ForemanMessage.queryForWorker(opts.workerId, { limit, before: opts.before }),
     ]);
   } else if (opts.repoId != null) {
     [webhooks, messages] = await Promise.all([
-      WebhookEvent.queryForRepo(opts.repoId),
-      ForemanMessage.queryForRepo(opts.repoId),
+      WebhookEvent.queryForRepo(opts.repoId, { limit, before: opts.before }),
+      ForemanMessage.queryForRepo(opts.repoId, { limit, before: opts.before }),
     ]);
   } else {
     [webhooks, messages] = await Promise.all([

--- a/src/foreman/models/foreman-message.ts
+++ b/src/foreman/models/foreman-message.ts
@@ -54,27 +54,30 @@ export class ForemanMessage extends ActiveRecord {
 
   // ── Queries ──────────────────────────────────────────────────────────────────
 
-  static async queryForTask(taskId: string): Promise<ForemanMessage[]> {
-    const { data } = await ForemanMessage.select()
+  static async queryForTask(taskId: string, opts: { limit?: number; before?: string } = {}): Promise<ForemanMessage[]> {
+    let query = ForemanMessage.select()
       .eq("task_id", taskId)
-      .order("created_at", { ascending: false })
-      .limit(500);
+      .order("created_at", { ascending: false });
+    if (opts.before) query = query.lt("created_at", opts.before);
+    const { data } = await query.limit(opts.limit ?? 500);
     return (data ?? []).map((r: DbRow) => new ForemanMessage(r));
   }
 
-  static async queryForWorker(workerId: string): Promise<ForemanMessage[]> {
-    const { data } = await ForemanMessage.select()
+  static async queryForWorker(workerId: string, opts: { limit?: number; before?: string } = {}): Promise<ForemanMessage[]> {
+    let query = ForemanMessage.select()
       .eq("worker_id", workerId)
-      .order("created_at", { ascending: false })
-      .limit(500);
+      .order("created_at", { ascending: false });
+    if (opts.before) query = query.lt("created_at", opts.before);
+    const { data } = await query.limit(opts.limit ?? 500);
     return (data ?? []).map((r: DbRow) => new ForemanMessage(r));
   }
 
-  static async queryForRepo(repoId: number): Promise<ForemanMessage[]> {
-    const { data } = await ForemanMessage.select()
+  static async queryForRepo(repoId: number, opts: { limit?: number; before?: string } = {}): Promise<ForemanMessage[]> {
+    let query = ForemanMessage.select()
       .eq("repo_id", repoId)
-      .order("created_at", { ascending: false })
-      .limit(500);
+      .order("created_at", { ascending: false });
+    if (opts.before) query = query.lt("created_at", opts.before);
+    const { data } = await query.limit(opts.limit ?? 500);
     return (data ?? []).map((r: DbRow) => new ForemanMessage(r));
   }
 

--- a/src/foreman/models/webhook-event.ts
+++ b/src/foreman/models/webhook-event.ts
@@ -105,27 +105,30 @@ export class WebhookEvent extends ActiveRecord {
 
   // ── Queries ──────────────────────────────────────────────────────────────────
 
-  static async queryForTask(taskId: string): Promise<WebhookEvent[]> {
-    const { data } = await WebhookEvent.select()
+  static async queryForTask(taskId: string, opts: { limit?: number; before?: string } = {}): Promise<WebhookEvent[]> {
+    let query = WebhookEvent.select()
       .eq("task_id", taskId)
-      .order("received_at", { ascending: false })
-      .limit(500);
+      .order("received_at", { ascending: false });
+    if (opts.before) query = query.lt("received_at", opts.before);
+    const { data } = await query.limit(opts.limit ?? 500);
     return (data ?? []).map((r: Row) => new WebhookEvent(r));
   }
 
-  static async queryForWorker(workerId: string): Promise<WebhookEvent[]> {
-    const { data } = await WebhookEvent.select()
+  static async queryForWorker(workerId: string, opts: { limit?: number; before?: string } = {}): Promise<WebhookEvent[]> {
+    let query = WebhookEvent.select()
       .eq("worker_id", workerId)
-      .order("received_at", { ascending: false })
-      .limit(500);
+      .order("received_at", { ascending: false });
+    if (opts.before) query = query.lt("received_at", opts.before);
+    const { data } = await query.limit(opts.limit ?? 500);
     return (data ?? []).map((r: Row) => new WebhookEvent(r));
   }
 
-  static async queryForRepo(repoId: number): Promise<WebhookEvent[]> {
-    const { data } = await WebhookEvent.select()
+  static async queryForRepo(repoId: number, opts: { limit?: number; before?: string } = {}): Promise<WebhookEvent[]> {
+    let query = WebhookEvent.select()
       .eq("repo_id", repoId)
-      .order("received_at", { ascending: false })
-      .limit(500);
+      .order("received_at", { ascending: false });
+    if (opts.before) query = query.lt("received_at", opts.before);
+    const { data } = await query.limit(opts.limit ?? 500);
     return (data ?? []).map((r: Row) => new WebhookEvent(r));
   }
 

--- a/tests/browser/task-detail.spec.ts
+++ b/tests/browser/task-detail.spec.ts
@@ -7,6 +7,17 @@
  */
 import { test, expect } from "@playwright/test";
 
+function makeTaskEvents(startId: number, count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    kind: "webhook",
+    id: startId + i,
+    timestamp: new Date(Date.now() - (startId + i) * 1000).toISOString(),
+    taskId: "pg-task",
+    workerId: null,
+    summary: `task-event-${startId + i}`,
+  }));
+}
+
 const BASE = "http://localhost:14567";
 
 async function postWebhook(name: string, payload: object): Promise<void> {
@@ -92,4 +103,53 @@ test("task detail page: live events appear as webhooks arrive for that task", as
   // fmtEvent for issue_comment/created with body "LGTM":
   // "issue_comment/created — "LGTM""
   await expect(page.getByText(/issue_comment\/created/).first()).toBeVisible();
+});
+
+test("task detail: appends next page and removes load-more after last page", async ({ page }) => {
+  const PAGE_SIZE = 50;
+
+  await page.route("**/api/tasks/pg-task/events**", async (route) => {
+    const url = new URL(route.request().url());
+    await route.fulfill({
+      json: url.searchParams.has("before")
+        ? makeTaskEvents(PAGE_SIZE, 5)
+        : makeTaskEvents(0, PAGE_SIZE),
+    });
+  });
+  await page.route("**/api/tasks/pg-task", async (route) => {
+    await route.fulfill({ json: { taskId: "pg-task", title: "Pagination test task", status: "pending" } });
+  });
+
+  await page.goto("/tasks/pg-task");
+  await expect(page.getByText("task-event-0")).toBeVisible();
+
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+  await expect(page.getByText(`task-event-${PAGE_SIZE}`)).toBeVisible();
+  await expect(page.getByRole("button", { name: "Load more" })).not.toBeVisible();
+});
+
+test("task detail: passes before cursor from last entry of current page", async ({ page }) => {
+  const PAGE_SIZE = 50;
+  const firstPage = makeTaskEvents(0, PAGE_SIZE);
+  const expectedCursor = firstPage[firstPage.length - 1].timestamp;
+
+  let capturedBefore: string | null = null;
+  await page.route("**/api/tasks/pg-task/events**", async (route) => {
+    const url = new URL(route.request().url());
+    const before = url.searchParams.get("before");
+    if (before) capturedBefore = before;
+    await route.fulfill({ json: before ? makeTaskEvents(PAGE_SIZE, 3) : firstPage });
+  });
+  await page.route("**/api/tasks/pg-task", async (route) => {
+    await route.fulfill({ json: { taskId: "pg-task", title: "Pagination test task", status: "pending" } });
+  });
+
+  await page.goto("/tasks/pg-task");
+  await expect(page.getByText("task-event-0")).toBeVisible();
+
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+  await expect(page.getByText(`task-event-${PAGE_SIZE}`)).toBeVisible();
+  expect(capturedBefore).toBe(expectedCursor);
 });

--- a/tests/browser/worker-detail.spec.ts
+++ b/tests/browser/worker-detail.spec.ts
@@ -7,6 +7,17 @@
  */
 import { test, expect } from "@playwright/test";
 
+function makeWorkerMessages(startId: number, count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    kind: "message",
+    id: startId + i,
+    timestamp: new Date(Date.now() - (startId + i) * 1000).toISOString(),
+    taskId: null,
+    workerId: "pg-worker",
+    summary: `worker-msg-${startId + i}`,
+  }));
+}
+
 const BASE = "http://localhost:14567";
 
 async function connectWorker(): Promise<string> {
@@ -68,4 +79,53 @@ test("worker detail page: live messages appear when the worker disconnects", asy
 
   // The disconnect entry should appear live without a page reload
   await expect(page.getByRole("cell", { name: /disconnected/ })).toBeVisible();
+});
+
+test("worker detail: appends next page and removes load-more after last page", async ({ page }) => {
+  const PAGE_SIZE = 50;
+
+  await page.route("**/api/workers/pg-worker/messages**", async (route) => {
+    const url = new URL(route.request().url());
+    await route.fulfill({
+      json: url.searchParams.has("before")
+        ? makeWorkerMessages(PAGE_SIZE, 5)
+        : makeWorkerMessages(0, PAGE_SIZE),
+    });
+  });
+  await page.route("**/api/workers/pg-worker", async (route) => {
+    await route.fulfill({ json: { workerId: "pg-worker", status: "idle" } });
+  });
+
+  await page.goto("/workers/pg-worker");
+  await expect(page.getByText("worker-msg-0")).toBeVisible();
+
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+  await expect(page.getByText(`worker-msg-${PAGE_SIZE}`)).toBeVisible();
+  await expect(page.getByRole("button", { name: "Load more" })).not.toBeVisible();
+});
+
+test("worker detail: passes before cursor from last entry of current page", async ({ page }) => {
+  const PAGE_SIZE = 50;
+  const firstPage = makeWorkerMessages(0, PAGE_SIZE);
+  const expectedCursor = firstPage[firstPage.length - 1].timestamp;
+
+  let capturedBefore: string | null = null;
+  await page.route("**/api/workers/pg-worker/messages**", async (route) => {
+    const url = new URL(route.request().url());
+    const before = url.searchParams.get("before");
+    if (before) capturedBefore = before;
+    await route.fulfill({ json: before ? makeWorkerMessages(PAGE_SIZE, 3) : firstPage });
+  });
+  await page.route("**/api/workers/pg-worker", async (route) => {
+    await route.fulfill({ json: { workerId: "pg-worker", status: "idle" } });
+  });
+
+  await page.goto("/workers/pg-worker");
+  await expect(page.getByText("worker-msg-0")).toBeVisible();
+
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+  await expect(page.getByText(`worker-msg-${PAGE_SIZE}`)).toBeVisible();
+  expect(capturedBefore).toBe(expectedCursor);
 });

--- a/tests/foreman.http.test.ts
+++ b/tests/foreman.http.test.ts
@@ -199,13 +199,21 @@ describe("GET /api/tasks/:id/events", () => {
     expect(JSON.parse(res.body)).toEqual([]);
   });
 
-  it("returns task events from queryActivityLog", async () => {
+  it("returns task events from queryActivityLog with limit 50", async () => {
     const entries = [{ id: 1, taskId: "42" }];
     vi.mocked(queryActivityLog).mockResolvedValue(entries as never);
     const res = await request(port, "GET", "/api/tasks/42/events");
     expect(res.status).toBe(200);
     expect(JSON.parse(res.body)).toEqual(entries);
-    expect(queryActivityLog).toHaveBeenCalledWith({ taskId: "42" });
+    expect(queryActivityLog).toHaveBeenCalledWith({ taskId: "42", limit: 50 });
+  });
+
+  it("passes before cursor to queryActivityLog for task events when provided", async () => {
+    const before = "2024-06-01T12:00:00.000Z";
+    vi.mocked(queryActivityLog).mockResolvedValue([]);
+    const res = await request(port, "GET", `/api/tasks/42/events?before=${encodeURIComponent(before)}`);
+    expect(res.status).toBe(200);
+    expect(queryActivityLog).toHaveBeenCalledWith({ taskId: "42", limit: 50, before });
   });
 });
 
@@ -216,13 +224,21 @@ describe("GET /api/workers/:id/messages", () => {
     expect(JSON.parse(res.body)).toEqual([]);
   });
 
-  it("returns worker messages from queryActivityLog", async () => {
+  it("returns worker messages from queryActivityLog with limit 50", async () => {
     const entries = [{ id: 1, workerId: "w1" }];
     vi.mocked(queryActivityLog).mockResolvedValue(entries as never);
     const res = await request(port, "GET", "/api/workers/w1/messages");
     expect(res.status).toBe(200);
     expect(JSON.parse(res.body)).toEqual(entries);
-    expect(queryActivityLog).toHaveBeenCalledWith({ workerId: "w1" });
+    expect(queryActivityLog).toHaveBeenCalledWith({ workerId: "w1", limit: 50 });
+  });
+
+  it("passes before cursor to queryActivityLog for worker messages when provided", async () => {
+    const before = "2024-06-01T12:00:00.000Z";
+    vi.mocked(queryActivityLog).mockResolvedValue([]);
+    const res = await request(port, "GET", `/api/workers/w1/messages?before=${encodeURIComponent(before)}`);
+    expect(res.status).toBe(200);
+    expect(queryActivityLog).toHaveBeenCalledWith({ workerId: "w1", limit: 50, before });
   });
 });
 


### PR DESCRIPTION
## Summary

- Threads `before` cursor and `limit: 50` through `queryActivityLog`'s filtered branches (taskId, workerId, repoId) and the corresponding HTTP endpoints (`/api/tasks/:id/events`, `/api/workers/:id/messages`, `/api/repos/:id/log`)
- Adds load-more sentinel + button to `TaskDetail` and `WorkerDetail`, matching the existing `EventLog` pagination pattern (IntersectionObserver auto-fires; button as fallback)
- Adds tests: HTTP unit tests for `before` cursor on filtered endpoints; frontend unit tests for load-more affordance; Playwright browser tests for both detail pages

## Test plan

- [ ] `npm test` — all non-DB unit tests pass
- [ ] `cd frontend && npm test` — all 56 component tests pass including new pagination tests
- [ ] `npx tsc --noEmit` — no type errors
- [ ] `npm run test:browser` — Playwright tests for task-detail and worker-detail pagination (requires `npm run build` first)
- [ ] Navigate to a task/worker with many events in the UI and verify load-more appears and appends entries

Closes #941

🤖 Generated with [Claude Code](https://claude.com/claude-code)