### PR TITLE
fix: prompt to complete when /worker:stop called with closed task

### DIFF
--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -810,7 +810,7 @@ export class WorkerController extends EventEmitter {
       this.currentTaskId = msg.taskId;
       this.currentIssue = msg.issue;
       this.prIsClosed = false;
-      this.issueClosed = false;
+      this.issueClosed = msg.issue.status === "closed";
       this.agentStatus.update({ taskNumber: msg.issue.number, prNumber: undefined });
       this.agentStatus.resetTaskStats();
       void this.agentStatus.refreshBranch();

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -27,8 +27,8 @@ class FakeWs extends EventEmitter {
 
 const AGENT_ID = "test-worker-id";
 
-function makeIssue(n = 1): Wire.TaskIssue {
-  return { number: n, title: `Issue ${n}`, body: `Body ${n}`, labels: [], repoUrl: "https://github.com/owner/repo" };
+function makeIssue(n = 1, status: Wire.TaskStatus = "assigned"): Wire.TaskIssue {
+  return { number: n, title: `Issue ${n}`, body: `Body ${n}`, labels: [], repoUrl: "https://github.com/owner/repo", status };
 }
 
 function makeEvent(name = "push"): Wire.WebhookEvent {
@@ -1999,6 +1999,12 @@ describe("getTaskConfirmInfo", () => {
     // Event for a different task — should be ignored entirely
     sendMsg(fakeWs, { type: "event_notification", taskId: "t99", event: { id: "e1", name: "issues", payload: { action: "closed" } } });
     expect(session.getTaskConfirmInfo()?.issueClosed).toBe(false);
+  });
+
+  it("returns issueClosed=true when task_assigned with status 'closed' (e.g. worker claims an already-closed task)", () => {
+    const issue = makeIssue(6, "closed");
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "t6", issue });
+    expect(session.getTaskQuitInfo()?.issueClosed).toBe(true);
   });
 });
 

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -2004,7 +2004,7 @@ describe("getTaskConfirmInfo", () => {
   it("returns issueClosed=true when task_assigned with status 'closed' (e.g. worker claims an already-closed task)", () => {
     const issue = makeIssue(6, "closed");
     sendMsg(fakeWs, { type: "task_assigned", taskId: "t6", issue });
-    expect(session.getTaskQuitInfo()?.issueClosed).toBe(true);
+    expect(session.getTaskConfirmInfo()?.issueClosed).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- `issueClosed` was always initialized to `false` when a `task_assigned` message arrived, regardless of the task's actual status
- When a worker claims an already-closed task (via `/worker:claim`), no `event_notification` for `issues/closed` is ever sent — so `issueClosed` stayed `false` permanently
- This caused `/worker:stop` (and all other exit paths) to show the wrong "still open / unassign" prompt instead of the "closed but not complete / complete before exiting?" prompt

**Fix**: Initialize `issueClosed = msg.issue.status === "closed"` so workers that receive a closed task via assignment immediately reflect the correct state.

## Test plan

- [ ] New test in `getTaskQuitInfo` suite: `task_assigned` with `status: "closed"` sets `issueClosed=true`
- [ ] Existing test "resets issueClosed to false on new task_assigned" continues to pass (new task has default `status: "assigned"`)
- [ ] All 1619 unit tests pass

Closes #946