### PR TITLE
fix: initialize prNumber in status bar from task_assigned message

### DIFF
--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -811,7 +811,7 @@ export class WorkerController extends EventEmitter {
       this.currentIssue = msg.issue;
       this.prIsClosed = false;
       this.issueClosed = msg.issue.status === "closed";
-      this.agentStatus.update({ taskNumber: msg.issue.number, prNumber: undefined });
+      this.agentStatus.update({ taskNumber: msg.issue.number, prNumber: msg.issue.prNumber ?? undefined });
       this.agentStatus.resetTaskStats();
       void this.agentStatus.refreshBranch();
       const initialPrompt = buildInitialPrompt(msg.issue, !!this.workspaceController?.workspace);

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -694,6 +694,18 @@ describe("status bar content", () => {
     expect(fmtStatus(sb)).not.toContain("PR #");
   });
 
+  it("shows PR number in status bar when task_assigned carries a prNumber", () => {
+    const issue = { ...makeIssue(3), prNumber: 123 };
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "t3", issue });
+    expect(fmtStatus(sb)).toContain("PR #123");
+  });
+
+  it("shows no PR number when task_assigned has no prNumber", () => {
+    const issue = makeIssue(4);
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "t4", issue });
+    expect(fmtStatus(sb)).not.toContain("PR #");
+  });
+
   it("clears PR number from status bar when pull_request/closed without merging is received", () => {
     const issue = makeIssue(1);
     sendMsg(fakeWs, { type: "task_assigned", taskId: "t1", issue });


### PR DESCRIPTION
## Summary

- Fix parallel bug to #946: `task_assigned` handler was unconditionally setting `prNumber: undefined` on the status bar, discarding the `prNumber` from the wire message
- Change `worker-controller.ts:814` to use `msg.issue.prNumber ?? undefined` so the status bar reflects the PR number immediately when a worker claims an already-pushed task
- Add two new tests in the `status bar content` suite: one verifying the PR number is shown when `task_assigned` carries a `prNumber`, one verifying no PR number is shown when there is none

## Test plan

- [x] New test: `task_assigned` with `prNumber` → status bar shows `PR #N`
- [x] Existing test: `task_assigned` with no `prNumber` → status bar shows no PR number
- [x] Existing test: `resets PR number when new task is assigned` still passes (new task has no `prNumber`)
- [x] All 1624 unit tests pass
- [x] Type check clean

Closes #958

🤖 Generated with [Claude Code](https://claude.com/claude-code)