### PR TITLE
fix: hide stale workers from dashboard

### DIFF
--- a/src/foreman/models/worker.ts
+++ b/src/foreman/models/worker.ts
@@ -137,7 +137,7 @@ export class Worker extends ActiveRecord {
 
   /**
    * For the admin dashboard: connected workers from memory plus disconnected
-   * workers from DB that still have a currently assigned task.
+   * workers from DB that are still the current worker on a non-complete task.
    */
   static async allForDashboard(): Promise<Wire.Worker[]> {
     const connected = [...registry.values()].map((w) => w.toWire());
@@ -147,9 +147,29 @@ export class Worker extends ActiveRecord {
     try {
       const { data, error } = await Worker.select().not("current_task_id", "is", null);
       if (!error && data) {
-        fromDb = (data as WorkerDbRow[])
-          .filter((row) => !connectedIds.has(row.worker_id))
-          .map((row) => new Worker(row).toWire());
+        const rows = (data as WorkerDbRow[]).filter((row) => !connectedIds.has(row.worker_id));
+
+        if (rows.length > 0) {
+          const taskResults = await Promise.all(
+            rows.map((row) =>
+              (db.from as any)("tasks")
+                .select("task_id, worker_id, completed_at, issue_closed_at, pr_merged_at")
+                .eq("task_id", row.current_task_id)
+                .maybeSingle(),
+            ),
+          );
+
+          fromDb = rows
+            .map((row, i) => ({ row, task: taskResults[i].data as { worker_id: string | null; completed_at: string | null; issue_closed_at: string | null; pr_merged_at: string | null } | null }))
+            .filter(({ row, task }) =>
+              task !== null &&
+              !task.completed_at &&
+              !task.issue_closed_at &&
+              !task.pr_merged_at &&
+              task.worker_id === row.worker_id,
+            )
+            .map(({ row }) => new Worker(row).toWire());
+        }
       }
     } catch {
       // Non-critical: dashboard degrades to just connected workers on DB error

--- a/tests/foreman.worker-db.test.ts
+++ b/tests/foreman.worker-db.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { Worker } from "../src/foreman/models/worker.js";
 import { db } from "../src/foreman/clients/db-client.js";
-import { fakeRepo, resetDb, createTestRepo } from "./helpers/task.js";
+import { fakeRepo, resetDb, createTestRepo, seedTask } from "./helpers/task.js";
 
 function fakeWs() {
   return { send: vi.fn(), close: vi.fn(), readyState: 1 } as any;
@@ -110,22 +110,71 @@ describe("Worker DB persistence", () => {
   });
 
   it("allForDashboard includes disconnected workers with assigned tasks from DB", async () => {
+    await seedTask({ task_id: "db-w1-active", issue_number: 1001, worker_id: "w1" });
     const repo = fakeRepo("owner/repo", 1, "new");
     const w = Worker.register("w1", fakeWs(), repo);
-    const task = { taskId: "42" } as any;
+    const task = { taskId: "db-w1-active" } as any;
     w.assign(task);
     w.markDisconnected();
     Worker._reset(); // clear in-memory (simulate reconnect context)
     await new Promise((r) => setTimeout(r, 20));
     const result = await Worker.allForDashboard();
     expect(result.map((w) => w.workerId)).toContain("w1");
-    expect(result.find((w) => w.workerId === "w1")?.currentTaskId).toBe("42");
+    expect(result.find((w) => w.workerId === "w1")?.currentTaskId).toBe("db-w1-active");
   });
 
   it("allForDashboard does not include disconnected workers without tasks", async () => {
     const repo = fakeRepo("owner/repo", 1, "new");
     const w = Worker.register("w1", fakeWs(), repo);
     w.remove(); // clean disconnect, no task
+    Worker._reset();
+    await new Promise((r) => setTimeout(r, 20));
+    const result = await Worker.allForDashboard();
+    expect(result.map((w) => w.workerId)).not.toContain("w1");
+  });
+
+  it("allForDashboard excludes disconnected workers whose task is complete", async () => {
+    await seedTask({ task_id: "db-w1-done", issue_number: 1002, worker_id: "w1", completed_at: new Date().toISOString() });
+    const repo = fakeRepo("owner/repo", 1, "new");
+    const w = Worker.register("w1", fakeWs(), repo);
+    w.assign({ taskId: "db-w1-done" } as any);
+    w.markDisconnected();
+    Worker._reset();
+    await new Promise((r) => setTimeout(r, 20));
+    const result = await Worker.allForDashboard();
+    expect(result.map((w) => w.workerId)).not.toContain("w1");
+  });
+
+  it("allForDashboard excludes disconnected workers whose task is closed", async () => {
+    await seedTask({ task_id: "db-w1-closed", issue_number: 1003, worker_id: "w1", issue_closed_at: new Date().toISOString() });
+    const repo = fakeRepo("owner/repo", 1, "new");
+    const w = Worker.register("w1", fakeWs(), repo);
+    w.assign({ taskId: "db-w1-closed" } as any);
+    w.markDisconnected();
+    Worker._reset();
+    await new Promise((r) => setTimeout(r, 20));
+    const result = await Worker.allForDashboard();
+    expect(result.map((w) => w.workerId)).not.toContain("w1");
+  });
+
+  it("allForDashboard excludes disconnected workers whose task is merged", async () => {
+    await seedTask({ task_id: "db-w1-merged", issue_number: 1004, worker_id: "w1", pr_merged_at: new Date().toISOString() });
+    const repo = fakeRepo("owner/repo", 1, "new");
+    const w = Worker.register("w1", fakeWs(), repo);
+    w.assign({ taskId: "db-w1-merged" } as any);
+    w.markDisconnected();
+    Worker._reset();
+    await new Promise((r) => setTimeout(r, 20));
+    const result = await Worker.allForDashboard();
+    expect(result.map((w) => w.workerId)).not.toContain("w1");
+  });
+
+  it("allForDashboard excludes disconnected workers no longer the current worker for their task", async () => {
+    await seedTask({ task_id: "db-w1-reassigned", issue_number: 1005, worker_id: "w2" });
+    const repo = fakeRepo("owner/repo", 1, "new");
+    const w = Worker.register("w1", fakeWs(), repo);
+    w.assign({ taskId: "db-w1-reassigned" } as any);
+    w.markDisconnected();
     Worker._reset();
     await new Promise((r) => setTimeout(r, 20));
     const result = await Worker.allForDashboard();


### PR DESCRIPTION
## Summary

- `Worker.allForDashboard()` now batch-fetches the task for each disconnected worker from the DB
- Filters out disconnected workers whose task is complete (`completed_at`), closed (`issue_closed_at`), or merged (`pr_merged_at`)
- Also filters out disconnected workers where the task's `worker_id` no longer matches them (task was reassigned to another worker)
- Connected workers are always shown regardless of task state (no change)

## Test plan

- [x] New tests for all three "complete" timestamp cases: `completed_at`, `issue_closed_at`, `pr_merged_at`
- [x] New test for the "no longer current worker" case (task reassigned)
- [x] Updated the existing "includes disconnected workers with assigned tasks" test to also seed the task in the DB (required for the new implementation to recognize it as active)
- [x] All 15 `foreman.worker-db.test.ts` tests pass
- [x] Full test suite: 1660 tests pass, type check clean

Closes #972

🤖 Generated with [Claude Code](https://claude.com/claude-code)