### PR TITLE
fix: stop status bar in finally block and route query errors through display

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ See **`docs/type-system.md`** for the full design. In brief: one server model cl
 
 ## Key conventions
 
-- **Output in agent/worker code**: use `display.print(...)` on an injected `display: WorkerDisplay` instance — it routes through the status-bar-aware renderer so messages don't corrupt the TUI. `WorkerDisplay` interface is defined in `controllers/worker-controller.ts`.
+- **Output in agent/worker code**: use `display.print(...)` on an injected `display: WorkerDisplay` instance — it routes through the status-bar-aware renderer so messages don't corrupt the TUI. `WorkerDisplay` interface is defined in `controllers/worker-controller.ts`. When calling `display.startBar()`, always call `display.stopBar()` in a `finally` block so the bar is cleared even if the surrounding code throws — leaving it active causes subsequent console output to visually concatenate with the bar text.
 - **Real-time UIs**: prefer event-based designs — a model holds state and emits on change; the UI subscribes once rather than scattering manual refresh calls.
 - **Pass model objects, not IDs**: controllers look up model objects from wire message IDs first, then pass the objects to helpers.
 - **Wire types**: all live in `shared/wire.ts`, imported as `import * as Wire from "../../shared/wire.js"`.

--- a/src/agent/controllers/agent-controller.ts
+++ b/src/agent/controllers/agent-controller.ts
@@ -200,9 +200,8 @@ export class AgentController {
       clearInterval(stallWatcher);
       process.stdin.removeListener("data", onInterrupt);
       this.currentAbortController = null;
+      display.stopBar();
     }
-
-    display.stopBar();
 
     if (!resultReceived && !stallRetry) {
       display.print(c.darkGray("\nInterrupted. What should the agent do instead?"));

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -261,7 +261,7 @@ export class BrunelAgent {
           }
           return !ac.signal.aborted;
         } catch (err) {
-          console.error(c.boldRed(`\nERROR: ${fmtError(err)}`));
+          this.display.print(c.boldRed(`\nERROR: ${fmtError(err)}`));
           logFull("ERROR", err instanceof Error ? { message: err.message, stack: err.stack } : err);
           return false;
         } finally {

--- a/tests/repl.query.test.ts
+++ b/tests/repl.query.test.ts
@@ -271,6 +271,25 @@ describe("runQuery - error handling", () => {
     expect(thrown).toBeInstanceOf(Error);
     expect((thrown as Error).message).toBe("network failure");
   });
+
+  it("status bar is stopped when the query iterator throws a non-abort error", async () => {
+    (query as any).mockImplementation(() => {
+      const gen = (async function* () {
+        throw new Error("API Error: Connection refused");
+      })();
+      (gen as any).close = () => {};
+      return gen;
+    });
+    const cap = captureConsole();
+    try {
+      await testController.runQuery("test", undefined).catch(() => {});
+    } finally {
+      cap.restore();
+    }
+    // Bar must be inactive so that a subsequent display.print() doesn't
+    // concatenate output with status bar text (the root cause of issue #962).
+    expect(testDisplay.active).toBe(false);
+  });
 });
 
 describe("runQuery - canUseTool callback registration", () => {

--- a/tests/worker.main.test.ts
+++ b/tests/worker.main.test.ts
@@ -192,6 +192,56 @@ describe("workerMain startup banner", () => {
   });
 });
 
+describe("workerMain query error display", () => {
+  let chdirSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    makeMockInput();
+    chdirSpy = vi.spyOn(process, "chdir").mockImplementation(() => {});
+    vi.mocked(confirmIfUnsafe).mockResolvedValue(true);
+    fakeWorkspace.isCreated = false;
+    vi.mocked(fakeWorkspace.destroy).mockResolvedValue(undefined);
+    vi.mocked(fakeWorkspace.checkSafety).mockResolvedValue({ uncommittedFiles: [], unpushedCommits: [], noUpstream: false });
+    vi.mocked(fakeWorkspace.create).mockImplementation(async () => { fakeWorkspace.isCreated = true; });
+  });
+
+  afterEach(() => {
+    chdirSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it("query errors are routed through display.print, not console.error", async () => {
+    // runQuery throws → runPrompt catch should call display.print, not console.error.
+    // This prevents status bar text from being appended to the error line (issue #962).
+    const runQueryFn = vi.fn().mockRejectedValue(new Error("API Error: Connection refused"));
+    installMocks(runQueryFn);
+    mockInput.ask
+      .mockResolvedValueOnce("do some work")
+      .mockResolvedValue("__eof__");
+
+    const agent = new BrunelAgent(getConfig());
+    const printSpy = vi.spyOn(agent.display, "print").mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, "error");
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("__process_exit__");
+    }) as unknown as ReturnType<typeof vi.spyOn>;
+
+    try {
+      await agent.start(true);
+    } catch (err) {
+      if (!(err instanceof Error && err.message === "__process_exit__")) throw err;
+    } finally {
+      exitSpy.mockRestore();
+    }
+
+    const errorPrints = printSpy.mock.calls
+      .map(([s]: [unknown]) => stripAnsi(String(s ?? "")))
+      .filter((s) => s.includes("ERROR"));
+    expect(errorPrints.length).toBeGreaterThan(0);
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+});
+
 describe("workerMain exit behavior", () => {
   let chdirSpy: ReturnType<typeof vi.spyOn>;
 


### PR DESCRIPTION
## Summary

- Move `display.stopBar()` into the `finally` block of `AgentController.runQuery()` so the animated bar is always cleared when the query exits — including when the iterator throws an error (previously the `stopBar()` call was only reached on the happy path)
- Change `console.error()` to `this.display.print()` in the `runPrompt` catch block in `index.ts`, routing error messages through the status-bar-aware output path

## Root cause

Every recurrence of this class of bug shares the same pattern: code that writes to stdout without going through `display.print()` bypasses the `clearBar()` / `drawBar()` lifecycle, causing error text and status bar text to appear on the same terminal line. The two fixes close both escape hatches for the query-error code path.

## Test plan

- `tests/repl.query.test.ts`: new test asserts `display.active === false` after `runQuery` throws a non-abort error (was `true` before fix)
- `tests/worker.main.test.ts`: new test asserts the error message goes through `display.print` (not `console.error`) when `runQuery` rejects

Closes #962

🤖 Generated with [Claude Code](https://claude.com/claude-code)