### PR TITLE
docs: document verbose output convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ See **`docs/type-system.md`** for the full design. In brief: one server model cl
 ## Key conventions
 
 - **Output in agent/worker code**: use `display.print(...)` on an injected `display: WorkerDisplay` instance — it routes through the status-bar-aware renderer so messages don't corrupt the TUI. `WorkerDisplay` interface is defined in `controllers/worker-controller.ts`. When calling `display.startBar()`, always call `display.stopBar()` in a `finally` block so the bar is cleared even if the surrounding code throws — leaving it active causes subsequent console output to visually concatenate with the bar text.
+- **Verbose output**: gate detailed output (full paths, URLs, diagnostic info) behind `config.verbose`. Non-verbose messages should be short status strings ("Creating workspace...", "Resetting workspace..."). Pass verbose as a `{ verbose: boolean }` config struct to controllers that need it — do not put it on `WorkerDisplay`. Never print credentials or tokens even in verbose mode; mask them (e.g. `[token]`) in any displayed URL.
 - **Real-time UIs**: prefer event-based designs — a model holds state and emits on change; the UI subscribes once rather than scattering manual refresh calls.
 - **Pass model objects, not IDs**: controllers look up model objects from wire message IDs first, then pass the objects to helpers.
 - **Wire types**: all live in `shared/wire.ts`, imported as `import * as Wire from "../../shared/wire.js"`.


### PR DESCRIPTION
## Summary

- Adds a **Verbose output** bullet to the Key conventions section documenting the pattern established by PR #825 (issue #812): gate detailed output (paths, URLs) behind `config.verbose`, pass it as a `{ verbose: boolean }` config struct (not via `WorkerDisplay`), and never print credentials or tokens even in verbose mode.

## Test plan

- [ ] No code changes — docs only; no tests needed
- [ ] Verify the new bullet reads accurately against the implementation in `workspace-controller.ts`