### PR TITLE
feat: prompt user for next action after task completion

### DIFF
--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -311,10 +311,12 @@ export class WorkerController extends EventEmitter {
   }
 
   /**
-   * Complete the current task: call afterTask hook, send task_complete, reset state.
-   * Returns 'task-complete' if a task was active, undefined if no task was assigned.
+   * Complete the current task: call afterTask hook, send task_complete, reset state,
+   * then prompt the user for what to do next.
+   * Returns 'task-complete' if the worker should remain (or become) idle,
+   * 'exit' if the user chose to quit, or undefined if no task was assigned.
    */
-  async completeCurrentTask(): Promise<"task-complete" | undefined> {
+  async completeCurrentTask(): Promise<"task-complete" | "exit" | undefined> {
     if (!this.currentTaskId) return undefined;
     if (this._activeAfterTask) {
       try { await this._activeAfterTask(); } catch (err) {
@@ -339,8 +341,44 @@ export class WorkerController extends EventEmitter {
     this.agentStatus.resetTaskStats();
     this.agentStatus.update({ taskNumber: undefined, prNumber: undefined });
     await this.agentStatus.refreshBranch();
-    this.display.print(c.sageGreen("Waiting for next task..."));
-    return "task-complete";
+    return this.promptAfterTaskComplete();
+  }
+
+  /**
+   * After completing a task, prompt the user for what to do next.
+   * Falls back to "wait for next task" silently when no picker is available
+   * (e.g. non-interactive environments or tests that don't inject a pickFn).
+   */
+  private async promptAfterTaskComplete(): Promise<"task-complete" | "exit"> {
+    const pickFn = this.options?.pickFn ?? (this.picker ? (opts: string[]) => this.picker!.pick(opts) : null);
+
+    if (!pickFn) {
+      this.display.print(c.sageGreen("Waiting for next task..."));
+      return "task-complete";
+    }
+
+    const idx = await pickFn([
+      "Wait to be assigned the next task",
+      "Choose a specific task to work on",
+      "Stop working for now",
+      "Quit and exit",
+    ]);
+
+    switch (idx) {
+      case 1:
+        await this.stop();
+        this.display.print(c.sageGreen("To claim a specific task, use /worker:claim <taskId>."));
+        return "task-complete";
+      case 2:
+        await this.stop();
+        return "task-complete";
+      case 3:
+        await this.stop();
+        return "exit";
+      default:
+        this.display.print(c.sageGreen("Waiting for next task..."));
+        return "task-complete";
+    }
   }
 
   // ── Lifecycle ─────────────────────────────────────────────────────────────

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1604,6 +1604,93 @@ describe("afterTask callback on /worker:complete", () => {
   });
 });
 
+// ── completeCurrentTask: post-completion prompt ───────────────────────────────
+
+describe("completeCurrentTask: post-completion prompt", () => {
+  async function makeSession(pickFn: (opts: string[]) => Promise<number>) {
+    const ws = new FakeWs();
+    const sess = new WorkerController(sb, display, undefined, undefined, "owner/repo", {
+      wsFactory: vi.fn().mockReturnValue(ws),
+      pickFn,
+    });
+    await sess.start();
+    sendMsg(ws, { type: "task_assigned", taskId: "t-pick", issue: makeIssue(77) });
+    sess.takeNextPrompt();
+    return { sess, ws };
+  }
+
+  it("with no picker and no pickFn: defaults to waiting for next task, stays active, returns 'task-complete'", async () => {
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "t-nopick", issue: makeIssue(5) });
+    session.takeNextPrompt();
+    const result = await session.completeCurrentTask();
+    expect(result).toBe("task-complete");
+    expect(session.isActive).toBe(true);
+    const printed = display.print.mock.calls.map(([l]: [string]) => stripAnsi(l));
+    expect(printed.some(l => l.includes("Waiting for next task"))).toBe(true);
+  });
+
+  it("option 0 (wait for next task): stays active and returns 'task-complete'", async () => {
+    const { sess } = await makeSession(async () => 0);
+    const result = await sess.completeCurrentTask();
+    expect(result).toBe("task-complete");
+    expect(sess.isActive).toBe(true);
+  });
+
+  it("option 0 (wait for next task): prints 'Waiting for next task'", async () => {
+    const { sess } = await makeSession(async () => 0);
+    await sess.completeCurrentTask();
+    const printed = display.print.mock.calls.map(([l]: [string]) => stripAnsi(l));
+    expect(printed.some(l => l.includes("Waiting for next task"))).toBe(true);
+  });
+
+  it("option 1 (choose specific task): stops worker mode and returns 'task-complete'", async () => {
+    const { sess } = await makeSession(async () => 1);
+    const result = await sess.completeCurrentTask();
+    expect(result).toBe("task-complete");
+    expect(sess.isActive).toBe(false);
+  });
+
+  it("option 1 (choose specific task): prints message about /worker:claim", async () => {
+    const { sess } = await makeSession(async () => 1);
+    await sess.completeCurrentTask();
+    const printed = display.print.mock.calls.map(([l]: [string]) => stripAnsi(l));
+    expect(printed.some(l => l.includes("/worker:claim"))).toBe(true);
+  });
+
+  it("option 2 (stop working): stops worker mode and returns 'task-complete'", async () => {
+    const { sess } = await makeSession(async () => 2);
+    const result = await sess.completeCurrentTask();
+    expect(result).toBe("task-complete");
+    expect(sess.isActive).toBe(false);
+  });
+
+  it("option 2 (stop working): does not print /worker:claim message", async () => {
+    const { sess } = await makeSession(async () => 2);
+    await sess.completeCurrentTask();
+    const printed = display.print.mock.calls.map(([l]: [string]) => stripAnsi(l));
+    expect(printed.some(l => l.includes("/worker:claim"))).toBe(false);
+  });
+
+  it("option 3 (quit and exit): stops worker mode and returns 'exit'", async () => {
+    const { sess } = await makeSession(async () => 3);
+    const result = await sess.completeCurrentTask();
+    expect(result).toBe("exit");
+    expect(sess.isActive).toBe(false);
+  });
+
+  it("picker is called with the four expected option labels", async () => {
+    const mockPick = vi.fn().mockResolvedValue(0);
+    const { sess } = await makeSession(mockPick);
+    await sess.completeCurrentTask();
+    expect(mockPick).toHaveBeenCalledWith([
+      expect.stringContaining("Wait"),
+      expect.stringContaining("specific task"),
+      expect.stringContaining("Stop working"),
+      expect.stringContaining("Quit"),
+    ]);
+  });
+});
+
 // ── sendGoodbye ───────────────────────────────────────────────────────────────
 
 describe("sendGoodbye", () => {


### PR DESCRIPTION
## Summary

- After `/worker:complete`, show an arrow-key picker instead of automatically going idle
- Four options: wait for next task, choose a specific task (with `/worker:claim` hint), stop working, or quit and exit
- Falls back silently to the original "wait for next task" behavior when no picker is available (non-interactive environments)

## Test plan

- [x] Unit tests for all four picker options added to `tests/worker.test.ts`
- [x] Test for no-picker fallback (backward compatibility)
- [x] Test that picker receives the four expected option labels
- [x] All 157 existing + new tests pass
- [x] TypeScript type check clean (`npx tsc --noEmit`)
- [x] ESLint clean (no new warnings)

Closes #948

🤖 Generated with [Claude Code](https://claude.com/claude-code)