### PR TITLE
feat: print message when stall retries are exhausted

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -250,7 +250,11 @@ export class BrunelAgent {
           if (workerController.isActive) {
             this.agentStatus.addQueryStats(stats.inputTokens, stats.outputTokens, stats.costUsd);
           }
-          return stallRetry ? false : !ac.signal.aborted;
+          if (stallRetry) {
+            this.display.print(c.amber(`\n⚠ Connection stalled — giving up after ${MAX_STALL_RETRIES} retries. Please try again.`));
+            return false;
+          }
+          return !ac.signal.aborted;
         } catch (err) {
           console.error(c.boldRed(`\nERROR: ${fmtError(err)}`));
           logFull("ERROR", err instanceof Error ? { message: err.message, stack: err.stack } : err);

--- a/tests/worker.main.test.ts
+++ b/tests/worker.main.test.ts
@@ -502,3 +502,56 @@ describe("workerMain input cancel discipline", () => {
     if (agentError) throw agentError;
   });
 });
+
+describe("workerMain stall retry exhaustion", () => {
+  let chdirSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    makeMockInput();
+    chdirSpy = vi.spyOn(process, "chdir").mockImplementation(() => {});
+    vi.mocked(confirmIfUnsafe).mockResolvedValue(true);
+    fakeWorkspace.isCreated = false;
+    vi.mocked(fakeWorkspace.destroy).mockResolvedValue(undefined);
+    vi.mocked(fakeWorkspace.checkSafety).mockResolvedValue({ uncommittedFiles: [], unpushedCommits: [], noUpstream: false });
+    vi.mocked(fakeWorkspace.create).mockImplementation(async () => { fakeWorkspace.isCreated = true; });
+  });
+
+  afterEach(() => {
+    chdirSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it("prints a 'giving up' message when all stall retries are exhausted", async () => {
+    // ask: first call returns a prompt, second call exits
+    let askCallCount = 0;
+    mockInput.ask.mockImplementation(() => {
+      askCallCount++;
+      if (askCallCount === 1) return Promise.resolve("do some work");
+      return Promise.resolve("__eof__");
+    });
+
+    const stallResult = { stallRetry: true, sessionId: undefined, stats: { inputTokens: 0, outputTokens: 0, costUsd: undefined } };
+    const runQueryFn = vi.fn().mockResolvedValue(stallResult);
+    installMocks(runQueryFn);
+
+    const agent = new BrunelAgent(getConfig());
+    const printSpy = vi.spyOn(agent.display, "print");
+
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("__process_exit__");
+    }) as unknown as ReturnType<typeof vi.spyOn>;
+
+    try {
+      await agent.start(true);
+    } catch (err) {
+      if (!(err instanceof Error && err.message === "__process_exit__")) throw err;
+    } finally {
+      exitSpy.mockRestore();
+    }
+
+    const printed = printSpy.mock.calls.map(([s]: [unknown]) => stripAnsi(String(s))).join("\n");
+    expect(printed).toContain("Connection stalled");
+    expect(printed).toContain("giving up");
+    expect(printed).toContain("retries");
+  });
+});


### PR DESCRIPTION
## Summary

- When `runPrompt` exhausts all `MAX_STALL_RETRIES` (2) retry attempts due to first-message connection stalls, prints `⚠ Connection stalled — giving up after 2 retries. Please try again.` so the user knows why the prompt was abandoned
- Adds a test in `worker.main.test.ts` that mocks `runQuery` to always return `stallRetry: true` and verifies the "giving up" message appears

## Test plan

- [ ] `npm test` passes (1619 unit tests)
- [ ] `npx tsc --noEmit` passes

Closes #939