### PR TITLE
fix: honour workspace reset cancellation in task completion flow

### DIFF
--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -10,7 +10,7 @@ import { fmtNum, fmtTaskStats } from "../../../shared/formatters.js";
 import { getConfig } from "../../config.js";
 import type { CommandRegistry } from "./command-controller.js";
 import { Picker } from "../views/picker.js";
-import { WorkspaceController } from "./workspace-controller.js";
+import { WorkspaceController, UserCancelledError } from "./workspace-controller.js";
 
 // ── WorkerDisplay interface ───────────────────────────────────────────────────
 
@@ -296,6 +296,7 @@ export class WorkerController extends EventEmitter {
   private async buildCompleteGoodbyeOpts(): Promise<{ task_complete: true; stats?: { inputTokens: number; outputTokens: number; costUsd?: number } }> {
     if (this._activeAfterTask) {
       try { await this._activeAfterTask(); } catch (err) {
+        if (err instanceof UserCancelledError) throw err;
         this.display.print(c.amber(`afterTask failed: ${fmtError(err)}`));
       }
     }
@@ -390,6 +391,7 @@ export class WorkerController extends EventEmitter {
     if (!this.currentTaskId) return undefined;
     if (this._activeAfterTask) {
       try { await this._activeAfterTask(); } catch (err) {
+        if (err instanceof UserCancelledError) throw err;
         // Log but don't abort — the task IS complete even if workspace cleanup fails.
         // Returning early here would leave the task stuck on the foreman forever.
         this.display.print(c.amber(`afterTask failed: ${fmtError(err)}`));
@@ -492,7 +494,12 @@ export class WorkerController extends EventEmitter {
     if (taskInfo) {
       const choice = await this.confirmTaskQuit(taskInfo);
       if (choice === "cancel") return;
-      if (choice === "complete-and-quit") goodbyeOpts = await this.buildCompleteGoodbyeOpts();
+      if (choice === "complete-and-quit") {
+        try { goodbyeOpts = await this.buildCompleteGoodbyeOpts(); } catch (err) {
+          if (err instanceof UserCancelledError) return;
+          throw err;
+        }
+      }
     }
     this._stopped = true;
     this.sendGoodbye(goodbyeOpts);
@@ -517,7 +524,10 @@ export class WorkerController extends EventEmitter {
           this.display.print(c.boldRed("Not connected to a foreman."));
           return undefined;
         }
-        return this.completeCurrentTask();
+        try { return await this.completeCurrentTask(); } catch (err) {
+          if (err instanceof UserCancelledError) return undefined;
+          throw err;
+        }
       },
     });
     registry.register("start", {
@@ -570,7 +580,10 @@ export class WorkerController extends EventEmitter {
             const choice = await this.confirmTaskClaim(taskInfo);
             if (choice === "cancel") return undefined;
             if (choice === "complete-and-claim") {
-              await this.completeCurrentTask();
+              try { await this.completeCurrentTask(); } catch (err) {
+                if (err instanceof UserCancelledError) return undefined;
+                throw err;
+              }
               // currentTaskId is now cleared; fall through to claim below
             } else {
               // "claim" — abandon current task: signal foreman and reconnect with new claim

--- a/src/agent/controllers/workspace-controller.ts
+++ b/src/agent/controllers/workspace-controller.ts
@@ -4,6 +4,14 @@ import type { WorkerDisplay } from "./worker-controller.js";
 import { Workspace, confirmIfUnsafe } from "../models/workspace.js";
 import { fmtError } from "../../utils.js";
 
+/** Thrown when the user explicitly cancels an operation (e.g. workspace reset). */
+export class UserCancelledError extends Error {
+  constructor() {
+    super("cancelled");
+    this.name = "UserCancelledError";
+  }
+}
+
 /**
  * WorkspaceController owns workspace lifecycle (creation, reset between tasks,
  * and destruction on exit) and registers the /workspace:* slash commands.
@@ -144,7 +152,7 @@ export class WorkspaceController {
     const ok = await confirmIfUnsafe(workspace, workspace.confirm);
     if (!ok) {
       display.print(c.amber("Workspace reset cancelled. Task not marked complete."));
-      throw new Error("cancelled");
+      throw new UserCancelledError();
     }
     try {
       await workspace.reset();

--- a/tests/worker.claim.test.ts
+++ b/tests/worker.claim.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { EventEmitter } from "events";
 import { WorkerController } from "../src/agent/controllers/worker-controller.js";
+import { UserCancelledError } from "../src/agent/controllers/workspace-controller.js";
 import { AgentStatus } from "../src/agent/models/agent-status.js";
 import { CommandRegistry } from "../src/agent/controllers/command-controller.js";
 import * as Wire from "../shared/wire.js";
@@ -197,6 +198,26 @@ describe("when has an active task", () => {
     const claim = sentClaimTask(fakeWs);
     expect(claim).toBeDefined();
     expect(claim?.taskId).toBe("new-task-id");
+  });
+
+  it("complete-and-claim: does NOT claim when afterTask throws UserCancelledError", async () => {
+    const pickFn = vi.fn().mockResolvedValue(0); // "Yes, complete first"
+    const afterTask = vi.fn().mockRejectedValue(new UserCancelledError());
+    sessionWithPick = new WorkerController(
+      new AgentStatus({ agentId: "test-worker-id" }),
+      display,
+      undefined,
+      undefined,
+      "owner/repo",
+      { wsFactory, pickFn, afterTask },
+    );
+    await sessionWithPick.start();
+    setupActiveTask(sessionWithPick);
+    fakeWs.send.mockClear();
+    const handler = await getClaimHandler(sessionWithPick);
+    await handler("new-task-id");
+    expect(sentTaskComplete(fakeWs)).toBeUndefined();
+    expect(sentClaimTask(fakeWs)).toBeUndefined();
   });
 
   it("quit sends goodbye, clears current task, and sets pending claim for reconnect", async () => {

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { EventEmitter } from "events";
 import { WorkerController } from "../src/agent/controllers/worker-controller.js";
+import { UserCancelledError } from "../src/agent/controllers/workspace-controller.js";
 import { AgentStatus } from "../src/agent/models/agent-status.js";
 import { Display } from "../src/agent/views/display.js";
 import * as Wire from "../shared/wire.js";
@@ -1614,6 +1615,36 @@ describe("afterTask callback on /worker:complete", () => {
     const lastMsg = JSON.parse(fakeWs.send.mock.calls.at(-1)![0]);
     expect(lastMsg.type).toBe("task_complete");
   });
+
+  it("does NOT send task_complete when afterTask throws UserCancelledError", async () => {
+    const afterTask = vi.fn().mockRejectedValue(new UserCancelledError());
+    const sessionWithAfterTask = new WorkerController(sb, display, undefined, undefined, "", { wsFactory, afterTask });
+    await sessionWithAfterTask.start();
+
+    const issue = makeIssue();
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "t1", issue });
+    sessionWithAfterTask.takeNextPrompt();
+
+    const sendCountBefore = fakeWs.send.mock.calls.length;
+    try { await sessionWithAfterTask.completeCurrentTask(); } catch { /* UserCancelledError expected */ }
+    const taskCompleteSent = fakeWs.send.mock.calls
+      .slice(sendCountBefore)
+      .some(([data]: [string]) => JSON.parse(data).type === "task_complete");
+    expect(taskCompleteSent).toBe(false);
+  });
+
+  it("preserves task state when afterTask throws UserCancelledError", async () => {
+    const afterTask = vi.fn().mockRejectedValue(new UserCancelledError());
+    const sessionWithAfterTask = new WorkerController(sb, display, undefined, undefined, "", { wsFactory, afterTask });
+    await sessionWithAfterTask.start();
+
+    const issue = makeIssue();
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "t1", issue });
+    sessionWithAfterTask.takeNextPrompt();
+
+    try { await sessionWithAfterTask.completeCurrentTask(); } catch { /* UserCancelledError expected */ }
+    expect(sessionWithAfterTask.hasTask()).toBe(true);
+  });
 });
 
 // ── completeCurrentTask: post-completion prompt ───────────────────────────────
@@ -1813,6 +1844,22 @@ describe("stop — complete-and-quit", () => {
     const msgs = fakeWs.send.mock.calls.map(([d]: [string]) => JSON.parse(d));
     const goodbye = msgs.find((m: { type: string }) => m.type === "worker_goodbye");
     expect(goodbye.stats).toBeUndefined();
+  });
+
+  it("does NOT stop when afterTask throws UserCancelledError during complete-and-quit", async () => {
+    const afterTask = vi.fn().mockRejectedValue(new UserCancelledError());
+    const s = new WorkerController(sb, display, undefined, undefined, "owner/repo", { wsFactory, afterTask });
+    await s.start();
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue: makeIssue() });
+    s.takeNextPrompt();
+    vi.spyOn(s, "confirmTaskQuit").mockResolvedValue("complete-and-quit");
+
+    fakeWs.send.mockClear();
+    await s.stop();
+
+    const msgs = fakeWs.send.mock.calls.map(([d]: [string]) => JSON.parse(d));
+    expect(msgs.find((m: { type: string }) => m.type === "worker_goodbye")).toBeUndefined();
+    expect(s.isActive).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- When the user cancels the workspace reset prompt during a "complete first" flow (e.g. `/worker:claim` → "Yes, complete first" → "No, cancel"), the `afterTask` hook was throwing an error that was silently swallowed by `completeCurrentTask()`, causing the task to be incorrectly marked complete.
- Introduces `UserCancelledError` as a distinct error class in `WorkspaceController`. `completeCurrentTask()` and `buildCompleteGoodbyeOpts()` now re-throw user cancellations instead of absorbing them, while genuine unexpected failures still log and proceed (to avoid leaving tasks stuck on the foreman forever).
- The `/worker:claim`, `/worker:complete`, and `stop()` callers each handle `UserCancelledError` gracefully by returning early without completing the task or proceeding with the claimed/quit action.

## Test plan

- [x] New test: `completeCurrentTask()` does NOT send `task_complete` when afterTask throws `UserCancelledError`
- [x] New test: task state is preserved (not cleared) when afterTask throws `UserCancelledError`
- [x] New test: `/worker:claim` with "complete-and-claim" does NOT send `claim_task` when afterTask is cancelled
- [x] New test: `stop()` does NOT send `worker_goodbye` and stays active when afterTask is cancelled during "complete-and-quit"
- [x] Existing test preserved: genuine `afterTask` failures (non-cancel) still send `task_complete` to avoid foreman deadlock
- [x] All 1656 non-DB tests pass, type check clean, lint clean

Closes #963