### PR TITLE
feat: refactor worker state machine — ready/reserved/assigned states

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,18 +43,23 @@ Status is **derived from timestamps**, not stored: `completedAt` → complete, `
 
 `Task.upsert()` intentionally does not overwrite status fields on conflict, so re-syncing at startup never clobbers existing assignments.
 
-Task assignment is **repo-scoped**: `TaskManager.tryAssignWork()` only assigns a task to a worker if (a) the worker's repo status is `"active"` and (b) the task's `repoId` matches the worker's repo. Workers from inactive or mismatched repos are silently skipped. Cross-repo enforcement also applies on reconnect: if a worker reconnects claiming a task that belongs to a different repo, `handleBusyHello` sends `cancelled` and the worker resets to idle.
+Task assignment is **repo-scoped**: `TaskManager.tryAssignWork()` only assigns a task to a worker if (a) the worker's repo status is `"active"` and (b) the task's `repoId` matches the worker's repo. Workers from inactive or mismatched repos are silently skipped. Cross-repo enforcement also applies on reconnect: if a worker reconnects claiming a task that belongs to a different repo, `handleAssignedHello` sends `cancelled` and the worker resets to idle.
 
 ## Worker/Foreman handshake
 
 Every `worker_hello` includes a `repo` field (owner/name parsed from `git remote get-url origin`). The foreman resolves this to a `Repo` via `Repo.findOrCreate()` and stores it on the `Worker` — every registered Worker always has a `Repo`. Missing or unresolvable repo is a fatal error.
 
-Every `worker_hello` gets a `hello_ack` with one of three statuses before any task is sent:
-- `idle` — worker is free, foreman may now assign
-- `busy` — reconnection accepted, worker may resume
+Every `worker_hello` gets a `hello_ack` with one of four statuses before any task is sent:
+- `ready` — worker is free and available for auto-assignment
+- `reserved` — worker is registered but NOT available for auto-assignment (will send `claim_task` next)
+- `assigned` — reconnection accepted, worker may resume the in-progress task
 - `cancelled` — task was taken or completed; worker should reset and become idle
 
-An idle `worker_hello` may include `claimTaskId` to atomically register and claim a specific task (used by the `/worker:claim` command on first connect). The foreman sends `hello_ack { status: "idle" }` first, then immediately sends `task_assigned` or a non-fatal `foreman_error`.
+Worker state transitions happen via dedicated messages while the worker stays connected:
+- `task_complete { nextState?: "ready" | "reserved" }` — complete a task and declare next state; defaults to `"ready"`
+- `worker_ready` — transition from `reserved` → `ready` (e.g., after claiming a specific task or deciding to accept work)
+
+The `/worker:claim` command connects with `status: "reserved"` (no `claimTaskId` in the hello), receives `hello_ack { status: "reserved" }`, then sends `claim_task { taskId }` separately. The foreman replies with `task_assigned` or a non-fatal `foreman_error`.
 
 `hello_ack` also carries `repoStatus: "new" | "active"`. If `"new"`, the worker prompts the user to activate the repo. On confirmation the worker sends `activate_repo`; the foreman activates the repo, seeds tasks from open labeled issues, and replies with `repo_activated`. The worker then transitions to idle and normal task assignment proceeds. If the user declines activation, the worker exits worker mode and returns to the interactive REPL.
 

--- a/docs/type-system.md
+++ b/docs/type-system.md
@@ -79,15 +79,19 @@ The foreman↔worker WebSocket protocol is defined as union types in `wire.ts`:
 
 ```ts
 export type ForemanMessage =
-  | { type: "task_assigned"; taskId: string; task: Task }
+  | { type: "task_assigned"; taskId: string; issue: TaskIssue }
   | { type: "event_notification"; taskId: string; event: WebhookEvent }
-  | { type: "hello_ack"; workerId: string; status: "idle" | "busy" | "cancelled" }
+  | { type: "hello_ack"; workerId: string; status: "ready" | "reserved" | "assigned" | "cancelled"; repoStatus: "new" | "active" }
+  | { type: "repo_activated"; workerId: string }
   | { type: "foreman_error"; message: string; fatal: boolean };
 
 export type WorkerMessage =
-  | { type: "worker_hello"; workerId: string; claimedTaskId?: string }
-  | { type: "task_complete"; taskId: string }
-  | { type: "worker_goodbye"; taskId: string };
+  | { type: "worker_hello"; workerId: string; repo: string; taskId?: string; status: "ready" | "reserved" | "assigned" }
+  | { type: "task_complete"; workerId: string; taskId: string; nextState?: "ready" | "reserved" }
+  | { type: "worker_goodbye"; workerId: string; taskId?: string }
+  | { type: "activate_repo"; workerId: string }
+  | { type: "claim_task"; workerId: string; taskId: string }
+  | { type: "worker_ready"; workerId: string };
 ```
 
 Payload types within the union reference the shared Wire interfaces directly rather than duplicating field definitions.

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -93,7 +93,7 @@ export default function Dashboard() {
       </section>
 
       <section style={{ marginTop: "2rem" }}>
-        <h3>Workers ({workers.filter((w) => w.status === "idle").length} idle · {workers.filter((w) => w.status === "busy").length} busy)</h3>
+        <h3>Workers ({workers.filter((w) => w.status === "ready").length} ready · {workers.filter((w) => w.status === "assigned").length} assigned)</h3>
         {workers.length === 0 ? <p>No workers connected.</p> : (
           <ul>
             {workers.map((w) => (

--- a/frontend/src/pages/RepoDetail.tsx
+++ b/frontend/src/pages/RepoDetail.tsx
@@ -92,7 +92,7 @@ export default function RepoDetail() {
       </section>
 
       <section style={{ marginTop: "2rem" }}>
-        <h3>Workers ({workers.filter((w) => w.status === "idle").length} idle · {workers.filter((w) => w.status === "busy").length} busy)</h3>
+        <h3>Workers ({workers.filter((w) => w.status === "ready").length} ready · {workers.filter((w) => w.status === "assigned").length} assigned)</h3>
         {workers.length === 0 ? <p>No workers connected.</p> : (
           <ul>
             {workers.map((w) => (

--- a/frontend/tests/RepoDetail.test.tsx
+++ b/frontend/tests/RepoDetail.test.tsx
@@ -35,7 +35,7 @@ const mockTask: Task = {
 
 const mockWorker: Worker = {
   workerId: "worker-abc-123",
-  status: "busy",
+  status: "assigned",
   repo: "user/my-repo",
   currentTaskId: "99",
 };
@@ -114,7 +114,7 @@ describe("RepoDetail", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Fix auth bug")).toBeInTheDocument();
-      expect(screen.getByText(/1 idle.*0 busy|0 idle.*1 busy/)).toBeInTheDocument();
+      expect(screen.getByText(/0 ready.*1 assigned|1 assigned/)).toBeInTheDocument();
     });
   });
 

--- a/shared/wire.ts
+++ b/shared/wire.ts
@@ -95,16 +95,17 @@ export interface TaskIssue {
 
 // Worker → Foreman messages
 export type WorkerMessage =
-  | { type: "worker_hello"; workerId: string; repo: string; taskId?: string; claimTaskId?: string; status: "idle" | "busy"; workerSecret?: string }
-  | { type: "task_complete"; workerId: string; taskId: string; stats?: { inputTokens: number; outputTokens: number; costUsd?: number } }
+  | { type: "worker_hello"; workerId: string; repo: string; taskId?: string; status: "ready" | "reserved" | "assigned"; workerSecret?: string }
+  | { type: "task_complete"; workerId: string; taskId: string; nextState?: "ready" | "reserved"; stats?: { inputTokens: number; outputTokens: number; costUsd?: number } }
   | { type: "worker_goodbye"; workerId: string; taskId?: string; task_complete?: boolean; stats?: { inputTokens: number; outputTokens: number; costUsd?: number } }
   | { type: "activate_repo"; workerId: string }
-  | { type: "claim_task"; workerId: string; taskId: string };
+  | { type: "claim_task"; workerId: string; taskId: string }
+  | { type: "worker_ready"; workerId: string };
 
 // Foreman → Worker messages
 export type ForemanMessage =
   | { type: "task_assigned"; taskId: string; issue: TaskIssue }
   | { type: "event_notification"; taskId: string; event: WebhookEvent }
-  | { type: "hello_ack"; workerId: string; status: "idle" | "busy" | "cancelled"; repoStatus: "new" | "active" }
+  | { type: "hello_ack"; workerId: string; status: "ready" | "reserved" | "assigned" | "cancelled"; repoStatus: "new" | "active" }
   | { type: "repo_activated"; workerId: string }
   | { type: "foreman_error"; message: string; fatal: boolean };

--- a/shared/wire.ts
+++ b/shared/wire.ts
@@ -41,7 +41,7 @@ export interface Task {
 /** Wire representation of a worker — sent over the admin WebSocket and REST API. */
 export interface Worker {
   workerId: string;
-  status: "idle" | "busy" | "disconnected";
+  status: "ready" | "reserved" | "assigned" | "disconnected";
   currentTaskId?: string;
   repo?: string;
   // Diagnostic fields — present in REST responses, optional in WebSocket snapshots

--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -293,6 +293,16 @@ export class WorkerController extends EventEmitter {
     }
   }
 
+  /** Send worker_ready to opt back into auto-assignment from a reserved state. */
+  sendWorkerReady(): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify({
+        type: "worker_ready",
+        workerId: this.agentStatus.agentId,
+      } satisfies Wire.WorkerMessage));
+    }
+  }
+
   private async buildCompleteGoodbyeOpts(): Promise<{ task_complete: true; stats?: { inputTokens: number; outputTokens: number; costUsd?: number } }> {
     if (this._activeAfterTask) {
       try { await this._activeAfterTask(); } catch (err) {
@@ -384,10 +394,17 @@ export class WorkerController extends EventEmitter {
   /**
    * Complete the current task: call afterTask hook, send task_complete, reset state,
    * then prompt the user for what to do next.
+   *
+   * nextState defaults to "ready" (worker becomes eligible for auto-assignment).
+   * Pass "reserved" when the caller intends to immediately claim a specific task —
+   * this prevents the foreman from auto-assigning while the claim is in flight.
+   * When "reserved", the picker is skipped and "task-complete" is returned immediately
+   * so the caller can continue with its own follow-up action (e.g. sendClaimTask).
+   *
    * Returns 'task-complete' if the worker should remain (or become) idle,
    * 'exit' if the user chose to quit, or undefined if no task was assigned.
    */
-  async completeCurrentTask(): Promise<"task-complete" | "exit" | undefined> {
+  async completeCurrentTask(nextState: "ready" | "reserved" = "ready"): Promise<"task-complete" | "exit" | undefined> {
     if (!this.currentTaskId) return undefined;
     if (this._activeAfterTask) {
       try { await this._activeAfterTask(); } catch (err) {
@@ -403,6 +420,7 @@ export class WorkerController extends EventEmitter {
       type: "task_complete",
       workerId: this.agentStatus.agentId,
       taskId: this.currentTaskId,
+      ...(nextState !== "ready" && { nextState }),
       ...(hasStats && { stats: { inputTokens: taskInputTokens, outputTokens: taskOutputTokens, costUsd: taskCostUsd } }),
     });
     const taskNumber = this.currentIssue!.number;
@@ -413,6 +431,8 @@ export class WorkerController extends EventEmitter {
     this.agentStatus.resetTaskStats();
     this.agentStatus.update({ taskNumber: undefined, prNumber: undefined });
     await this.agentStatus.refreshBranch();
+    // When called with "reserved", skip the picker — caller handles next action.
+    if (nextState === "reserved") return "task-complete";
     return this.promptAfterTaskComplete();
   }
 
@@ -580,7 +600,11 @@ export class WorkerController extends EventEmitter {
             const choice = await this.confirmTaskClaim(taskInfo);
             if (choice === "cancel") return undefined;
             if (choice === "complete-and-claim") {
-              try { await this.completeCurrentTask(); } catch (err) {
+              try {
+                // Complete with "reserved" so foreman doesn't auto-assign
+                // while we're about to claim a specific task.
+                await this.completeCurrentTask("reserved");
+              } catch (err) {
                 if (err instanceof UserCancelledError) return undefined;
                 throw err;
               }
@@ -721,16 +745,17 @@ export class WorkerController extends EventEmitter {
     };
 
     ws.on("open", () => {
-      // Read and consume any pending claim so it's included in this hello exactly once.
-      const claimTaskId = this._pendingClaimTaskId;
-      this._pendingClaimTaskId = undefined;
+      // If a claim is pending, connect as "reserved" so the foreman doesn't
+      // auto-assign while we're about to claim a specific task. After hello_ack,
+      // transitionToRegistered() will send the claim_task message automatically.
+      // Do NOT put _pendingClaimTaskId in the hello — it will be sent as claim_task.
+      const hasPendingClaim = !!this._pendingClaimTaskId;
       ws.send(JSON.stringify({
         type: "worker_hello",
         workerId: this.agentStatus.agentId,
         repo: this.repo,
         ...(this.currentTaskId !== undefined && { taskId: this.currentTaskId }),
-        ...(claimTaskId && { claimTaskId }),
-        status: this.currentTaskId ? "busy" : "idle",
+        status: this.currentTaskId ? "assigned" : (hasPendingClaim ? "reserved" : "ready"),
       } satisfies Wire.WorkerMessage));
 
       this.connectionState = "hello_sent";
@@ -877,10 +902,15 @@ export class WorkerController extends EventEmitter {
         await this.stop();
         this.emit("prompts_ready");
       } else {
-        // "idle" or "busy" with repoStatus 'active' (or no repoStatus for back-compat).
-        if (msg.status === "idle") {
+        // "ready", "reserved", or "assigned" with active repoStatus.
+        if (msg.status === "ready") {
           this.transitionToIdle();
+        } else if (msg.status === "reserved") {
+          // Registered but not auto-assignable. transitionToRegistered() flushes
+          // the buffer and sends any pending claim_task message.
+          this.transitionToRegistered();
         } else {
+          // "assigned" — reconnected with active task
           this.transitionToRegistered();
         }
       }

--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -903,14 +903,11 @@ export class WorkerController extends EventEmitter {
         this.emit("prompts_ready");
       } else {
         // "ready", "reserved", or "assigned" with active repoStatus.
+        // "reserved" and "assigned" both call transitionToRegistered(), which
+        // flushes the buffer and sends any pending claim_task message.
         if (msg.status === "ready") {
           this.transitionToIdle();
-        } else if (msg.status === "reserved") {
-          // Registered but not auto-assignable. transitionToRegistered() flushes
-          // the buffer and sends any pending claim_task message.
-          this.transitionToRegistered();
         } else {
-          // "assigned" — reconnected with active task
           this.transitionToRegistered();
         }
       }

--- a/src/foreman/controllers/wss.ts
+++ b/src/foreman/controllers/wss.ts
@@ -114,6 +114,8 @@ export class ForemanWss {
             await this.handleActivateRepo(workerId, ws);
           } else if (msg.type === "claim_task") {
             await this.handleClaimTask(workerId, msg);
+          } else if (msg.type === "worker_ready") {
+            await this.handleWorkerReady(workerId);
           } else {
             log(`[worker ${workerId}] unknown message type: ${(msg as R).type}`);
             return;
@@ -313,7 +315,7 @@ export class ForemanWss {
       await task.assign(worker);
     }
     // For complete tasks, the task stays complete while worker finishes cleanup/finalization work
-    this.sendMsg(worker, { type: "hello_ack", workerId: worker.workerId, status: "busy", repoStatus: worker.repo.status }, { logTaskId: task.taskId });
+    this.sendMsg(worker, { type: "hello_ack", workerId: worker.workerId, status: "assigned", repoStatus: worker.repo.status }, { logTaskId: task.taskId });
     this.flushQueuedEvents(worker, task);
   }
 
@@ -338,17 +340,17 @@ export class ForemanWss {
       return;
     }
 
-    if (msg.status === "busy" && msg.taskId) {
-      await this.handleBusyHello(workerId, msg.taskId, ws, repo);
-    } else if (msg.claimTaskId) {
-      await this.handleClaimHello(workerId, msg.claimTaskId, ws, repo);
+    if (msg.status === "assigned" && msg.taskId) {
+      await this.handleAssignedHello(workerId, msg.taskId, ws, repo);
+    } else if (msg.status === "reserved") {
+      await this.handleReservedHello(workerId, ws, repo);
     } else {
-      await this.handleIdleHello(workerId, ws, repo);
+      await this.handleReadyHello(workerId, ws, repo);
     }
   }
 
   async handleTaskComplete(workerId: string, msg: Extract<Wire.WorkerMessage, { type: "task_complete" }>): Promise<void> {
-    this.workerLog(workerId, `task_complete #${msg.taskId}`);
+    this.workerLog(workerId, `task_complete #${msg.taskId} (nextState=${msg.nextState ?? "ready"})`);
     const task = await Task.get(msg.taskId);
     if (task && task.workerId !== workerId) {
       this.workerLog(workerId, `task_complete #${msg.taskId} ignored — owned by ${task.workerId ?? "nobody"}`);
@@ -362,7 +364,12 @@ export class ForemanWss {
         return; // don't release — keeps task assigned so the failure is visible
       }
     }
-    Worker.fromRegistry(workerId)?.release();
+    const worker = Worker.fromRegistry(workerId);
+    if (msg.nextState === "reserved") {
+      worker?.releaseReserved();
+    } else {
+      worker?.release();
+    }
   }
 
   async handleWorkerGoodbye(workerId: string, msg: Extract<Wire.WorkerMessage, { type: "worker_goodbye" }>): Promise<void> {
@@ -387,7 +394,7 @@ export class ForemanWss {
   }
 
   /**
-   * Handles the "busy" branch of a worker_hello — the worker is reconnecting
+   * Handles the "assigned" branch of a worker_hello — the worker is reconnecting
    * and claims to be mid-task. Decides among seven cases:
    *
    * 1. Unknown task (numeric taskId) → create placeholder, reclaim
@@ -398,7 +405,7 @@ export class ForemanWss {
    * 6. Live task, different worker → cancel
    * 7. Otherwise (live task, same or no worker) → reclaim
    */
-  async handleBusyHello(workerId: string, claimedTaskId: string, ws: WebSocket, repo: Repo): Promise<void> {
+  async handleAssignedHello(workerId: string, claimedTaskId: string, ws: WebSocket, repo: Repo): Promise<void> {
     try {
       const existing = await Task.get(claimedTaskId);
       const worker = Worker.register(workerId, ws, repo);
@@ -434,7 +441,7 @@ export class ForemanWss {
         await this.reclaimWorker(worker, existing);
       }
     } catch (err) {
-      log(`ERROR handleBusyHello ${workerId}: ${fmtError(err)}`);
+      log(`ERROR handleAssignedHello ${workerId}: ${fmtError(err)}`);
       // DB error during task lookup or reclaim — recoverable: DB may be temporarily down.
       // Worker retries on reconnect and the operation succeeds once the DB recovers.
       this.sendError(ws, `Internal error during reconnection: ${fmtError(err)}`, false, workerId, repo.id);
@@ -442,58 +449,74 @@ export class ForemanWss {
   }
 
   /**
-   * Handles the "idle" branch of a worker_hello — the worker is connecting
-   * fresh (or restarting without a task). Reverts any stale prior assignment,
-   * registers the worker, and sends an idle hello_ack.
+   * Shared registration logic for workers connecting fresh (no task).
+   * Reverts any stale prior assignment, registers the worker.
+   * Returns the registered Worker, or null if an error was sent to ws.
    */
-  async handleIdleHello(workerId: string, ws: WebSocket, repo: Repo): Promise<void> {
-    try {
-      // DB error here is transient — recoverable: worker retries on reconnect.
-      const priorTask = await Task.getByWorker(workerId);
-      if (priorTask) {
-        try {
-          await priorTask.revert();
-          this.workerLog(workerId, `hello idle (had task #${priorTask.taskId}) — reverting task to pending`);
-        } catch (err) {
-          log(`ERROR Failed to revert task #${priorTask.taskId} to pending: ${fmtError(err)}`);
-          // DB error reverting prior task — recoverable: task stays assigned so the
-          // failure is visible; a new idle assignment would create a double assignment.
-          // Worker retries on reconnect and the revert succeeds once the DB recovers.
-          this.sendError(ws, `Failed to revert prior task to pending: ${fmtError(err)}`, false, workerId, repo.id, priorTask.taskId);
-          return; // don't register as idle — task stays assigned, worker retries on reconnect
-        }
-      } else {
-        this.workerLog(workerId, "hello idle");
+  private async _registerFresh(workerId: string, ws: WebSocket, repo: Repo): Promise<Worker | null> {
+    // DB error here is transient — recoverable: worker retries on reconnect.
+    const priorTask = await Task.getByWorker(workerId);
+    if (priorTask) {
+      try {
+        await priorTask.revert();
+        this.workerLog(workerId, `reverted stale task #${priorTask.taskId} to pending`);
+      } catch (err) {
+        log(`ERROR Failed to revert task #${priorTask.taskId} to pending: ${fmtError(err)}`);
+        // DB error reverting prior task — recoverable: task stays assigned so the
+        // failure is visible; a new idle assignment would create a double assignment.
+        // Worker retries on reconnect and the revert succeeds once the DB recovers.
+        this.sendError(ws, `Failed to revert prior task to pending: ${fmtError(err)}`, false, workerId, repo.id, priorTask.taskId);
+        return null; // don't register — task stays assigned, worker retries on reconnect
       }
-      const w = Worker.register(workerId, ws, repo);
-      this.sendMsg(w, { type: "hello_ack", workerId: w.workerId, status: "idle", repoStatus: repo.status });
+    }
+    return Worker.register(workerId, ws, repo);
+  }
+
+  /**
+   * Handles the "ready" branch of a worker_hello — the worker is connecting
+   * fresh, available for auto-assignment. Reverts any stale prior assignment,
+   * registers the worker, and sends a ready hello_ack.
+   */
+  async handleReadyHello(workerId: string, ws: WebSocket, repo: Repo): Promise<void> {
+    try {
+      const worker = await this._registerFresh(workerId, ws, repo);
+      if (!worker) return; // error already sent
+      this.workerLog(workerId, "hello ready");
+      this.sendMsg(worker, { type: "hello_ack", workerId: worker.workerId, status: "ready", repoStatus: repo.status });
     } catch (err) {
-      log(`ERROR handleIdleHello ${workerId}: ${fmtError(err)}`);
+      log(`ERROR handleReadyHello ${workerId}: ${fmtError(err)}`);
       // DB error during worker lookup — recoverable: DB may be temporarily down.
-      // Worker retries on reconnect and the operation succeeds once the DB recovers.
-      this.sendError(ws, `Internal error during idle hello: ${fmtError(err)}`, false, workerId, repo.id);
+      this.sendError(ws, `Internal error during ready hello: ${fmtError(err)}`, false, workerId, repo.id);
     }
   }
 
   /**
-   * Handles a worker_hello that carries claimTaskId — the worker is connecting
-   * fresh and wants to be assigned a specific task. Registers as idle first
-   * (reverting any prior stale assignment and sending hello_ack), then
-   * immediately processes the claim exactly like handleClaimTask does.
+   * Handles the "reserved" branch of a worker_hello — the worker is connecting
+   * but NOT available for auto-assignment. Registers, marks as reserved, and
+   * sends hello_ack { status: "reserved" }. The worker will send claim_task
+   * separately after receiving the ack.
    */
-  async handleClaimHello(workerId: string, claimTaskId: string, ws: WebSocket, repo: Repo): Promise<void> {
-    await this.handleIdleHello(workerId, ws, repo);
+  async handleReservedHello(workerId: string, ws: WebSocket, repo: Repo): Promise<void> {
+    try {
+      const worker = await this._registerFresh(workerId, ws, repo);
+      if (!worker) return; // error already sent
+      this.workerLog(workerId, "hello reserved");
+      worker.markReserved();
+      this.sendMsg(worker, { type: "hello_ack", workerId: worker.workerId, status: "reserved", repoStatus: repo.status });
+    } catch (err) {
+      log(`ERROR handleReservedHello ${workerId}: ${fmtError(err)}`);
+      this.sendError(ws, `Internal error during reserved hello: ${fmtError(err)}`, false, workerId, repo.id);
+    }
+  }
+
+  async handleWorkerReady(workerId: string): Promise<void> {
     const worker = Worker.fromRegistry(workerId);
-    if (!worker) return; // handleIdleHello failed; error already sent to ws
-    this.workerLog(workerId, `hello claim task=#${claimTaskId}`);
-    const outcome = await worker.repo.taskManager.claimTask(worker, claimTaskId);
-    if (!outcome.ok) {
-      this.sendMsg(worker, { type: "foreman_error", message: outcome.error, fatal: false }, { logTaskId: claimTaskId });
+    if (!worker) {
+      log(`[worker ${shortWorkerId(workerId)}] worker_ready received but worker not in registry — ignoring`);
       return;
     }
-    const { task } = outcome;
-    this.sendMsg(worker, { type: "task_assigned", taskId: task.taskId, issue: task.toAssignmentPayload() });
-    this.workerLog(workerId, `→ claim task_assigned #${task.issueNumber} "${task.title}"`);
+    this.workerLog(workerId, "worker_ready");
+    worker.markAvailable();
   }
 
   async handleActivateRepo(workerId: string, ws: WebSocket): Promise<void> {

--- a/src/foreman/models/worker.ts
+++ b/src/foreman/models/worker.ts
@@ -38,10 +38,11 @@ export class Worker extends ActiveRecord {
   }
 
   readonly workerId: string;
-  status: "idle" | "busy" | "disconnected";
-  /** In-memory only — false when worker is in "reserved" state (registered but not eligible for auto-assignment). */
-  isAvailable = true;
+  status: "ready" | "reserved" | "assigned" | "disconnected";
   disconnectedAt?: Date;
+
+  /** True when the worker is eligible for auto-assignment (i.e. status is "ready"). */
+  get isAvailable(): boolean { return this.status === "ready"; }
 
   // Fields populated from DB row (undefined for synthetic registry instances)
   readonly repoFullName?: string;
@@ -64,7 +65,11 @@ export class Worker extends ActiveRecord {
   private constructor(row: WorkerDbRow) {
     super();
     this.workerId = row.worker_id;
-    this.status = row.status as "idle" | "busy" | "disconnected";
+    // Map DB column values (idle/busy/disconnected) to in-memory vocabulary.
+    // "idle" → "ready" (reserved is not persisted; both write "idle" to DB).
+    // "busy" → "assigned". "disconnected" is unchanged.
+    const dbStatus = row.status as "idle" | "busy" | "disconnected";
+    this.status = dbStatus === "idle" ? "ready" : dbStatus === "busy" ? "assigned" : "disconnected";
     this.repoFullName = (row as any).repos?.full_name ?? undefined;
     this.numConnections = row.num_connections ?? undefined;
     this.firstConnectedAt = row.first_connected_at ?? undefined;
@@ -102,8 +107,7 @@ export class Worker extends ActiveRecord {
       } as unknown as WorkerDbRow);
     }
     worker.repo = repo;
-    worker.status = "idle";
-    worker.isAvailable = true;
+    worker.status = "ready";
     worker.currentTask = undefined;
     worker.disconnectedAt = undefined;
     sockets.set(workerId, ws);
@@ -124,7 +128,7 @@ export class Worker extends ActiveRecord {
   }
 
   static getIdle(): Worker[] {
-    return [...registry.values()].filter((w) => w.status === "idle" && w.isAvailable);
+    return [...registry.values()].filter((w) => w.status === "ready");
   }
 
   static getByTask(taskId: string): Worker | undefined {
@@ -224,15 +228,14 @@ export class Worker extends ActiveRecord {
   }
 
   assign(task: Task): void {
-    this.status = "busy";
+    this.status = "assigned";
     this.currentTask = task;
     Worker.events.emit("changed");
     this._chain(() => this.update({ status: "busy", current_task_id: task.taskId }));
   }
 
   release(): void {
-    this.status = "idle";
-    this.isAvailable = true;
+    this.status = "ready";
     this.currentTask = undefined;
     Worker.events.emit("changed");
     this._chain(() => this.update({ status: "idle", current_task_id: null }));
@@ -240,8 +243,7 @@ export class Worker extends ActiveRecord {
 
   /** Release the task but stay reserved — not eligible for auto-assignment. */
   releaseReserved(): void {
-    this.status = "idle";
-    this.isAvailable = false;
+    this.status = "reserved";
     this.currentTask = undefined;
     Worker.events.emit("changed");
     this._chain(() => this.update({ status: "idle", current_task_id: null }));
@@ -249,13 +251,13 @@ export class Worker extends ActiveRecord {
 
   /** Mark as unavailable for auto-assignment (reserved state). */
   markReserved(): void {
-    this.isAvailable = false;
+    this.status = "reserved";
     Worker.events.emit("changed");
   }
 
   /** Mark as available for auto-assignment (ready state). */
   markAvailable(): void {
-    this.isAvailable = true;
+    this.status = "ready";
     Worker.events.emit("changed");
   }
 
@@ -295,9 +297,12 @@ export class Worker extends ActiveRecord {
   }
 
   toWire(): Wire.Worker {
+    // Wire.Worker.status uses the legacy DB vocabulary — map back for the dashboard.
+    const wireStatus: Wire.Worker["status"] =
+      this.status === "assigned" ? "busy" : this.status === "disconnected" ? "disconnected" : "idle";
     return {
       workerId: this.workerId,
-      status: this.status,
+      status: wireStatus,
       currentTaskId: this.currentTaskId,
       repo: this.repo?.fullName ?? this.repoFullName,
       numConnections: this.numConnections,

--- a/src/foreman/models/worker.ts
+++ b/src/foreman/models/worker.ts
@@ -42,7 +42,7 @@ export class Worker extends ActiveRecord {
   disconnectedAt?: Date;
 
   /** True when the worker is eligible for auto-assignment (i.e. status is "ready"). */
-  get isAvailable(): boolean { return this.status === "ready"; }
+  get isReady(): boolean { return this.status === "ready"; }
 
   // Fields populated from DB row (undefined for synthetic registry instances)
   readonly repoFullName?: string;
@@ -65,11 +65,7 @@ export class Worker extends ActiveRecord {
   private constructor(row: WorkerDbRow) {
     super();
     this.workerId = row.worker_id;
-    // Map DB column values (idle/busy/disconnected) to in-memory vocabulary.
-    // "idle" → "ready" (reserved is not persisted; both write "idle" to DB).
-    // "busy" → "assigned". "disconnected" is unchanged.
-    const dbStatus = row.status as "idle" | "busy" | "disconnected";
-    this.status = dbStatus === "idle" ? "ready" : dbStatus === "busy" ? "assigned" : "disconnected";
+    this.status = row.status as "ready" | "reserved" | "assigned" | "disconnected";
     this.repoFullName = (row as any).repos?.full_name ?? undefined;
     this.numConnections = row.num_connections ?? undefined;
     this.firstConnectedAt = row.first_connected_at ?? undefined;
@@ -199,7 +195,7 @@ export class Worker extends ActiveRecord {
     if (existing) {
       await existing.update({
         repo_id: repo.id,
-        status: "idle",
+        status: "ready",
         current_task_id: null,
         last_connected_at: now,
         num_connections: (existing.numConnections ?? 0) + 1,
@@ -210,7 +206,7 @@ export class Worker extends ActiveRecord {
       await Worker.insert({
         worker_id: workerId,
         repo_id: repo.id,
-        status: "idle",
+        status: "ready",
         current_task_id: null,
         first_connected_at: now,
         last_connected_at: now,
@@ -231,14 +227,14 @@ export class Worker extends ActiveRecord {
     this.status = "assigned";
     this.currentTask = task;
     Worker.events.emit("changed");
-    this._chain(() => this.update({ status: "busy", current_task_id: task.taskId }));
+    this._chain(() => this.update({ status: "assigned", current_task_id: task.taskId }));
   }
 
   release(): void {
     this.status = "ready";
     this.currentTask = undefined;
     Worker.events.emit("changed");
-    this._chain(() => this.update({ status: "idle", current_task_id: null }));
+    this._chain(() => this.update({ status: "ready", current_task_id: null }));
   }
 
   /** Release the task but stay reserved — not eligible for auto-assignment. */
@@ -246,7 +242,7 @@ export class Worker extends ActiveRecord {
     this.status = "reserved";
     this.currentTask = undefined;
     Worker.events.emit("changed");
-    this._chain(() => this.update({ status: "idle", current_task_id: null }));
+    this._chain(() => this.update({ status: "reserved", current_task_id: null }));
   }
 
   /** Mark as unavailable for auto-assignment (reserved state). */
@@ -297,12 +293,9 @@ export class Worker extends ActiveRecord {
   }
 
   toWire(): Wire.Worker {
-    // Wire.Worker.status uses the legacy DB vocabulary — map back for the dashboard.
-    const wireStatus: Wire.Worker["status"] =
-      this.status === "assigned" ? "busy" : this.status === "disconnected" ? "disconnected" : "idle";
     return {
       workerId: this.workerId,
-      status: wireStatus,
+      status: this.status,
       currentTaskId: this.currentTaskId,
       repo: this.repo?.fullName ?? this.repoFullName,
       numConnections: this.numConnections,

--- a/src/foreman/models/worker.ts
+++ b/src/foreman/models/worker.ts
@@ -39,6 +39,8 @@ export class Worker extends ActiveRecord {
 
   readonly workerId: string;
   status: "idle" | "busy" | "disconnected";
+  /** In-memory only — false when worker is in "reserved" state (registered but not eligible for auto-assignment). */
+  isAvailable = true;
   disconnectedAt?: Date;
 
   // Fields populated from DB row (undefined for synthetic registry instances)
@@ -101,6 +103,7 @@ export class Worker extends ActiveRecord {
     }
     worker.repo = repo;
     worker.status = "idle";
+    worker.isAvailable = true;
     worker.currentTask = undefined;
     worker.disconnectedAt = undefined;
     sockets.set(workerId, ws);
@@ -121,7 +124,7 @@ export class Worker extends ActiveRecord {
   }
 
   static getIdle(): Worker[] {
-    return [...registry.values()].filter((w) => w.status === "idle");
+    return [...registry.values()].filter((w) => w.status === "idle" && w.isAvailable);
   }
 
   static getByTask(taskId: string): Worker | undefined {
@@ -229,9 +232,31 @@ export class Worker extends ActiveRecord {
 
   release(): void {
     this.status = "idle";
+    this.isAvailable = true;
     this.currentTask = undefined;
     Worker.events.emit("changed");
     this._chain(() => this.update({ status: "idle", current_task_id: null }));
+  }
+
+  /** Release the task but stay reserved — not eligible for auto-assignment. */
+  releaseReserved(): void {
+    this.status = "idle";
+    this.isAvailable = false;
+    this.currentTask = undefined;
+    Worker.events.emit("changed");
+    this._chain(() => this.update({ status: "idle", current_task_id: null }));
+  }
+
+  /** Mark as unavailable for auto-assignment (reserved state). */
+  markReserved(): void {
+    this.isAvailable = false;
+    Worker.events.emit("changed");
+  }
+
+  /** Mark as available for auto-assignment (ready state). */
+  markAvailable(): void {
+    this.isAvailable = true;
+    Worker.events.emit("changed");
   }
 
   markDisconnected(): void {

--- a/supabase/migrations/20260502000000_worker_status_vocabulary.sql
+++ b/supabase/migrations/20260502000000_worker_status_vocabulary.sql
@@ -1,0 +1,5 @@
+-- Migrate worker status column to use the new protocol vocabulary.
+-- idle → ready, busy → assigned (reserved/disconnected are already correct).
+UPDATE workers SET status = 'ready' WHERE status = 'idle';
+UPDATE workers SET status = 'assigned' WHERE status = 'busy';
+ALTER TABLE workers ALTER COLUMN status SET DEFAULT 'ready';

--- a/tests/browser/dashboard.spec.ts
+++ b/tests/browser/dashboard.spec.ts
@@ -118,12 +118,12 @@ test("live task assignment: dashboard updates without page reload", async ({
     const taskRow = tasksSection.getByRole("row").filter({ hasText: "#2001" });
     await expect(taskRow.getByText("assigned")).toBeVisible();
 
-    // Workers section header shows "1 busy" (or at least the worker item
-    // contains "busy" next to the worker prefix)
+    // Workers section header shows "1 assigned" (or at least the worker item
+    // contains "assigned" next to the worker prefix)
     const workerItem = page
       .getByRole("listitem")
       .filter({ has: page.locator(`a[href="/workers/${workerId}"]`) });
-    await expect(workerItem.getByText("busy")).toBeVisible();
+    await expect(workerItem.getByText("assigned")).toBeVisible();
   } finally {
     await disconnectWorker(workerId);
   }

--- a/tests/browser/server.ts
+++ b/tests/browser/server.ts
@@ -101,7 +101,7 @@ async function handleTestRoute(
       const ws = new WebSocket(`ws://localhost:${PORT}/worker`);
       await new Promise<void>((resolve, reject) => {
         ws.once("open", () => {
-          ws.send(JSON.stringify({ type: "worker_hello", repo: "owner/repo", workerId, status: "idle" }));
+          ws.send(JSON.stringify({ type: "worker_hello", repo: "owner/repo", workerId, status: "ready" }));
           ws.once("message", () => resolve()); // hello_ack
         });
         ws.once("error", reject);

--- a/tests/browser/worker-detail.spec.ts
+++ b/tests/browser/worker-detail.spec.ts
@@ -93,7 +93,7 @@ test("worker detail: appends next page and removes load-more after last page", a
     });
   });
   await page.route("**/api/workers/pg-worker", async (route) => {
-    await route.fulfill({ json: { workerId: "pg-worker", status: "idle" } });
+    await route.fulfill({ json: { workerId: "pg-worker", status: "ready" } });
   });
 
   await page.goto("/workers/pg-worker");
@@ -118,7 +118,7 @@ test("worker detail: passes before cursor from last entry of current page", asyn
     await route.fulfill({ json: before ? makeWorkerMessages(PAGE_SIZE, 3) : firstPage });
   });
   await page.route("**/api/workers/pg-worker", async (route) => {
-    await route.fulfill({ json: { workerId: "pg-worker", status: "idle" } });
+    await route.fulfill({ json: { workerId: "pg-worker", status: "ready" } });
   });
 
   await page.goto("/workers/pg-worker");

--- a/tests/foreman.admin-broadcast.test.ts
+++ b/tests/foreman.admin-broadcast.test.ts
@@ -118,11 +118,11 @@ describe("foreman admin broadcast — hello_ack log event summary", () => {
     adminWss.broadcastLogEvent = (entry) => logEntries.push(entry);
 
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "worker-abc", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "worker-abc", status: "ready" });
     await waitUntil(() => logEntries.some((e) => e.summary.includes("hello_ack")));
 
     const entry = logEntries.find((e) => e.summary.includes("hello_ack"));
-    expect(entry?.summary).toContain("idle");
+    expect(entry?.summary).toContain("ready");
   });
 
   it("hello_ack busy includes status and taskId in summary", async () => {
@@ -137,11 +137,11 @@ describe("foreman admin broadcast — hello_ack log event summary", () => {
     adminWss.broadcastLogEvent = (entry) => logEntries.push(entry);
 
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "worker-abc", status: "busy", taskId: "42" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "worker-abc", status: "assigned", taskId: "42" });
     await waitUntil(() => logEntries.some((e) => e.summary.includes("hello_ack")));
 
     const entry = logEntries.find((e) => e.summary.includes("hello_ack"));
-    expect(entry?.summary).toContain("busy");
+    expect(entry?.summary).toContain("assigned");
     expect(entry?.summary).toContain("42");
   });
 
@@ -158,7 +158,7 @@ describe("foreman admin broadcast — hello_ack log event summary", () => {
     adminWss.broadcastLogEvent = (entry) => logEntries.push(entry);
 
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "worker-xyz", status: "busy", taskId: "42" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "worker-xyz", status: "assigned", taskId: "42" });
     await waitUntil(() => logEntries.some((e) => e.summary.includes("hello_ack")));
 
     const entry = logEntries.find((e) => e.summary.includes("hello_ack"));

--- a/tests/foreman.claim-task.test.ts
+++ b/tests/foreman.claim-task.test.ts
@@ -72,7 +72,7 @@ describe("handleClaimTask", () => {
     await wss.handleClaimTask("w1", { type: "claim_task", workerId: "w1", taskId: "10" });
 
     expect(Worker.fromRegistry("w1")?.currentTaskId).toBe("10");
-    expect(Worker.fromRegistry("w1")?.status).toBe("busy");
+    expect(Worker.fromRegistry("w1")?.status).toBe("assigned");
   });
 
   it("sends foreman_error (non-fatal) when task does not exist", async () => {

--- a/tests/foreman.hello-handlers.test.ts
+++ b/tests/foreman.hello-handlers.test.ts
@@ -591,7 +591,7 @@ describe("handleReservedHello", () => {
     // Worker is in registry...
     expect(Worker.fromRegistry("w1")).toBeDefined();
     // ...but NOT available for auto-assignment
-    expect(Worker.fromRegistry("w1")?.isAvailable).toBe(false);
+    expect(Worker.fromRegistry("w1")?.isReady).toBe(false);
     // No task_assigned was sent
     const assigned = sendMsg.mock.calls.find(([, msg]) => (msg as { type: string }).type === "task_assigned");
     expect(assigned).toBeUndefined();
@@ -612,7 +612,7 @@ describe("handleReservedHello", () => {
     expect(revertSpy).toHaveBeenCalled();
     const ack = helloAck(sendMsg);
     expect(ack?.status).toBe("reserved");
-    expect(Worker.fromRegistry("w1")?.isAvailable).toBe(false);
+    expect(Worker.fromRegistry("w1")?.isReady).toBe(false);
   });
 
   it("stores repo on the registered Worker", async () => {
@@ -629,11 +629,11 @@ describe("handleWorkerReady", () => {
   it("marks worker as available", async () => {
     const { wss } = makeWss(taskManager);
     await wss.handleReservedHello("w1", fakeWs(), taskManager.repo);
-    expect(Worker.fromRegistry("w1")?.isAvailable).toBe(false);
+    expect(Worker.fromRegistry("w1")?.isReady).toBe(false);
 
     await wss.handleWorkerReady("w1");
 
-    expect(Worker.fromRegistry("w1")?.isAvailable).toBe(true);
+    expect(Worker.fromRegistry("w1")?.isReady).toBe(true);
   });
 
   it("no-op when worker not in registry", async () => {

--- a/tests/foreman.hello-handlers.test.ts
+++ b/tests/foreman.hello-handlers.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for ForemanWss.handleBusyHello and ForemanWss.handleIdleHello.
+ * Unit tests for ForemanWss.handleAssignedHello and ForemanWss.handleReadyHello.
  *
  * Each reconnection case is verified by calling the public methods directly on
  * a ForemanWss instance with sendMsg spied out.
@@ -50,22 +50,22 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-// ── handleBusyHello ────────────────────────────────────────────────────────────
+// ── handleAssignedHello ────────────────────────────────────────────────────────────
 
-describe("handleBusyHello", () => {
+describe("handleAssignedHello", () => {
   describe("unknown task", () => {
     it("numeric taskId — creates placeholder and sends busy ack", async () => {
       const { wss, sendMsg } = makeWss(taskManager);
-      await wss.handleBusyHello("w1", "42", fakeWs(), fakeRepo());
+      await wss.handleAssignedHello("w1", "42", fakeWs(), fakeRepo());
 
       const ack = helloAck(sendMsg);
-      expect(ack?.status).toBe("busy");
+      expect(ack?.status).toBe("assigned");
       expect(Worker.fromRegistry("w1")?.currentTaskId).toBe("42");
     });
 
     it("non-numeric taskId — sends cancelled ack", async () => {
       const { wss, sendMsg } = makeWss(taskManager);
-      await wss.handleBusyHello("w1", "not-a-number", fakeWs(), fakeRepo());
+      await wss.handleAssignedHello("w1", "not-a-number", fakeWs(), fakeRepo());
 
       const ack = helloAck(sendMsg);
       expect(ack?.status).toBe("cancelled");
@@ -85,10 +85,10 @@ describe("handleBusyHello", () => {
       const assignSpy = vi.spyOn(Task.prototype, "assign");
 
       const { wss, sendMsg } = makeWss(taskManager);
-      await wss.handleBusyHello("w1", "10", fakeWs(), fakeRepo());
+      await wss.handleAssignedHello("w1", "10", fakeWs(), fakeRepo());
 
       const ack = helloAck(sendMsg);
-      expect(ack?.status).toBe("busy");
+      expect(ack?.status).toBe("assigned");
       // task.assign must NOT be called because task is already complete
       expect(assignSpy).not.toHaveBeenCalled();
       expect(Worker.fromRegistry("w1")?.currentTaskId).toBe("10");
@@ -105,7 +105,7 @@ describe("handleBusyHello", () => {
       });
 
       const { wss, sendMsg } = makeWss(taskManager);
-      await wss.handleBusyHello("w1", "10", fakeWs(), fakeRepo());
+      await wss.handleAssignedHello("w1", "10", fakeWs(), fakeRepo());
 
       const ack = helloAck(sendMsg);
       expect(ack?.status).toBe("cancelled");
@@ -123,7 +123,7 @@ describe("handleBusyHello", () => {
       });
 
       const { wss, sendMsg } = makeWss(taskManager);
-      await wss.handleBusyHello("w1", "10", fakeWs(), fakeRepo());
+      await wss.handleAssignedHello("w1", "10", fakeWs(), fakeRepo());
 
       const ack = helloAck(sendMsg);
       expect(ack?.status).toBe("cancelled");
@@ -140,10 +140,10 @@ describe("handleBusyHello", () => {
       const assignSpy = vi.spyOn(Task.prototype, "assign");
 
       const { wss, sendMsg } = makeWss(taskManager);
-      await wss.handleBusyHello("w1", "10", fakeWs(), fakeRepo());
+      await wss.handleAssignedHello("w1", "10", fakeWs(), fakeRepo());
 
       const ack = helloAck(sendMsg);
-      expect(ack?.status).toBe("busy");
+      expect(ack?.status).toBe("assigned");
       expect(assignSpy).toHaveBeenCalledWith(expect.objectContaining({ workerId: "w1" }));
       expect(Worker.fromRegistry("w1")?.currentTaskId).toBe("10");
 
@@ -158,10 +158,10 @@ describe("handleBusyHello", () => {
       const assignSpy = vi.spyOn(Task.prototype, "assign");
 
       const { wss, sendMsg } = makeWss(taskManager);
-      await wss.handleBusyHello("w1", "10", fakeWs(), fakeRepo());
+      await wss.handleAssignedHello("w1", "10", fakeWs(), fakeRepo());
 
       const ack = helloAck(sendMsg);
-      expect(ack?.status).toBe("busy");
+      expect(ack?.status).toBe("assigned");
       expect(assignSpy).toHaveBeenCalledWith(expect.objectContaining({ workerId: "w1" }));
     });
   });
@@ -180,7 +180,7 @@ describe("handleBusyHello", () => {
       taskManager.queueEvent(task, { toWorkerPayload: () => ({ name: "issue_comment", payload: {} }), eventName: "issue_comment" } as any);
 
       const { wss, sendMsg } = makeWss(taskManager);
-      await wss.handleBusyHello("w1", "10", fakeWs(), fakeRepo());
+      await wss.handleAssignedHello("w1", "10", fakeWs(), fakeRepo());
 
       const eventNotifs = sendMsg.mock.calls.filter(
         ([, msg]) => (msg as { type: string }).type === "event_notification"
@@ -190,15 +190,15 @@ describe("handleBusyHello", () => {
   });
 });
 
-// ── handleIdleHello ────────────────────────────────────────────────────────────
+// ── handleReadyHello ────────────────────────────────────────────────────────────
 
-describe("handleIdleHello", () => {
+describe("handleReadyHello", () => {
   it("no prior task — registers worker and sends idle ack", async () => {
     const { wss, sendMsg } = makeWss(taskManager);
-    await wss.handleIdleHello("w1", fakeWs(), fakeRepo());
+    await wss.handleReadyHello("w1", fakeWs(), fakeRepo());
 
     const ack = helloAck(sendMsg);
-    expect(ack?.status).toBe("idle");
+    expect(ack?.status).toBe("ready");
     expect(Worker.fromRegistry("w1")?.status).toBe("idle");
 
     await new Promise((r) => setTimeout(r, 20));
@@ -217,11 +217,11 @@ describe("handleIdleHello", () => {
     const revertSpy = vi.spyOn(Task.prototype, "revert");
 
     const { wss, sendMsg } = makeWss(taskManager);
-    await wss.handleIdleHello("w1", fakeWs(), fakeRepo());
+    await wss.handleReadyHello("w1", fakeWs(), fakeRepo());
 
     expect(revertSpy).toHaveBeenCalled();
     const ack = helloAck(sendMsg);
-    expect(ack?.status).toBe("idle");
+    expect(ack?.status).toBe("ready");
     expect(Worker.fromRegistry("w1")?.status).toBe("idle");
   });
 
@@ -236,7 +236,7 @@ describe("handleIdleHello", () => {
 
     const { wss, sendMsg } = makeWss(taskManager);
     const logSpy = vi.spyOn(utils, "log").mockImplementation(() => {});
-    await expect(wss.handleIdleHello("w1", fakeWs(), fakeRepo())).resolves.toBeUndefined();
+    await expect(wss.handleReadyHello("w1", fakeWs(), fakeRepo())).resolves.toBeUndefined();
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("ERROR"));
     // Worker must NOT be registered — allowing a new assignment would leave two tasks
     // pointing at this worker in the DB.
@@ -258,7 +258,7 @@ describe("handleIdleHello", () => {
     const { wss } = makeWss(taskManager);
     vi.spyOn(utils, "log").mockImplementation(() => {});
     const ws = fakeWs();
-    await wss.handleIdleHello("w1", ws, fakeRepo());
+    await wss.handleReadyHello("w1", ws, fakeRepo());
 
     const errorCall = ws.send.mock.calls.find(([data]: [string]) => {
       const msg = JSON.parse(data);
@@ -274,46 +274,46 @@ describe("handleIdleHello", () => {
 // ── repo stored on Worker ──────────────────────────────────────────────────────
 
 describe("repo stored on Worker", () => {
-  it("handleIdleHello stores repo on registered Worker", async () => {
+  it("handleReadyHello stores repo on registered Worker", async () => {
     const { wss } = makeWss(taskManager);
     const repo = fakeRepo("acme/widget");
-    await wss.handleIdleHello("w1", fakeWs(), repo);
+    await wss.handleReadyHello("w1", fakeWs(), repo);
     expect(Worker.fromRegistry("w1")?.repo).toBe(repo);
   });
 
-  it("handleBusyHello stores repo on registered Worker", async () => {
+  it("handleAssignedHello stores repo on registered Worker", async () => {
     await seedTask({ task_id: "10", issue_number: 10, repo_id: taskManager.repo.id, worker_id: "w1", assigned_at: new Date().toISOString() });
     const { wss } = makeWss(taskManager);
     const repo = fakeRepo("acme/widget");
-    await wss.handleBusyHello("w1", "10", fakeWs(), repo);
+    await wss.handleAssignedHello("w1", "10", fakeWs(), repo);
     expect(Worker.fromRegistry("w1")?.repo).toBe(repo);
   });
 
   it("Repo.findOrCreate is called with msg.repo from worker_hello", async () => {
     const findOrCreateSpy = vi.spyOn(Repo, "findOrCreate").mockResolvedValue(fakeRepo("owner/repo") as unknown as Repo);
     // Trigger via the full WS message path by calling handleWorkerHello-equivalent logic
-    // through handleIdleHello directly with a pre-resolved repo (spy verifies the call).
+    // through handleReadyHello directly with a pre-resolved repo (spy verifies the call).
     const resolvedRepo = await Repo.findOrCreate("owner/repo");
     expect(findOrCreateSpy).toHaveBeenCalledWith("owner/repo");
     expect(resolvedRepo.fullName).toBe("owner/repo");
   });
 });
 
-// ── handleBusyHello error handling ─────────────────────────────────────────────
+// ── handleAssignedHello error handling ─────────────────────────────────────────────
 //
-// All errors in handleBusyHello are transient DB errors (Task.get failing,
+// All errors in handleAssignedHello are transient DB errors (Task.get failing,
 // Task.upsert failing, or task.assign failing during reclaim). These are
 // recoverable — the DB may be temporarily down — so fatal: false is correct.
 // The worker retries on reconnect and the operation succeeds once the DB recovers.
 
-describe("handleBusyHello — error handling", () => {
+describe("handleAssignedHello — error handling", () => {
   it("sends foreman_error (non-fatal) when Task.get throws (DB read failure)", async () => {
     vi.spyOn(Task, "get").mockRejectedValueOnce(new Error("DB connection lost"));
 
     const { wss } = makeWss(taskManager);
     vi.spyOn(utils, "log").mockImplementation(() => {});
     const ws = fakeWs();
-    await wss.handleBusyHello("w1", "10", ws, fakeRepo());
+    await wss.handleAssignedHello("w1", "10", ws, fakeRepo());
 
     const errorCall = ws.send.mock.calls.find(([data]: [string]) => {
       const msg = JSON.parse(data);
@@ -332,7 +332,7 @@ describe("handleBusyHello — error handling", () => {
     const { wss } = makeWss(taskManager);
     vi.spyOn(utils, "log").mockImplementation(() => {});
     const ws = fakeWs();
-    await wss.handleBusyHello("w1", "42", ws, fakeRepo());
+    await wss.handleAssignedHello("w1", "42", ws, fakeRepo());
 
     const errorCall = ws.send.mock.calls.find(([data]: [string]) => {
       const msg = JSON.parse(data);
@@ -357,7 +357,7 @@ describe("handleBusyHello — error handling", () => {
     const { wss } = makeWss(taskManager);
     vi.spyOn(utils, "log").mockImplementation(() => {});
     const ws = fakeWs();
-    await wss.handleBusyHello("w1", "10", ws, fakeRepo());
+    await wss.handleAssignedHello("w1", "10", ws, fakeRepo());
 
     const errorCall = ws.send.mock.calls.find(([data]: [string]) => {
       const msg = JSON.parse(data);
@@ -370,21 +370,21 @@ describe("handleBusyHello — error handling", () => {
   });
 });
 
-// ── handleIdleHello error handling ─────────────────────────────────────────────
+// ── handleReadyHello error handling ─────────────────────────────────────────────
 //
-// All errors in handleIdleHello are transient DB errors (Task.getByWorker
+// All errors in handleReadyHello are transient DB errors (Task.getByWorker
 // failing, or priorTask.revert failing). These are recoverable — the DB may be
 // temporarily down — so fatal: false is correct in both cases. The worker
 // retries on reconnect and the operation succeeds once the DB recovers.
 
-describe("handleIdleHello — error handling", () => {
+describe("handleReadyHello — error handling", () => {
   it("sends foreman_error (non-fatal) when Task.getByWorker throws (DB read failure)", async () => {
     vi.spyOn(Task, "getByWorker").mockRejectedValueOnce(new Error("DB connection lost"));
 
     const { wss } = makeWss(taskManager);
     vi.spyOn(utils, "log").mockImplementation(() => {});
     const ws = fakeWs();
-    await wss.handleIdleHello("w1", ws, fakeRepo());
+    await wss.handleReadyHello("w1", ws, fakeRepo());
 
     const errorCall = ws.send.mock.calls.find(([data]: [string]) => {
       const msg = JSON.parse(data);
@@ -401,7 +401,7 @@ describe("handleIdleHello — error handling", () => {
 
     const { wss, sendMsg } = makeWss(taskManager);
     vi.spyOn(utils, "log").mockImplementation(() => {});
-    await wss.handleIdleHello("w1", fakeWs(), fakeRepo());
+    await wss.handleReadyHello("w1", fakeWs(), fakeRepo());
 
     expect(Worker.fromRegistry("w1")).toBeUndefined();
     const ackCall = sendMsg.mock.calls.find(([, msg]) => (msg as { type: string }).type === "hello_ack");
@@ -413,7 +413,7 @@ describe("handleIdleHello — error handling", () => {
 // ── sendError persistence ──────────────────────────────────────────────────────
 
 describe("sendError — ForemanMessage.log() is called", () => {
-  it("persists foreman_error to activity log when handleIdleHello revert fails", async () => {
+  it("persists foreman_error to activity log when handleReadyHello revert fails", async () => {
     await seedTask({
       task_id: "10",
       issue_number: 10,
@@ -426,7 +426,7 @@ describe("sendError — ForemanMessage.log() is called", () => {
     vi.spyOn(utils, "log").mockImplementation(() => {});
 
     const { wss } = makeWss(taskManager);
-    await wss.handleIdleHello("w1", fakeWs(), fakeRepo());
+    await wss.handleReadyHello("w1", fakeWs(), fakeRepo());
 
     const errorLogCall = logSpy.mock.calls.find(([data]) => data.msgType === "foreman_error");
     expect(errorLogCall).toBeDefined();
@@ -436,7 +436,7 @@ describe("sendError — ForemanMessage.log() is called", () => {
     expect((errorLogCall![0].payload as { message?: string }).message).toContain("DB down");
   });
 
-  it("persists foreman_error to activity log when handleBusyHello throws", async () => {
+  it("persists foreman_error to activity log when handleAssignedHello throws", async () => {
     await seedTask({
       task_id: "10",
       issue_number: 10,
@@ -450,7 +450,7 @@ describe("sendError — ForemanMessage.log() is called", () => {
     vi.spyOn(utils, "log").mockImplementation(() => {});
 
     const { wss } = makeWss(taskManager);
-    await wss.handleBusyHello("w1", "10", fakeWs(), fakeRepo());
+    await wss.handleAssignedHello("w1", "10", fakeWs(), fakeRepo());
 
     const errorLogCall = logSpy.mock.calls.find(([data]) => data.msgType === "foreman_error");
     expect(errorLogCall).toBeDefined();
@@ -463,24 +463,24 @@ describe("sendError — ForemanMessage.log() is called", () => {
 // ── repoStatus in hello_ack ────────────────────────────────────────────────────
 
 describe("repoStatus in hello_ack", () => {
-  it("handleIdleHello sends repoStatus: 'new' for a new repo", async () => {
+  it("handleReadyHello sends repoStatus: 'new' for a new repo", async () => {
     const { wss, sendMsg } = makeWss(taskManager);
     const repo = fakeRepo("new/repo");
-    await wss.handleIdleHello("w1", fakeWs(), repo);
+    await wss.handleReadyHello("w1", fakeWs(), repo);
 
     const ack = helloAck(sendMsg) as { status: string; repoStatus: string } | undefined;
-    expect(ack?.status).toBe("idle");
+    expect(ack?.status).toBe("ready");
     expect(ack?.repoStatus).toBe("new");
   });
 
-  it("handleIdleHello sends repoStatus: 'active' for an active repo", async () => {
+  it("handleReadyHello sends repoStatus: 'active' for an active repo", async () => {
     const repo = await createTestRepo("active/repo");
     await repo.activate();
     const { wss, sendMsg } = makeWss(taskManager);
-    await wss.handleIdleHello("w1", fakeWs(), repo);
+    await wss.handleReadyHello("w1", fakeWs(), repo);
 
     const ack = helloAck(sendMsg) as { status: string; repoStatus: string } | undefined;
-    expect(ack?.status).toBe("idle");
+    expect(ack?.status).toBe("ready");
     expect(ack?.repoStatus).toBe("active");
   });
 
@@ -488,7 +488,7 @@ describe("repoStatus in hello_ack", () => {
     await seedTask({ task_id: "10", issue_number: 10, repo_id: taskManager.repo.id, worker_id: "w2", assigned_at: new Date().toISOString() });
     const { wss, sendMsg } = makeWss(taskManager);
     const repo = fakeRepo("some/repo", 1, "active");
-    await wss.handleBusyHello("w1", "10", fakeWs(), repo);
+    await wss.handleAssignedHello("w1", "10", fakeWs(), repo);
 
     const ack = helloAck(sendMsg) as { status: string; repoStatus: string } | undefined;
     expect(ack?.status).toBe("cancelled");
@@ -499,10 +499,10 @@ describe("repoStatus in hello_ack", () => {
     await seedTask({ task_id: "10", issue_number: 10, repo_id: taskManager.repo.id, worker_id: "w1", assigned_at: new Date().toISOString() });
     const { wss, sendMsg } = makeWss(taskManager);
     const repo = fakeRepo("some/repo", 1, "active");
-    await wss.handleBusyHello("w1", "10", fakeWs(), repo);
+    await wss.handleAssignedHello("w1", "10", fakeWs(), repo);
 
     const ack = helloAck(sendMsg) as { status: string; repoStatus: string } | undefined;
-    expect(ack?.status).toBe("busy");
+    expect(ack?.status).toBe("assigned");
     expect(ack?.repoStatus).toBe("active");
   });
 });
@@ -527,7 +527,7 @@ describe("activate_repo", () => {
     vi.spyOn(TaskManager.prototype, "loadIssuesFromGithub").mockResolvedValue(undefined);
 
     const ws = fakeWs();
-    await wss.handleIdleHello("w1", ws, repo);
+    await wss.handleReadyHello("w1", ws, repo);
     await wss.handleActivateRepo("w1", ws);
 
     const activatedCall = sendMsg.mock.calls.find(([, msg]) => (msg as { type: string }).type === "repo_activated");
@@ -542,7 +542,7 @@ describe("activate_repo", () => {
 
     const { wss } = makeWssForActivate();
     const ws = fakeWs();
-    await wss.handleIdleHello("w1", ws, repo);
+    await wss.handleReadyHello("w1", ws, repo);
     await wss.handleActivateRepo("w1", ws);
 
     expect(activateSpy).toHaveBeenCalled();
@@ -556,7 +556,7 @@ describe("activate_repo", () => {
 
     const { wss } = makeWssForActivate();
     const ws = fakeWs();
-    await wss.handleIdleHello("w1", ws, repo);
+    await wss.handleReadyHello("w1", ws, repo);
     await wss.handleActivateRepo("w1", ws);
 
     const errorCall = ws.send.mock.calls.find(([data]: [string]) => {
@@ -576,105 +576,120 @@ describe("activate_repo", () => {
   });
 });
 
-// ── handleClaimHello ───────────────────────────────────────────────────────────
+// ── handleReservedHello ────────────────────────────────────────────────────────
 
-describe("handleClaimHello", () => {
-  beforeEach(async () => {
+describe("handleReservedHello", () => {
+  it("registers worker, sends hello_ack with status='reserved', worker is NOT immediately assigned a task", async () => {
     await taskManager.repo.activate();
-  });
-
-  it("sends idle hello_ack then task_assigned for a valid unassigned task", async () => {
     await seedTask({ task_id: "77", issue_number: 77, repo_id: taskManager.repo.id });
-    const { wss, sendMsg } = makeWss(taskManager);
 
-    await wss.handleClaimHello("w1", "77", fakeWs(), taskManager.repo);
+    const { wss, sendMsg } = makeWss(taskManager);
+    await wss.handleReservedHello("w1", fakeWs(), taskManager.repo);
 
     const ack = helloAck(sendMsg);
-    expect(ack?.status).toBe("idle");
-
-    const assignedCall = sendMsg.mock.calls.find(([, msg]) => (msg as { type: string }).type === "task_assigned");
-    expect(assignedCall).toBeDefined();
-    expect((assignedCall![1] as { taskId: string }).taskId).toBe("77");
+    expect(ack?.status).toBe("reserved");
+    // Worker is in registry...
+    expect(Worker.fromRegistry("w1")).toBeDefined();
+    // ...but NOT available for auto-assignment
+    expect(Worker.fromRegistry("w1")?.isAvailable).toBe(false);
+    // No task_assigned was sent
+    const assigned = sendMsg.mock.calls.find(([, msg]) => (msg as { type: string }).type === "task_assigned");
+    expect(assigned).toBeUndefined();
   });
 
-  it("registers worker as busy with the claimed task", async () => {
-    await seedTask({ task_id: "77", issue_number: 77, repo_id: taskManager.repo.id });
-    const { wss } = makeWss(taskManager);
+  it("reverts a stale prior assignment and sends reserved ack", async () => {
+    await seedTask({
+      task_id: "77",
+      issue_number: 77,
+      worker_id: "w1",
+      assigned_at: new Date().toISOString(),
+    });
+    const revertSpy = vi.spyOn(Task.prototype, "revert");
 
-    await wss.handleClaimHello("w1", "77", fakeWs(), taskManager.repo);
-
-    expect(Worker.fromRegistry("w1")?.status).toBe("busy");
-    expect(Worker.fromRegistry("w1")?.currentTaskId).toBe("77");
-  });
-
-  it("sends foreman_error (non-fatal) when task does not exist", async () => {
     const { wss, sendMsg } = makeWss(taskManager);
+    await wss.handleReservedHello("w1", fakeWs(), taskManager.repo);
 
-    await wss.handleClaimHello("w1", "999", fakeWs(), taskManager.repo);
-
+    expect(revertSpy).toHaveBeenCalled();
     const ack = helloAck(sendMsg);
-    expect(ack?.status).toBe("idle");
-
-    const errorCall = sendMsg.mock.calls.find(([, msg]) => (msg as { type: string }).type === "foreman_error");
-    expect(errorCall).toBeDefined();
-    expect((errorCall![1] as { fatal: boolean }).fatal).toBe(false);
-    expect((errorCall![1] as { message: string }).message).toContain("999");
+    expect(ack?.status).toBe("reserved");
+    expect(Worker.fromRegistry("w1")?.isAvailable).toBe(false);
   });
 
-  it("worker is idle when claim fails", async () => {
+  it("stores repo on the registered Worker", async () => {
     const { wss } = makeWss(taskManager);
-    await wss.handleClaimHello("w1", "nonexistent", fakeWs(), taskManager.repo);
-    expect(Worker.fromRegistry("w1")?.status).toBe("idle");
-  });
-
-  it("sends foreman_error when task is held by an active worker", async () => {
-    const repo = taskManager.repo;
-    // Seed task with worker_id set so claimTask sees it as assigned in the DB
-    const task = await seedTask({ task_id: "77", issue_number: 77, repo_id: repo.id, worker_id: "w2", assigned_at: new Date().toISOString() });
-    const w2 = Worker.register("w2", fakeWs(), repo);
-    w2.assign(task);
-
-    const { wss, sendMsg } = makeWss(taskManager);
-    await wss.handleClaimHello("w1", "77", fakeWs(), repo);
-
-    const errorCall = sendMsg.mock.calls.find(([, msg]) => (msg as { type: string }).type === "foreman_error");
-    expect(errorCall).toBeDefined();
-    expect((errorCall![1] as { fatal: boolean }).fatal).toBe(false);
+    const repo = fakeRepo("acme/widget");
+    await wss.handleReservedHello("w1", fakeWs(), repo);
+    expect(Worker.fromRegistry("w1")?.repo).toBe(repo);
   });
 });
 
-// ── handleWorkerHello routing for claimTaskId ──────────────────────────────────
+// ── handleWorkerReady ─────────────────────────────────────────────────────────
 
-describe("handleWorkerHello with claimTaskId", () => {
-  it("routes to handleClaimHello when hello has claimTaskId and status is idle", async () => {
+describe("handleWorkerReady", () => {
+  it("marks worker as available", async () => {
     const { wss } = makeWss(taskManager);
-    vi.spyOn(Repo, "findOrCreate").mockResolvedValue(taskManager.repo as unknown as Repo);
-    const claimHelloSpy = vi.spyOn(wss, "handleClaimHello").mockResolvedValue();
+    await wss.handleReservedHello("w1", fakeWs(), taskManager.repo);
+    expect(Worker.fromRegistry("w1")?.isAvailable).toBe(false);
 
-    await wss.handleWorkerHello("w1", fakeWs(), {
-      type: "worker_hello",
-      workerId: "w1",
-      repo: "owner/repo",
-      status: "idle",
-      claimTaskId: "77",
-    });
+    await wss.handleWorkerReady("w1");
 
-    expect(claimHelloSpy).toHaveBeenCalledWith("w1", "77", expect.anything(), taskManager.repo);
+    expect(Worker.fromRegistry("w1")?.isAvailable).toBe(true);
   });
 
-  it("routes to handleIdleHello when hello has no claimTaskId", async () => {
+  it("no-op when worker not in registry", async () => {
+    const { wss } = makeWss(taskManager);
+    await expect(wss.handleWorkerReady("unknown-worker")).resolves.toBeUndefined();
+  });
+});
+
+// ── handleWorkerHello routing ──────────────────────────────────────────────────
+
+describe("handleWorkerHello routing", () => {
+  it("status='assigned' with taskId → routes to handleAssignedHello", async () => {
     const { wss } = makeWss(taskManager);
     vi.spyOn(Repo, "findOrCreate").mockResolvedValue(taskManager.repo as unknown as Repo);
-    const idleHelloSpy = vi.spyOn(wss, "handleIdleHello").mockResolvedValue();
+    const spy = vi.spyOn(wss, "handleAssignedHello" as any).mockResolvedValue(undefined);
+    await seedTask({ task_id: "77", issue_number: 77, repo_id: taskManager.repo.id });
 
     await wss.handleWorkerHello("w1", fakeWs(), {
       type: "worker_hello",
       workerId: "w1",
       repo: "owner/repo",
-      status: "idle",
+      taskId: "77",
+      status: "assigned",
     });
 
-    expect(idleHelloSpy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith("w1", "77", expect.anything(), expect.anything());
+  });
+
+  it("status='reserved' → routes to handleReservedHello", async () => {
+    const { wss } = makeWss(taskManager);
+    vi.spyOn(Repo, "findOrCreate").mockResolvedValue(taskManager.repo as unknown as Repo);
+    const spy = vi.spyOn(wss, "handleReservedHello" as any).mockResolvedValue(undefined);
+
+    await wss.handleWorkerHello("w1", fakeWs(), {
+      type: "worker_hello",
+      workerId: "w1",
+      repo: "owner/repo",
+      status: "reserved",
+    });
+
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("status='ready' → routes to handleReadyHello", async () => {
+    const { wss } = makeWss(taskManager);
+    vi.spyOn(Repo, "findOrCreate").mockResolvedValue(taskManager.repo as unknown as Repo);
+    const spy = vi.spyOn(wss, "handleReadyHello" as any).mockResolvedValue(undefined);
+
+    await wss.handleWorkerHello("w1", fakeWs(), {
+      type: "worker_hello",
+      workerId: "w1",
+      repo: "owner/repo",
+      status: "ready",
+    });
+
+    expect(spy).toHaveBeenCalled();
   });
 });
 

--- a/tests/foreman.hello-handlers.test.ts
+++ b/tests/foreman.hello-handlers.test.ts
@@ -150,7 +150,7 @@ describe("handleAssignedHello", () => {
       await new Promise((r) => setTimeout(r, 20));
       const dbWorker = await Worker.get("w1");
       expect(dbWorker?.workerId).toBe("w1");
-      expect(dbWorker?.status).toBe("busy");
+      expect(dbWorker?.status).toBe("assigned");
     });
 
     it("unassigned — reclaims (busy ack, task.assign called)", async () => {
@@ -199,12 +199,12 @@ describe("handleReadyHello", () => {
 
     const ack = helloAck(sendMsg);
     expect(ack?.status).toBe("ready");
-    expect(Worker.fromRegistry("w1")?.status).toBe("idle");
+    expect(Worker.fromRegistry("w1")?.status).toBe("ready");
 
     await new Promise((r) => setTimeout(r, 20));
     const dbWorker = await Worker.get("w1");
     expect(dbWorker?.workerId).toBe("w1");
-    expect(dbWorker?.status).toBe("idle");
+    expect(dbWorker?.status).toBe("ready");
   });
 
   it("has prior task — reverts it and sends idle ack", async () => {
@@ -222,7 +222,7 @@ describe("handleReadyHello", () => {
     expect(revertSpy).toHaveBeenCalled();
     const ack = helloAck(sendMsg);
     expect(ack?.status).toBe("ready");
-    expect(Worker.fromRegistry("w1")?.status).toBe("idle");
+    expect(Worker.fromRegistry("w1")?.status).toBe("ready");
   });
 
   it("revert failure is logged and worker is NOT registered (task stays assigned, worker retries)", async () => {

--- a/tests/foreman.multi-repo.test.ts
+++ b/tests/foreman.multi-repo.test.ts
@@ -354,7 +354,7 @@ describe("Full activation → assignment flow", () => {
     port = await startServer();
 
     // Worker connects for repo-a (new repo).
-    const ws = await connect({ type: "worker_hello", repo: "owner/repo-a", workerId: "w1", status: "idle" });
+    const ws = await connect({ type: "worker_hello", repo: "owner/repo-a", workerId: "w1", status: "ready" });
     const q = makeQueue(ws);
 
     const ack = await q.next() as { type: string; repoStatus: string };
@@ -392,10 +392,10 @@ describe("Multi-repo assignment isolation: two workers, two repos", () => {
     port = await startServer();
 
     // Connect both workers; set up queues immediately to avoid losing early messages.
-    const wsA = await connect({ type: "worker_hello", repo: "owner/repo-a", workerId: "wA", status: "idle" });
+    const wsA = await connect({ type: "worker_hello", repo: "owner/repo-a", workerId: "wA", status: "ready" });
     const qA = makeQueue(wsA);
 
-    const wsB = await connect({ type: "worker_hello", repo: "owner/repo-b", workerId: "wB", status: "idle" });
+    const wsB = await connect({ type: "worker_hello", repo: "owner/repo-b", workerId: "wB", status: "ready" });
     const qB = makeQueue(wsB);
 
     // Consume hello_acks then task_assigned for each worker.
@@ -430,7 +430,7 @@ describe("Multi-repo assignment isolation: two workers, two repos", () => {
     ({ wss } = new ForemanWss({ server: httpServer, config: defaultCfg }));
     port = await startServer();
 
-    const ws = await connect({ type: "worker_hello", repo: "owner/repo-a", workerId: "wA", status: "idle" });
+    const ws = await connect({ type: "worker_hello", repo: "owner/repo-a", workerId: "wA", status: "ready" });
     const q = makeQueue(ws);
     await q.next(); // hello_ack
 
@@ -461,7 +461,7 @@ describe("Negative: worker from repo-a cannot claim task from repo-b", () => {
 
     // Worker from repo-a claims task "t63b" which belongs to repo-b.
     const fakeWs = { send: vi.fn(), close: vi.fn(), readyState: 1 } as any;
-    await foremanWss.handleBusyHello("wA", "t63b", fakeWs, m1.repo);
+    await foremanWss.handleAssignedHello("wA", "t63b", fakeWs, m1.repo);
 
     const ackCall = sendMsg.mock.calls.find(([, msg]) => (msg as { type: string }).type === "hello_ack");
     expect(ackCall).toBeDefined();

--- a/tests/foreman.multi-repo.test.ts
+++ b/tests/foreman.multi-repo.test.ts
@@ -435,11 +435,11 @@ describe("Multi-repo assignment isolation: two workers, two repos", () => {
     await q.next(); // hello_ack
 
     // Give assignWork time to run — the worker should NOT receive a task.
-    await waitUntil(() => Worker.fromRegistry("wA")?.status === "idle");
+    await waitUntil(() => Worker.fromRegistry("wA")?.status === "ready");
 
     // repo-b's task stays pending.
     expect((await Task.get("t62b"))?.status).toBe("pending");
-    expect(Worker.fromRegistry("wA")?.status).toBe("idle");
+    expect(Worker.fromRegistry("wA")?.status).toBe("ready");
   });
 });
 

--- a/tests/foreman.reconcile.test.ts
+++ b/tests/foreman.reconcile.test.ts
@@ -62,7 +62,7 @@ describe("reconcile()", () => {
 
     expect(fakeWs.send).toHaveBeenCalledWith(expect.stringContaining('"task_assigned"'), expect.any(Function));
     expect((await Task.get("42"))?.status).toBe("assigned");
-    expect(Worker.fromRegistry("w1")?.status).toBe("busy");
+    expect(Worker.fromRegistry("w1")?.status).toBe("assigned");
   });
 
   it("does NOT remove an assigned task (reconcile never deletes)", async () => {

--- a/tests/foreman.registry.test.ts
+++ b/tests/foreman.registry.test.ts
@@ -17,7 +17,7 @@ beforeEach(() => { Worker._reset(); });
 describe("Worker", () => {
   it("registers a worker and retrieves it", () => {
     Worker.register("w1", fakeWs(), fakeRepo());
-    expect(Worker.fromRegistry("w1")).toMatchObject({ workerId: "w1", status: "idle" });
+    expect(Worker.fromRegistry("w1")).toMatchObject({ workerId: "w1", status: "ready" });
   });
 
   it("getIdle returns an idle worker", () => {
@@ -34,7 +34,7 @@ describe("Worker", () => {
   it("assign marks worker busy with taskId", () => {
     const w = Worker.register("w1", fakeWs(), fakeRepo());
     w.assign(fakeTask("42"));
-    expect(w.status).toBe("busy");
+    expect(w.status).toBe("assigned");
     expect(w.currentTaskId).toBe("42");
   });
 
@@ -42,7 +42,7 @@ describe("Worker", () => {
     const w = Worker.register("w1", fakeWs(), fakeRepo());
     w.assign(fakeTask("42"));
     w.release();
-    expect(w.status).toBe("idle");
+    expect(w.status).toBe("ready");
     expect(w.currentTaskId).toBeUndefined();
   });
 
@@ -83,7 +83,8 @@ describe("Worker", () => {
   it("toWire returns WorkerSnapshot", () => {
     const w = Worker.register("w1", fakeWs(), fakeRepo());
     w.assign(fakeTask("42"));
-    expect(w.toWire()).toEqual({ workerId: "w1", status: "busy", currentTaskId: "42", repo: "owner/repo" });
+    // toWire maps internal "assigned" → "busy" for Wire.Worker dashboard compat
+    expect(w.toWire()).toMatchObject({ workerId: "w1", status: "busy", currentTaskId: "42", repo: "owner/repo" });
   });
 
   describe("markDisconnected", () => {

--- a/tests/foreman.registry.test.ts
+++ b/tests/foreman.registry.test.ts
@@ -83,8 +83,7 @@ describe("Worker", () => {
   it("toWire returns WorkerSnapshot", () => {
     const w = Worker.register("w1", fakeWs(), fakeRepo());
     w.assign(fakeTask("42"));
-    // toWire maps internal "assigned" → "busy" for Wire.Worker dashboard compat
-    expect(w.toWire()).toMatchObject({ workerId: "w1", status: "busy", currentTaskId: "42", repo: "owner/repo" });
+    expect(w.toWire()).toMatchObject({ workerId: "w1", status: "assigned", currentTaskId: "42", repo: "owner/repo" });
   });
 
   describe("markDisconnected", () => {

--- a/tests/foreman.startup.test.ts
+++ b/tests/foreman.startup.test.ts
@@ -146,7 +146,7 @@ describe("tryAssignWork — assign persistence", () => {
 
     port = await startServer();
     const ws = await connect({ type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
-    await waitUntil(() => Worker.fromRegistry("w1")?.status === "idle");
+    await waitUntil(() => Worker.fromRegistry("w1")?.status === "ready");
 
     expect((await Task.get("42"))?.status).toBe("pending");
   });
@@ -197,7 +197,7 @@ describe("startup reconnect behaviour", () => {
 
     port = await startServer();
     const ws = await connect({ type: "worker_hello", repo: "owner/repo", workerId: "new-worker", status: "ready" });
-    await waitUntil(() => Worker.fromRegistry("new-worker")?.status === "idle");
+    await waitUntil(() => Worker.fromRegistry("new-worker")?.status === "ready");
 
     // new-worker should NOT get task 42 — it belongs to original-worker
     expect((await Task.get("42"))?.status).toBe("assigned");
@@ -215,7 +215,7 @@ describe("startup reconnect behaviour", () => {
     port = await startServer();
     await connect({ type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "assigned", taskId: "42" });
 
-    await waitUntil(() => Worker.fromRegistry("w1")?.status === "busy");
+    await waitUntil(() => Worker.fromRegistry("w1")?.status === "assigned");
     expect((await Task.get("42"))?.status).toBe("assigned");
     expect((await Task.get("42"))?.workerId).toBe("w1");
   });
@@ -434,7 +434,7 @@ describe("startup — restore tasks from tasks table (DB is source of truth)", (
 
     // Step 4: an idle worker connects — must NOT receive the already-assigned task
     const ws = await connect({ type: "worker_hello", repo: "owner/repo", workerId: "new-worker", status: "ready" });
-    await waitUntil(() => Worker.fromRegistry("new-worker")?.status === "idle");
+    await waitUntil(() => Worker.fromRegistry("new-worker")?.status === "ready");
 
     expect((await Task.get("42"))?.workerId).toBe("original-worker");
   });
@@ -496,7 +496,7 @@ describe("startup reconnect — worker reconnects to complete task", () => {
 
     await waitUntil(() => Worker.fromRegistry("w1") !== undefined);
     // Worker should be reclaimed as busy to allow finalization work
-    expect(Worker.fromRegistry("w1")?.status).toBe("busy");
+    expect(Worker.fromRegistry("w1")?.status).toBe("assigned");
     // Task should stay complete
     expect((await Task.get("42"))?.status).toBe("complete");
   });
@@ -519,10 +519,10 @@ describe("startup reconnect — worker reconnects to complete task", () => {
     const spyComplete = vi.spyOn(t2!, "complete");
 
     ws.send(JSON.stringify({ type: "task_complete", workerId: "w1", taskId: "42" }));
-    await waitUntil(() => Worker.fromRegistry("w1")?.status === "idle");
+    await waitUntil(() => Worker.fromRegistry("w1")?.status === "ready");
 
     // The task was already complete; task_complete is still a no-op (idempotent)
-    expect(Worker.fromRegistry("w1")?.status).toBe("idle");
+    expect(Worker.fromRegistry("w1")?.status).toBe("ready");
   });
 });
 
@@ -540,13 +540,13 @@ describe("task_complete marks task complete", () => {
     port = await startServer();
     const ws = await connect({ type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "assigned", taskId: "42" });
 
-    await waitUntil(() => Worker.fromRegistry("w1")?.status === "busy");
+    await waitUntil(() => Worker.fromRegistry("w1")?.status === "assigned");
 
     // Spy on the prototype so we capture the call regardless of which instance is used
     const spyComplete = vi.spyOn(Task.prototype, "complete");
 
     ws.send(JSON.stringify({ type: "task_complete", workerId: "w1", taskId: "42" }));
-    await waitUntil(() => Worker.fromRegistry("w1")?.status === "idle");
+    await waitUntil(() => Worker.fromRegistry("w1")?.status === "ready");
 
     expect(spyComplete).toHaveBeenCalled();
   });

--- a/tests/foreman.startup.test.ts
+++ b/tests/foreman.startup.test.ts
@@ -125,7 +125,7 @@ describe("tryAssignWork — assign persistence", () => {
     ({ wss } = new ForemanWss({ server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
 
     port = await startServer();
-    const ws = await connect({ type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    const ws = await connect({ type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     const q = makeQueue(ws);
     await q.next(); // hello_ack
     const msg = await q.next(); // task_assigned
@@ -145,7 +145,7 @@ describe("tryAssignWork — assign persistence", () => {
     ({ wss } = new ForemanWss({ server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
 
     port = await startServer();
-    const ws = await connect({ type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    const ws = await connect({ type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await waitUntil(() => Worker.fromRegistry("w1")?.status === "idle");
 
     expect((await Task.get("42"))?.status).toBe("pending");
@@ -156,7 +156,7 @@ describe("tryAssignWork — assign persistence", () => {
     ({ wss } = new ForemanWss({ server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
 
     port = await startServer();
-    const ws = await connect({ type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    const ws = await connect({ type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     const q = makeQueue(ws);
     await q.next(); // hello_ack
     const msg = await q.next(); // task_assigned
@@ -178,7 +178,7 @@ describe("startup reconnect behaviour", () => {
     ({ wss } = new ForemanWss({ server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
 
     port = await startServer();
-    const ws = await connect({ type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    const ws = await connect({ type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     const q = makeQueue(ws);
     await q.next(); // hello_ack
     const msg = await q.next(); // task_assigned
@@ -196,7 +196,7 @@ describe("startup reconnect behaviour", () => {
     ({ wss } = new ForemanWss({ server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
 
     port = await startServer();
-    const ws = await connect({ type: "worker_hello", repo: "owner/repo", workerId: "new-worker", status: "idle" });
+    const ws = await connect({ type: "worker_hello", repo: "owner/repo", workerId: "new-worker", status: "ready" });
     await waitUntil(() => Worker.fromRegistry("new-worker")?.status === "idle");
 
     // new-worker should NOT get task 42 — it belongs to original-worker
@@ -213,7 +213,7 @@ describe("startup reconnect behaviour", () => {
     ({ wss } = new ForemanWss({ server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
 
     port = await startServer();
-    await connect({ type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "busy", taskId: "42" });
+    await connect({ type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "assigned", taskId: "42" });
 
     await waitUntil(() => Worker.fromRegistry("w1")?.status === "busy");
     expect((await Task.get("42"))?.status).toBe("assigned");
@@ -392,7 +392,7 @@ describe("startup — restore tasks from tasks table (DB is source of truth)", (
     await localForemanWss.reconcile();
 
     // Step 4: worker connects and receives task_assigned with real body/labels
-    const ws = await connect({ type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    const ws = await connect({ type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     const q = makeQueue(ws);
     await q.next(); // hello_ack
     const msg = await q.next() as { type: string; issue: { body: string; labels: string[] } };
@@ -433,7 +433,7 @@ describe("startup — restore tasks from tasks table (DB is source of truth)", (
     expect((await Task.get("42"))?.status).toBe("assigned");
 
     // Step 4: an idle worker connects — must NOT receive the already-assigned task
-    const ws = await connect({ type: "worker_hello", repo: "owner/repo", workerId: "new-worker", status: "idle" });
+    const ws = await connect({ type: "worker_hello", repo: "owner/repo", workerId: "new-worker", status: "ready" });
     await waitUntil(() => Worker.fromRegistry("new-worker")?.status === "idle");
 
     expect((await Task.get("42"))?.workerId).toBe("original-worker");
@@ -492,7 +492,7 @@ describe("startup reconnect — worker reconnects to complete task", () => {
     ({ wss } = new ForemanWss({ server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
 
     port = await startServer();
-    await connect({ type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "busy", taskId: "42" });
+    await connect({ type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "assigned", taskId: "42" });
 
     await waitUntil(() => Worker.fromRegistry("w1") !== undefined);
     // Worker should be reclaimed as busy to allow finalization work
@@ -511,7 +511,7 @@ describe("startup reconnect — worker reconnects to complete task", () => {
     ({ wss } = new ForemanWss({ server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
 
     port = await startServer();
-    const ws = await connect({ type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "busy", taskId: "42" });
+    const ws = await connect({ type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "assigned", taskId: "42" });
 
     await waitUntil(() => Worker.fromRegistry("w1") !== undefined);
     // Spy on complete after the task is already obtained
@@ -538,7 +538,7 @@ describe("task_complete marks task complete", () => {
     ({ wss } = new ForemanWss({ server: httpServer, config: { ...defaultCfg, taskLabel: "brunel:ready" } }));
 
     port = await startServer();
-    const ws = await connect({ type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "busy", taskId: "42" });
+    const ws = await connect({ type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "assigned", taskId: "42" });
 
     await waitUntil(() => Worker.fromRegistry("w1")?.status === "busy");
 

--- a/tests/foreman.timestamps.test.ts
+++ b/tests/foreman.timestamps.test.ts
@@ -140,7 +140,7 @@ afterEach(() => {
 describe("foreman log timestamps", () => {
   it("worker hello log lines start with ISO 8601 timestamp", async () => {
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "worker-abc123", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "worker-abc123", status: "ready" });
     await waitUntil(() => !!Worker.fromRegistry("worker-abc123"));
 
     expect(logLines.length).toBeGreaterThan(0);
@@ -154,7 +154,7 @@ describe("foreman log timestamps", () => {
 
     const ws = await connect();
     const reply = nextMsgWhere(ws, (m) => m.type === "task_assigned");
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "worker-abc123", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "worker-abc123", status: "ready" });
     await reply;
 
     for (const line of logLines) {
@@ -166,7 +166,7 @@ describe("foreman log timestamps", () => {
     await registerReady(taskManager, "1", 1, "owner/repo", "Fix the thing", "Body", []);
 
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "worker-abc123", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "worker-abc123", status: "ready" });
     await nextMsgWhere(ws, (m) => m.type === "task_assigned");
 
     logLines.length = 0;
@@ -181,7 +181,7 @@ describe("foreman log timestamps", () => {
 
   it("task enqueue log line starts with ISO 8601 timestamp", async () => {
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "worker-abc123", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "worker-abc123", status: "ready" });
     await waitUntil(() => !!Worker.fromRegistry("worker-abc123"));
 
     logLines.length = 0;

--- a/tests/foreman.webhook-routing.test.ts
+++ b/tests/foreman.webhook-routing.test.ts
@@ -307,7 +307,7 @@ describe("webhook-triggered task routing", () => {
     expect((msg as any).issue.title).toBe("Issue 42");
     expect((msg as any).issue.repoUrl).toBe("https://github.com/owner/repo");
     expect((await Task.get("42"))?.status).toBe("assigned");
-    expect(Worker.fromRegistry("w1")?.status).toBe("busy");
+    expect(Worker.fromRegistry("w1")?.status).toBe("assigned");
   });
 
   it("issues/labeled with non-task label does not enqueue or assign", async () => {
@@ -388,7 +388,7 @@ describe("webhook-triggered task routing", () => {
     expect(msg.type).toBe("task_assigned");
     expect((msg as any).issue.number).toBe(99);
     expect((await Task.get("99"))?.status).toBe("assigned");
-    expect(Worker.fromRegistry("w1")?.status).toBe("busy");
+    expect(Worker.fromRegistry("w1")?.status).toBe("assigned");
   });
 
   it("issues/opened without task label does not enqueue", async () => {

--- a/tests/foreman.webhook-routing.test.ts
+++ b/tests/foreman.webhook-routing.test.ts
@@ -292,7 +292,7 @@ describe("webhook-triggered task routing", () => {
   it("issues/labeled with task label assigns task to idle worker", async () => {
     // Worker connects idle (no tasks yet)
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await waitUntil(() => !!Worker.fromRegistry("w1"));
 
     // Webhook fires: issue #42 gets labeled brunel:ready.
@@ -313,7 +313,7 @@ describe("webhook-triggered task routing", () => {
   it("issues/labeled with non-task label does not enqueue or assign", async () => {
     const ws = await connect();
     const ackP = nextMsg(ws);
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await ackP; // consume hello_ack (worker is now registered)
 
     // No message should arrive after an unrelated label event
@@ -352,7 +352,7 @@ describe("webhook-triggered task routing", () => {
     // Worker connects afterwards — use nextMsgWhere to skip hello_ack and get task_assigned
     const ws = await connect();
     const reply = nextMsgWhere(ws, (m) => m.type === "task_assigned");
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
 
     const msg = await reply;
     expect(msg.type).toBe("task_assigned");
@@ -375,7 +375,7 @@ describe("webhook-triggered task routing", () => {
 
   it("issues/opened with task label in issue labels assigns task to idle worker", async () => {
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await waitUntil(() => !!Worker.fromRegistry("w1"));
 
     // Webhook fires: issue #99 opened with task label.
@@ -394,7 +394,7 @@ describe("webhook-triggered task routing", () => {
   it("issues/opened without task label does not enqueue", async () => {
     const ws = await connect();
     const ackP = nextMsg(ws);
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await ackP; // consume hello_ack
 
     foremanWss.routeEvent("evt-1", "issues", openedPayload(99, ["bug", "enhancement"]));
@@ -411,7 +411,7 @@ describe("webhook-triggered task routing", () => {
     // Give worker an existing task
     await registerReady(taskManager, "1", 1, "owner/repo", "First Issue", "Body", ["brunel:ready"]);
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await nextMsgWhere(ws, (m) => m.type === "task_assigned"); // task_assigned for issue 1
 
     // New issue arrives via webhook
@@ -436,7 +436,7 @@ describe("PR event forwarding to workers", () => {
 
     // Worker connects and receives the task
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await nextMsgWhere(ws, (m) => m.type === "task_assigned");
 
     // Worker opens a PR that closes issue #42
@@ -455,7 +455,7 @@ describe("PR event forwarding to workers", () => {
     await registerReady(taskManager, "42", 42, "owner/repo", "Issue 42", "Body", ["brunel:ready"]);
 
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await nextMsgWhere(ws, (m) => m.type === "task_assigned");
 
     await foremanWss.routeEvent("evt-pr", "pull_request", prOpenedPayload(10, "Closes #42"));
@@ -472,7 +472,7 @@ describe("PR event forwarding to workers", () => {
     await registerReady(taskManager, "42", 42, "owner/repo", "Issue 42", "Body", ["brunel:ready"]);
 
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await nextMsgWhere(ws, (m) => m.type === "task_assigned");
 
     await foremanWss.routeEvent("evt-pr", "pull_request", prOpenedPayload(10, "Resolves #42"));
@@ -489,7 +489,7 @@ describe("PR event forwarding to workers", () => {
     await registerReady(taskManager, "42", 42, "owner/repo", "Issue 42", "Body", ["brunel:ready"]);
 
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await nextMsgWhere(ws, (m) => m.type === "task_assigned");
 
     // PR with no linked issue — should be silently ignored
@@ -508,7 +508,7 @@ describe("PR event forwarding to workers", () => {
     await registerReady(taskManager, "42", 42, "owner/repo", "Issue 42", "Body", ["brunel:ready"]);
 
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await nextMsgWhere(ws, (m) => m.type === "task_assigned");
 
     // PR opened without closing keyword — not linked
@@ -532,7 +532,7 @@ describe("PR event forwarding to workers", () => {
     await registerReady(taskManager, "42", 42, "owner/repo", "Issue 42", "Body", ["brunel:ready"]);
 
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await nextMsgWhere(ws, (m) => m.type === "task_assigned");
 
     // PR opened without closing keyword — not linked
@@ -554,7 +554,7 @@ describe("PR event forwarding to workers", () => {
     await registerReady(taskManager, "42", 42, "owner/repo", "Issue 42", "Body", ["brunel:ready"]);
 
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await nextMsgWhere(ws, (m) => m.type === "task_assigned");
 
     // PR opened with closing keyword — linked
@@ -580,7 +580,7 @@ describe("PR event forwarding to workers", () => {
   it("check_run for unknown PR is silently dropped", async () => {
     const ws = await connect();
     const ackP = nextMsg(ws);
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await ackP; // consume hello_ack
 
     foremanWss.routeEvent("evt-cr", "check_run", checkRunPayload(999, "failure"));
@@ -595,7 +595,7 @@ describe("PR event forwarding to workers", () => {
     await registerReady(taskManager, "42", 42, "owner/repo", "Issue 42", "Body", ["brunel:ready"]);
 
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await nextMsgWhere(ws, (m) => m.type === "task_assigned");
 
     await foremanWss.routeEvent("evt-pr", "pull_request", prOpenedPayload(10, "Closes #42"));
@@ -611,7 +611,7 @@ describe("PR event forwarding to workers", () => {
   it("check_suite for unknown PR is silently dropped", async () => {
     const ws = await connect();
     const ackP = nextMsg(ws);
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await ackP; // consume hello_ack
 
     foremanWss.routeEvent("evt-cs", "check_suite", checkSuitePayload(999, "failure"));
@@ -625,7 +625,7 @@ describe("PR event forwarding to workers", () => {
   it("check_suite with empty pull_requests is routed by head_branch", async () => {
     await registerReady(taskManager, "42", 42, "owner/repo", "Issue 42", "Body", ["brunel:ready"]);
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await nextMsgWhere(ws, (m) => m.type === "task_assigned");
 
     await foremanWss.routeEvent("evt-pr", "pull_request", prOpenedPayload(10, "Closes #42", "fix-issue-42"));
@@ -641,7 +641,7 @@ describe("PR event forwarding to workers", () => {
   it("check_run with empty pull_requests is routed by head_branch", async () => {
     await registerReady(taskManager, "42", 42, "owner/repo", "Issue 42", "Body", ["brunel:ready"]);
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await nextMsgWhere(ws, (m) => m.type === "task_assigned");
 
     await foremanWss.routeEvent("evt-pr", "pull_request", prOpenedPayload(10, "Closes #42", "fix-issue-42"));
@@ -657,7 +657,7 @@ describe("PR event forwarding to workers", () => {
   it("check_suite with empty pull_requests and unknown branch is silently dropped", async () => {
     const ws = await connect();
     const ackP = nextMsg(ws);
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await ackP; // consume hello_ack
 
     foremanWss.routeEvent("evt-cs", "check_suite", checkSuitePayloadByBranch("unknown-branch", "failure"));
@@ -672,7 +672,7 @@ describe("PR event forwarding to workers", () => {
     await registerReady(taskManager, "42", 42, "owner/repo", "Issue 42", "Body", ["brunel:ready"]);
 
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await nextMsgWhere(ws, (m) => m.type === "task_assigned");
 
     foremanWss.routeEvent("evt-pr-open", "pull_request", prOpenedPayload(10, "Closes #42"));
@@ -692,7 +692,7 @@ describe("PR event forwarding to workers", () => {
     await registerReady(taskManager, "42", 42, "owner/repo", "Issue 42", "Body", ["brunel:ready"]);
 
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await nextMsgWhere(ws, (m) => m.type === "task_assigned");
 
     foremanWss.routeEvent("evt-pr-open", "pull_request", prOpenedPayload(10, "Closes #42"));
@@ -708,7 +708,7 @@ describe("PR event forwarding to workers", () => {
     await registerReady(taskManager, "42", 42, "owner/repo", "Issue 42", "Body", ["brunel:ready"]);
 
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await nextMsgWhere(ws, (m) => m.type === "task_assigned");
 
     foremanWss.routeEvent("evt-pr-open", "pull_request", prOpenedPayload(10, "Closes #42"));
@@ -729,7 +729,7 @@ describe("PR event forwarding to workers", () => {
     await registerReady(taskManager, "42", 42, "owner/repo", "Issue 42", "Body", ["brunel:ready"]);
 
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await nextMsgWhere(ws, (m) => m.type === "task_assigned");
 
     // Worker opens PR #10 that closes issue #42
@@ -749,7 +749,7 @@ describe("foreman event filtering", () => {
     await registerReady(taskManager, "42", 42, "owner/repo", "Issue 42", "Body", ["brunel:ready"]);
 
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await nextMsgWhere(ws, (m) => m.type === "task_assigned");
 
     // Register PR for the task (now also forwarded as event_notification — consume it)
@@ -792,7 +792,7 @@ describe("foreman event filtering", () => {
 
   it('issues/unlabeled with task label does not remove an already-assigned task', async () => {
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await waitUntil(() => !!Worker.fromRegistry("w1"));
 
     const reply = nextMsgWhere(ws, (m) => m.type === "task_assigned");
@@ -858,7 +858,7 @@ describe("foreman event filtering", () => {
     await registerReady(taskManager, "42", 42, "owner/repo", "Issue 42", "Body", ["brunel:ready"]);
 
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await nextMsgWhere(ws, (m) => m.type === "task_assigned");
 
     const reply = nextMsgWhere(ws, m => m.type === "event_notification" && (m as any).event.name === "issues");
@@ -875,7 +875,7 @@ describe("foreman event filtering", () => {
     await registerReady(taskManager, "42", 42, "owner/repo", "Issue 42", "Body", ["brunel:ready"]);
 
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await nextMsgWhere(ws, (m) => m.type === "task_assigned");
 
     const reply = nextMsgWhere(ws, m => m.type === "event_notification" && (m as any).event.name === "issues");

--- a/tests/foreman.websocket.test.ts
+++ b/tests/foreman.websocket.test.ts
@@ -133,7 +133,7 @@ describe("foreman WebSocket protocol", () => {
       new Promise<"timeout">((r) => setTimeout(() => r("timeout"), 50)),
     ]);
     expect(raceResult).toBe("timeout");
-    expect(Worker.fromRegistry("w1")?.status).toBe("idle");
+    expect(Worker.fromRegistry("w1")?.status).toBe("ready");
   });
 
   it("idle worker with pending task receives task_assigned", async () => {
@@ -147,7 +147,7 @@ describe("foreman WebSocket protocol", () => {
     expect(msg.issue.number).toBe(1);
     expect(msg.taskId).toBe("1");
     expect((await Task.get("1"))?.status).toBe("assigned");
-    expect(Worker.fromRegistry("w1")?.status).toBe("busy");
+    expect(Worker.fromRegistry("w1")?.status).toBe("assigned");
   });
 
   it("second idle worker gets no message when only task is already assigned", async () => {
@@ -183,7 +183,7 @@ describe("foreman WebSocket protocol", () => {
 
     const w1Status = Worker.fromRegistry("w1")?.status;
     const w2Status = Worker.fromRegistry("w2")?.status;
-    const busyCount = [w1Status, w2Status].filter((s) => s === "busy").length;
+    const busyCount = [w1Status, w2Status].filter((s) => s === "assigned").length;
     expect(busyCount).toBe(1);
 
     const task = await Task.get("42");
@@ -206,7 +206,7 @@ describe("foreman WebSocket protocol", () => {
 
     const w1Status = Worker.fromRegistry("w1")?.status;
     const w2Status = Worker.fromRegistry("w2")?.status;
-    const busyCount = [w1Status, w2Status].filter((s) => s === "busy").length;
+    const busyCount = [w1Status, w2Status].filter((s) => s === "assigned").length;
     expect(busyCount).toBe(1);
 
     const task = await Task.get("99");
@@ -257,7 +257,7 @@ describe("foreman WebSocket protocol", () => {
     await q.next(); // task_assigned
 
     send(ws, { type: "task_complete", workerId: "w1", taskId: "3001", stats: { inputTokens: 1000, outputTokens: 500, costUsd: 0.05 } });
-    await waitUntil(() => Worker.fromRegistry("w1")?.status === "idle");
+    await waitUntil(() => Worker.fromRegistry("w1")?.status === "ready");
 
     const task = await Task.get("3001");
     expect(task?.inputTokens).toBe(1000);
@@ -284,7 +284,7 @@ describe("foreman WebSocket protocol", () => {
     ]);
 
     expect(raceResult).toBe("timeout"); // no task_assigned (would reset in-progress session)
-    expect(Worker.fromRegistry("w1")?.status).toBe("busy");
+    expect(Worker.fromRegistry("w1")?.status).toBe("assigned");
     expect(Worker.fromRegistry("w1")?.currentTaskId).toBe("1");
     expect((await Task.get("1"))?.status).toBe("assigned");
   });
@@ -354,7 +354,7 @@ describe("foreman WebSocket protocol", () => {
       new Promise<"timeout">((r) => setTimeout(() => r("timeout"), 50)),
     ]);
     expect(raceResult2).toBe("timeout");
-    expect(Worker.fromRegistry("worker-a")?.status).toBe("busy");
+    expect(Worker.fromRegistry("worker-a")?.status).toBe("assigned");
   });
 
   it("task_complete releases worker to idle", async () => {
@@ -363,7 +363,7 @@ describe("foreman WebSocket protocol", () => {
     send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await nextMsg(ws); // task_assigned
     send(ws, { type: "task_complete", workerId: "w1", taskId: "1" });
-    await waitUntil(() => Worker.fromRegistry("w1")?.status === "idle");
+    await waitUntil(() => Worker.fromRegistry("w1")?.status === "ready");
     expect((await Task.get("1"))?.status).toBe("complete");
   });
 
@@ -379,7 +379,7 @@ describe("foreman WebSocket protocol", () => {
     const ws = await connect();
     send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", taskId: "1", status: "assigned" });
     await waitUntil(() => Worker.fromRegistry("w1") !== undefined);
-    expect(Worker.fromRegistry("w1")?.status).toBe("busy");
+    expect(Worker.fromRegistry("w1")?.status).toBe("assigned");
     expect(Worker.fromRegistry("w1")?.currentTaskId).toBe("1");
   });
 
@@ -466,7 +466,7 @@ describe("hello_ack handshake", () => {
     send(wsB, { type: "worker_hello", repo: "owner/repo", workerId: "worker-b", taskId: "1", status: "assigned" });
     const ack = await ackPromise;
     expect(ack).toMatchObject({ type: "hello_ack", workerId: "worker-b", status: "cancelled" });
-    expect(Worker.fromRegistry("worker-b")?.status).toBe("idle");
+    expect(Worker.fromRegistry("worker-b")?.status).toBe("ready");
   });
 
   it("worker reconnecting busy with nonexistent taskId receives cancelled status", async () => {
@@ -475,7 +475,7 @@ describe("hello_ack handshake", () => {
     send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", taskId: "nonexistent", status: "assigned" });
     const ack = await ackPromise;
     expect(ack).toMatchObject({ type: "hello_ack", workerId: "w1", status: "cancelled" });
-    expect(Worker.fromRegistry("w1")?.status).toBe("idle");
+    expect(Worker.fromRegistry("w1")?.status).toBe("ready");
   });
 
   it("allows worker to reclaim task even if complete (issue closed, same worker)", async () => {
@@ -490,7 +490,7 @@ describe("hello_ack handshake", () => {
     send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", taskId: "1", status: "assigned" });
     const ack = await ackPromise;
     expect(ack).toMatchObject({ type: "hello_ack", workerId: "w1", status: "assigned" });
-    expect(Worker.fromRegistry("w1")?.status).toBe("busy");
+    expect(Worker.fromRegistry("w1")?.status).toBe("assigned");
     expect(Worker.fromRegistry("w1")?.currentTaskId).toBe("1");
   });
 
@@ -506,7 +506,7 @@ describe("hello_ack handshake", () => {
     send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", taskId: "1", status: "assigned" });
     const ack = await ackPromise;
     expect(ack).toMatchObject({ type: "hello_ack", workerId: "w1", status: "cancelled" });
-    expect(Worker.fromRegistry("w1")?.status).toBe("idle");
+    expect(Worker.fromRegistry("w1")?.status).toBe("ready");
   });
 
   it("queued events are sent after hello_ack on reclaim", async () => {
@@ -667,8 +667,8 @@ describe("worker secret enforcement", () => {
   it("accepts any worker when workerSecret is not configured", async () => {
     const ws = await connect();
     send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
-    await waitUntil(() => Worker.fromRegistry("w1")?.status === "idle");
-    expect(Worker.fromRegistry("w1")?.status).toBe("idle");
+    await waitUntil(() => Worker.fromRegistry("w1")?.status === "ready");
+    expect(Worker.fromRegistry("w1")?.status).toBe("ready");
   });
 });
 
@@ -868,7 +868,7 @@ describe("disconnected worker state", () => {
       expect(msg.event.name).toBe("issue_comment");
     }
 
-    expect(Worker.fromRegistry("w1")?.status).toBe("busy");
+    expect(Worker.fromRegistry("w1")?.status).toBe("assigned");
     expect((await Task.get("1"))?.status).toBe("assigned");
   });
 
@@ -889,7 +889,7 @@ describe("disconnected worker state", () => {
     expect(msg.type).toBe("task_assigned");
     if (msg.type === "task_assigned") expect(msg.taskId).toBe("1");
 
-    expect(Worker.fromRegistry("w1")?.status).toBe("busy");
+    expect(Worker.fromRegistry("w1")?.status).toBe("assigned");
     expect((await Task.get("1"))?.status).toBe("assigned");
     expect((await Task.get("1"))?.workerId).toBe("w1");
   });
@@ -985,7 +985,7 @@ describe("worker_goodbye — revert persistence", () => {
 
     const ws = await connect();
     send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
-    await waitUntil(() => Worker.fromRegistry("w1")?.status === "busy");
+    await waitUntil(() => Worker.fromRegistry("w1")?.status === "assigned");
 
     send(ws, { type: "worker_goodbye", workerId: "w1", taskId: "1" });
     await waitUntil(() => Worker.fromRegistry("w1") === undefined);
@@ -1070,7 +1070,7 @@ describe("worker_goodbye with task_complete: true", () => {
 
     const ws = await connect();
     send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
-    await waitUntil(() => Worker.fromRegistry("w1")?.status === "busy");
+    await waitUntil(() => Worker.fromRegistry("w1")?.status === "assigned");
 
     send(ws, { type: "worker_goodbye", workerId: "w1", taskId: "1", task_complete: true });
     await waitUntil(() => Worker.fromRegistry("w1") === undefined);
@@ -1111,7 +1111,7 @@ describe("worker_hello — reclaim complete task for finalization work", () => {
     send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", taskId: "1", status: "assigned" });
     const ack = await ackPromise;
     expect(ack).toMatchObject({ type: "hello_ack", workerId: "w1", status: "assigned" });
-    expect(Worker.fromRegistry("w1")?.status).toBe("busy");
+    expect(Worker.fromRegistry("w1")?.status).toBe("assigned");
     expect(Worker.fromRegistry("w1")?.currentTaskId).toBe("1");
   });
 });
@@ -1147,7 +1147,7 @@ describe("stale close from old connection", () => {
     send(wsA, { type: "worker_hello", repo: "owner/repo", workerId: "worker-a", status: "ready" });
     await qA.next(); // hello_ack
     await qA.next(); // task_assigned
-    await waitUntil(() => Worker.fromRegistry("worker-a")?.status === "busy");
+    await waitUntil(() => Worker.fromRegistry("worker-a")?.status === "assigned");
 
     const wsA2 = await connect();
     const qA2 = makeQueue(wsA2);
@@ -1159,7 +1159,7 @@ describe("stale close from old connection", () => {
     await new Promise<void>((r) => wsA.once("close", r));
     for (let i = 0; i < 10; i++) await new Promise((r) => setImmediate(r));
 
-    expect(Worker.fromRegistry("worker-a")?.status).toBe("busy");
+    expect(Worker.fromRegistry("worker-a")?.status).toBe("assigned");
     expect(Worker.fromRegistry("worker-a")?.currentTaskId).toBe("1");
 
     wsA2.close();

--- a/tests/foreman.websocket.test.ts
+++ b/tests/foreman.websocket.test.ts
@@ -126,7 +126,7 @@ describe("foreman WebSocket protocol", () => {
   it("idle worker with no tasks receives no message", async () => {
     const ws = await connect();
     const ackP = nextMsg(ws);
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await ackP; // consume hello_ack
     const raceResult = await Promise.race([
       nextMsg(ws).then(() => "message" as const),
@@ -140,7 +140,7 @@ describe("foreman WebSocket protocol", () => {
     await makeTask(taskManager, 1);
     const ws = await connect();
     const q = makeQueue(ws);
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await q.next(); // hello_ack
     const msg = await q.next();
     assert(msg.type === "task_assigned");
@@ -155,11 +155,11 @@ describe("foreman WebSocket protocol", () => {
     const ws1 = await connect();
     const ws2 = await connect();
     const q1 = makeQueue(ws1);
-    send(ws1, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws1, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await q1.next(); // hello_ack
     await q1.next(); // task_assigned
     const ackP2 = nextMsg(ws2);
-    send(ws2, { type: "worker_hello", repo: "owner/repo", workerId: "w2", status: "idle" });
+    send(ws2, { type: "worker_hello", repo: "owner/repo", workerId: "w2", status: "ready" });
     await ackP2; // hello_ack
     const raceResult = await Promise.race([
       nextMsg(ws2).then(() => "message" as const),
@@ -173,9 +173,9 @@ describe("foreman WebSocket protocol", () => {
     const ws2 = await connect();
     const q1 = makeQueue(ws1);
     const q2 = makeQueue(ws2);
-    send(ws1, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws1, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await q1.next(); // hello_ack (no task yet)
-    send(ws2, { type: "worker_hello", repo: "owner/repo", workerId: "w2", status: "idle" });
+    send(ws2, { type: "worker_hello", repo: "owner/repo", workerId: "w2", status: "ready" });
     await q2.next(); // hello_ack (no task yet)
 
     await makeTask(taskManager, 42);
@@ -196,9 +196,9 @@ describe("foreman WebSocket protocol", () => {
     const ws2 = await connect();
     const q1 = makeQueue(ws1);
     const q2 = makeQueue(ws2);
-    send(ws1, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws1, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await q1.next(); // hello_ack (no task yet)
-    send(ws2, { type: "worker_hello", repo: "owner/repo", workerId: "w2", status: "idle" });
+    send(ws2, { type: "worker_hello", repo: "owner/repo", workerId: "w2", status: "ready" });
     await q2.next(); // hello_ack (no task yet)
 
     await makeTask(taskManager, 99);
@@ -220,7 +220,7 @@ describe("foreman WebSocket protocol", () => {
     await makeTask(taskManager, 1002);
     const ws = await connect();
     const q = makeQueue(ws);
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await q.next(); // hello_ack
     const first = await q.next();
     assert(first.type === "task_assigned");
@@ -238,7 +238,7 @@ describe("foreman WebSocket protocol", () => {
   it("task_complete with no further tasks sends no message", async () => {
     await makeTask(taskManager, 1);
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await nextMsg(ws); // task_assigned
     send(ws, { type: "task_complete", workerId: "w1", taskId: "1" });
     const raceResult = await Promise.race([
@@ -252,7 +252,7 @@ describe("foreman WebSocket protocol", () => {
     await makeTask(taskManager, 3001);
     const ws = await connect();
     const q = makeQueue(ws);
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await q.next(); // hello_ack
     await q.next(); // task_assigned
 
@@ -269,14 +269,14 @@ describe("foreman WebSocket protocol", () => {
     await makeTask(taskManager, 1);
     const ws1 = await connect();
     const q1 = makeQueue(ws1);
-    send(ws1, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws1, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await q1.next(); // hello_ack
     await q1.next(); // task_assigned
     await closeClient(ws1);
 
     const ws2 = await connect();
     const ackP = nextMsg(ws2);
-    send(ws2, { type: "worker_hello", repo: "owner/repo", workerId: "w1", taskId: "1", status: "busy" });
+    send(ws2, { type: "worker_hello", repo: "owner/repo", workerId: "w1", taskId: "1", status: "assigned" });
     await ackP; // hello_ack (status: busy)
     const raceResult = await Promise.race([
       nextMsg(ws2).then(() => "message" as const),
@@ -292,7 +292,7 @@ describe("foreman WebSocket protocol", () => {
   it("routeEvent sends event_notification to assigned worker", async () => {
     await makeTask(taskManager, 1);
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await nextMsg(ws); // task_assigned
 
     const reply = nextMsg(ws);
@@ -317,7 +317,7 @@ describe("foreman WebSocket protocol", () => {
     ws.send("not valid json {{{");
     await new Promise((r) => setTimeout(r, 20));
     const ackP = nextMsg(ws);
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await ackP; // hello_ack
     const raceResult = await Promise.race([
       nextMsg(ws).then(() => "message" as const),
@@ -330,14 +330,14 @@ describe("foreman WebSocket protocol", () => {
     await makeTask(taskManager, 1);
     const wsA = await connect();
     const qA = makeQueue(wsA);
-    send(wsA, { type: "worker_hello", repo: "owner/repo", workerId: "worker-a", status: "idle" });
+    send(wsA, { type: "worker_hello", repo: "owner/repo", workerId: "worker-a", status: "ready" });
     await qA.next(); // hello_ack
     await qA.next(); // task_assigned
     await closeClient(wsA);
 
     const wsB = await connect();
     const ackPB = nextMsg(wsB);
-    send(wsB, { type: "worker_hello", repo: "owner/repo", workerId: "worker-b", taskId: "1", status: "busy" });
+    send(wsB, { type: "worker_hello", repo: "owner/repo", workerId: "worker-b", taskId: "1", status: "assigned" });
     await ackPB; // hello_ack (status: cancelled — task belongs to A)
     const raceResultB = await Promise.race([
       nextMsg(wsB).then(() => "message" as const),
@@ -347,7 +347,7 @@ describe("foreman WebSocket protocol", () => {
 
     const wsA2 = await connect();
     const ackPA2 = nextMsg(wsA2);
-    send(wsA2, { type: "worker_hello", repo: "owner/repo", workerId: "worker-a", taskId: "1", status: "busy" });
+    send(wsA2, { type: "worker_hello", repo: "owner/repo", workerId: "worker-a", taskId: "1", status: "assigned" });
     await ackPA2; // hello_ack (status: busy)
     const raceResult2 = await Promise.race([
       nextMsg(wsA2).then(() => "message" as const),
@@ -360,7 +360,7 @@ describe("foreman WebSocket protocol", () => {
   it("task_complete releases worker to idle", async () => {
     await makeTask(taskManager, 1);
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await nextMsg(ws); // task_assigned
     send(ws, { type: "task_complete", workerId: "w1", taskId: "1" });
     await waitUntil(() => Worker.fromRegistry("w1")?.status === "idle");
@@ -377,7 +377,7 @@ describe("foreman WebSocket protocol", () => {
     await t!.complete();
 
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", taskId: "1", status: "busy" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", taskId: "1", status: "assigned" });
     await waitUntil(() => Worker.fromRegistry("w1") !== undefined);
     expect(Worker.fromRegistry("w1")?.status).toBe("busy");
     expect(Worker.fromRegistry("w1")?.currentTaskId).toBe("1");
@@ -389,7 +389,7 @@ describe("foreman WebSocket protocol", () => {
 
     const wsA = await connect();
     const qA = makeQueue(wsA);
-    send(wsA, { type: "worker_hello", repo: "owner/repo", workerId: "worker-a", status: "idle" });
+    send(wsA, { type: "worker_hello", repo: "owner/repo", workerId: "worker-a", status: "ready" });
     await qA.next(); // hello_ack
     const msgA = await qA.next();
     assert(msgA.type === "task_assigned");
@@ -398,7 +398,7 @@ describe("foreman WebSocket protocol", () => {
 
     const wsB = await connect();
     const qB = makeQueue(wsB);
-    send(wsB, { type: "worker_hello", repo: "owner/repo", workerId: "worker-b", status: "idle" });
+    send(wsB, { type: "worker_hello", repo: "owner/repo", workerId: "worker-b", status: "ready" });
     await qB.next(); // hello_ack
     const msgB = await qB.next();
     assert(msgB.type === "task_assigned");
@@ -430,16 +430,16 @@ describe("hello_ack handshake", () => {
   it("sends hello_ack with status idle when worker has no task", async () => {
     const ws = await connect();
     const ackPromise = nextMsg(ws);
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     const ack = await ackPromise;
-    expect(ack).toMatchObject({ type: "hello_ack", workerId: "w1", status: "idle" });
+    expect(ack).toMatchObject({ type: "hello_ack", workerId: "w1", status: "ready" });
   });
 
   it("sends hello_ack with status busy when worker reclaims its own task", async () => {
     await makeTask(taskManager, 1);
     const ws1 = await connect();
     const q1 = makeQueue(ws1);
-    send(ws1, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws1, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     const first = await q1.next(); // hello_ack
     expect(first.type).toBe("hello_ack");
     await q1.next(); // task_assigned
@@ -447,23 +447,23 @@ describe("hello_ack handshake", () => {
 
     const ws2 = await connect();
     const ackPromise = nextMsg(ws2);
-    send(ws2, { type: "worker_hello", repo: "owner/repo", workerId: "w1", taskId: "1", status: "busy" });
+    send(ws2, { type: "worker_hello", repo: "owner/repo", workerId: "w1", taskId: "1", status: "assigned" });
     const ack = await ackPromise;
-    expect(ack).toMatchObject({ type: "hello_ack", workerId: "w1", status: "busy" });
+    expect(ack).toMatchObject({ type: "hello_ack", workerId: "w1", status: "assigned" });
   });
 
   it("sends hello_ack with status cancelled when task was taken by another worker", async () => {
     await makeTask(taskManager, 1);
     const wsA = await connect();
     const qA = makeQueue(wsA);
-    send(wsA, { type: "worker_hello", repo: "owner/repo", workerId: "worker-a", status: "idle" });
+    send(wsA, { type: "worker_hello", repo: "owner/repo", workerId: "worker-a", status: "ready" });
     await qA.next(); // hello_ack
     await qA.next(); // task_assigned
     await closeClient(wsA);
 
     const wsB = await connect();
     const ackPromise = nextMsg(wsB);
-    send(wsB, { type: "worker_hello", repo: "owner/repo", workerId: "worker-b", taskId: "1", status: "busy" });
+    send(wsB, { type: "worker_hello", repo: "owner/repo", workerId: "worker-b", taskId: "1", status: "assigned" });
     const ack = await ackPromise;
     expect(ack).toMatchObject({ type: "hello_ack", workerId: "worker-b", status: "cancelled" });
     expect(Worker.fromRegistry("worker-b")?.status).toBe("idle");
@@ -472,7 +472,7 @@ describe("hello_ack handshake", () => {
   it("worker reconnecting busy with nonexistent taskId receives cancelled status", async () => {
     const ws = await connect();
     const ackPromise = nextMsg(ws);
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", taskId: "nonexistent", status: "busy" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", taskId: "nonexistent", status: "assigned" });
     const ack = await ackPromise;
     expect(ack).toMatchObject({ type: "hello_ack", workerId: "w1", status: "cancelled" });
     expect(Worker.fromRegistry("w1")?.status).toBe("idle");
@@ -487,9 +487,9 @@ describe("hello_ack handshake", () => {
 
     const ws = await connect();
     const ackPromise = nextMsg(ws);
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", taskId: "1", status: "busy" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", taskId: "1", status: "assigned" });
     const ack = await ackPromise;
-    expect(ack).toMatchObject({ type: "hello_ack", workerId: "w1", status: "busy" });
+    expect(ack).toMatchObject({ type: "hello_ack", workerId: "w1", status: "assigned" });
     expect(Worker.fromRegistry("w1")?.status).toBe("busy");
     expect(Worker.fromRegistry("w1")?.currentTaskId).toBe("1");
   });
@@ -503,7 +503,7 @@ describe("hello_ack handshake", () => {
 
     const ws = await connect();
     const ackPromise = nextMsg(ws);
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", taskId: "1", status: "busy" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", taskId: "1", status: "assigned" });
     const ack = await ackPromise;
     expect(ack).toMatchObject({ type: "hello_ack", workerId: "w1", status: "cancelled" });
     expect(Worker.fromRegistry("w1")?.status).toBe("idle");
@@ -519,9 +519,9 @@ describe("hello_ack handshake", () => {
     const ws = await connect();
     const messages: Wire.ForemanMessage[] = [];
     ws.on("message", (data) => messages.push(JSON.parse(data.toString())));
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", taskId: "1", status: "busy" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", taskId: "1", status: "assigned" });
     await waitUntil(() => messages.length >= 2);
-    expect(messages[0]).toMatchObject({ type: "hello_ack", status: "busy" });
+    expect(messages[0]).toMatchObject({ type: "hello_ack", status: "assigned" });
     expect(messages[1]).toMatchObject({ type: "event_notification" });
   });
 
@@ -529,12 +529,12 @@ describe("hello_ack handshake", () => {
     await makeTask(taskManager, 1);
     const wsA = await connect();
     const qA = makeQueue(wsA);
-    send(wsA, { type: "worker_hello", repo: "owner/repo", workerId: "worker-a", status: "idle" });
+    send(wsA, { type: "worker_hello", repo: "owner/repo", workerId: "worker-a", status: "ready" });
     await qA.next(); // hello_ack
     await qA.next(); // task_assigned
 
     const wsB = await connect();
-    send(wsB, { type: "worker_hello", repo: "owner/repo", workerId: "worker-b", status: "idle" });
+    send(wsB, { type: "worker_hello", repo: "owner/repo", workerId: "worker-b", status: "ready" });
     await nextMsg(wsB); // hello_ack (no task to assign)
 
     send(wsB, { type: "task_complete", workerId: "worker-b", taskId: "1" });
@@ -553,7 +553,7 @@ describe("dependency-aware task assignment", () => {
 
     const ws = await connect();
     const ackP = nextMsg(ws);
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await ackP; // hello_ack
     const raceResult = await Promise.race([
       nextMsg(ws).then(() => "message" as const),
@@ -569,7 +569,7 @@ describe("dependency-aware task assignment", () => {
 
     const ws = await connect();
     const q = makeQueue(ws);
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await q.next(); // hello_ack
     const msg = await q.next();
     expect(msg.type).toBe("task_assigned");
@@ -582,7 +582,7 @@ describe("dependency-aware task assignment", () => {
 
     const ws = await connect();
     const ackP = nextMsg(ws);
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await ackP; // hello_ack (no task yet — task is blocked)
 
     const reply = nextMsg(ws);
@@ -606,7 +606,7 @@ describe("dependency-aware task assignment", () => {
 
     const ws = await connect();
     const ackP = nextMsg(ws);
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await ackP; // hello_ack
     const raceResult = await Promise.race([
       nextMsg(ws).then(() => "message" as const),
@@ -623,7 +623,7 @@ describe("dependency-aware task assignment", () => {
 
     const ws = await connect();
     const q = makeQueue(ws);
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await q.next(); // hello_ack
     const msg = await q.next();
     expect(msg.type).toBe("task_assigned");
@@ -644,7 +644,7 @@ describe("worker secret enforcement", () => {
     const { server, secretWss, port } = await makeSecretServer("correct-secret");
     try {
       const ws = await connectWorker(port);
-      send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle", workerSecret: "wrong" });
+      send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready", workerSecret: "wrong" });
       await new Promise<void>((resolve) => ws.once("close", resolve));
       expect(ws.readyState).toBe(WebSocket.CLOSED);
     } finally {
@@ -656,7 +656,7 @@ describe("worker secret enforcement", () => {
     const { server, secretWss, port } = await makeSecretServer("correct-secret");
     try {
       const ws = await connectWorker(port);
-      send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle", workerSecret: "correct-secret" });
+      send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready", workerSecret: "correct-secret" });
       await new Promise((r) => setTimeout(r, 20));
       ws.close();
     } finally {
@@ -666,7 +666,7 @@ describe("worker secret enforcement", () => {
 
   it("accepts any worker when workerSecret is not configured", async () => {
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await waitUntil(() => Worker.fromRegistry("w1")?.status === "idle");
     expect(Worker.fromRegistry("w1")?.status).toBe("idle");
   });
@@ -676,7 +676,7 @@ describe("worker_hello — repo validation", () => {
   it("sends fatal foreman_error and does not register worker when repo field is missing", async () => {
     const ws = await connect();
     const q = makeQueue(ws);
-    send(ws, { type: "worker_hello", workerId: "w1", status: "idle" } as any);
+    send(ws, { type: "worker_hello", workerId: "w1", status: "ready" } as any);
     const msg = await q.next();
     expect(msg.type).toBe("foreman_error");
     assert(msg.type === "foreman_error");
@@ -699,7 +699,7 @@ describe("worker WebSocket connection", () => {
     await new Promise<void>((resolve, reject) => { ws.once("open", resolve); ws.once("error", reject); });
 
     const ackP = new Promise<void>((r) => ws.once("message", () => r()));
-    ws.send(JSON.stringify({ type: "worker_hello", repo: "owner/repo", workerId: "test-worker-id", status: "idle" }));
+    ws.send(JSON.stringify({ type: "worker_hello", repo: "owner/repo", workerId: "test-worker-id", status: "ready" }));
     await ackP;
 
     const raceResult = await Promise.race([
@@ -743,7 +743,7 @@ describe("worker disconnect DB logging", () => {
 
     const ws = new WebSocket(`ws://localhost:${testPort}/worker`);
     await new Promise<void>((resolve, reject) => { ws.once("open", resolve); ws.once("error", reject); });
-    ws.send(JSON.stringify({ type: "worker_hello", repo: "owner/repo", workerId: "w-disc-1", status: "idle" }));
+    ws.send(JSON.stringify({ type: "worker_hello", repo: "owner/repo", workerId: "w-disc-1", status: "ready" }));
     await waitUntil(() => !!Worker.fromRegistry("w-disc-1"));
 
     await new Promise<void>((resolve) => {
@@ -779,7 +779,7 @@ describe("worker disconnect DB logging", () => {
 
     const ws = new WebSocket(`ws://localhost:${testPort}/worker`);
     await new Promise<void>((resolve, reject) => { ws.once("open", resolve); ws.once("error", reject); });
-    ws.send(JSON.stringify({ type: "worker_hello", repo: "owner/repo", workerId: "w-disc-2", status: "idle" }));
+    ws.send(JSON.stringify({ type: "worker_hello", repo: "owner/repo", workerId: "w-disc-2", status: "ready" }));
     // Wait for task_assigned reply (after hello_ack)
     await new Promise<void>((resolve) => {
       let count = 0;
@@ -805,7 +805,7 @@ describe("disconnected worker state", () => {
   it("worker with active task is marked disconnected (not removed) on close", async () => {
     await makeTask(taskManager, 1);
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await nextMsg(ws); // task_assigned
 
     await closeClient(ws);
@@ -820,7 +820,7 @@ describe("disconnected worker state", () => {
 
   it("idle worker is removed from registry on close", async () => {
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await waitUntil(() => !!Worker.fromRegistry("w1"));
 
     await closeClient(ws);
@@ -832,7 +832,7 @@ describe("disconnected worker state", () => {
   it("events are queued (not dropped) when assigned worker is disconnected", async () => {
     await makeTask(taskManager, 1);
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await nextMsg(ws); // task_assigned
 
     await closeClient(ws);
@@ -849,7 +849,7 @@ describe("disconnected worker state", () => {
   it("reconnecting worker (busy) from disconnected state drains queued events", async () => {
     await makeTask(taskManager, 1);
     const ws1 = await connect();
-    send(ws1, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws1, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await nextMsg(ws1); // hello_ack (task is assigned server-side regardless)
 
     await closeClient(ws1);
@@ -859,7 +859,7 @@ describe("disconnected worker state", () => {
 
     const ws2 = await connect();
     const q2 = makeQueue(ws2);
-    send(ws2, { type: "worker_hello", repo: "owner/repo", workerId: "w1", taskId: "1", status: "busy" });
+    send(ws2, { type: "worker_hello", repo: "owner/repo", workerId: "w1", taskId: "1", status: "assigned" });
     await q2.next(); // hello_ack (status: busy)
     const msg = await q2.next();
     expect(msg.type).toBe("event_notification");
@@ -875,7 +875,7 @@ describe("disconnected worker state", () => {
   it("reconnecting worker (idle) from disconnected state reverts task to pending", async () => {
     await makeTask(taskManager, 1);
     const ws1 = await connect();
-    send(ws1, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws1, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await nextMsg(ws1); // hello_ack (task is assigned server-side regardless)
 
     await closeClient(ws1);
@@ -883,7 +883,7 @@ describe("disconnected worker state", () => {
 
     const ws2 = await connect();
     const q2 = makeQueue(ws2);
-    send(ws2, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws2, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await q2.next(); // hello_ack
     const msg = await q2.next();
     expect(msg.type).toBe("task_assigned");
@@ -898,7 +898,7 @@ describe("disconnected worker state", () => {
     await makeTask(taskManager, 1);
 
     const wsA = await connect();
-    send(wsA, { type: "worker_hello", repo: "owner/repo", workerId: "worker-a", status: "idle" });
+    send(wsA, { type: "worker_hello", repo: "owner/repo", workerId: "worker-a", status: "ready" });
     await nextMsg(wsA); // hello_ack (task is assigned server-side regardless)
 
     await closeClient(wsA);
@@ -906,12 +906,12 @@ describe("disconnected worker state", () => {
 
     const wsB = await connect();
     const ackPB = nextMsg(wsB);
-    send(wsB, { type: "worker_hello", repo: "owner/repo", workerId: "worker-b", status: "idle" });
+    send(wsB, { type: "worker_hello", repo: "owner/repo", workerId: "worker-b", status: "ready" });
     await ackPB; // hello_ack (no task available yet — assigned to disconnected worker-a)
 
     const wsA2 = await connect();
     const qA2 = makeQueue(wsA2);
-    send(wsA2, { type: "worker_hello", repo: "owner/repo", workerId: "worker-a", status: "idle" });
+    send(wsA2, { type: "worker_hello", repo: "owner/repo", workerId: "worker-a", status: "ready" });
     await qA2.next(); // hello_ack
     const msg = await qA2.next();
     expect(msg.type).toBe("task_assigned");
@@ -923,7 +923,7 @@ describe("worker_goodbye", () => {
   it("removes worker from registry and reverts task to pending", async () => {
     await makeTask(taskManager, 1);
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await nextMsg(ws); // task_assigned
 
     send(ws, { type: "worker_goodbye", workerId: "w1", taskId: "1" });
@@ -935,7 +935,7 @@ describe("worker_goodbye", () => {
 
   it("removes idle worker from registry when goodbye has no taskId", async () => {
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await waitUntil(() => !!Worker.fromRegistry("w1"));
 
     send(ws, { type: "worker_goodbye", workerId: "w1" });
@@ -949,13 +949,13 @@ describe("worker_goodbye", () => {
 
     const wsA = await connect();
     const qA = makeQueue(wsA);
-    send(wsA, { type: "worker_hello", repo: "owner/repo", workerId: "worker-a", status: "idle" });
+    send(wsA, { type: "worker_hello", repo: "owner/repo", workerId: "worker-a", status: "ready" });
     await qA.next(); // hello_ack
     await qA.next(); // task_assigned
 
     const wsB = await connect();
     const ackPB = nextMsg(wsB);
-    send(wsB, { type: "worker_hello", repo: "owner/repo", workerId: "worker-b", status: "idle" });
+    send(wsB, { type: "worker_hello", repo: "owner/repo", workerId: "worker-b", status: "ready" });
     await ackPB; // hello_ack (no task — still assigned to worker-a)
 
     const replyB = nextMsg(wsB);
@@ -984,7 +984,7 @@ describe("worker_goodbye — revert persistence", () => {
     });
 
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await waitUntil(() => Worker.fromRegistry("w1")?.status === "busy");
 
     send(ws, { type: "worker_goodbye", workerId: "w1", taskId: "1" });
@@ -997,7 +997,7 @@ describe("worker_goodbye — revert persistence", () => {
     const spyGet = vi.spyOn(Task, "get");
 
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await waitUntil(() => Worker.fromRegistry("w1") !== undefined);
 
     send(ws, { type: "worker_goodbye", workerId: "w1" });
@@ -1012,7 +1012,7 @@ describe("worker_goodbye with task_complete: true", () => {
   it("marks the task complete instead of reverting it to pending", async () => {
     await makeTask(taskManager, 1);
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await nextMsg(ws); // task_assigned
 
     send(ws, { type: "worker_goodbye", workerId: "w1", taskId: "1", task_complete: true });
@@ -1025,7 +1025,7 @@ describe("worker_goodbye with task_complete: true", () => {
   it("persists stats when task_complete: true with stats provided", async () => {
     await makeTask(taskManager, 1);
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await nextMsg(ws); // task_assigned
 
     send(ws, { type: "worker_goodbye", workerId: "w1", taskId: "1", task_complete: true, stats: { inputTokens: 100, outputTokens: 50, costUsd: 0.01 } });
@@ -1045,7 +1045,7 @@ describe("worker_goodbye with task_complete: true", () => {
 
     const ws = await connect();
     const q = makeQueue(ws);
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await q.next(); // hello_ack
     await q.next(); // task_assigned (task 1002, most recent)
 
@@ -1069,7 +1069,7 @@ describe("worker_goodbye with task_complete: true", () => {
     });
 
     const ws = await connect();
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     await waitUntil(() => Worker.fromRegistry("w1")?.status === "busy");
 
     send(ws, { type: "worker_goodbye", workerId: "w1", taskId: "1", task_complete: true });
@@ -1108,9 +1108,9 @@ describe("worker_hello — reclaim complete task for finalization work", () => {
 
     const ws = await connect();
     const ackPromise = nextMsg(ws);
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", taskId: "1", status: "busy" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", taskId: "1", status: "assigned" });
     const ack = await ackPromise;
-    expect(ack).toMatchObject({ type: "hello_ack", workerId: "w1", status: "busy" });
+    expect(ack).toMatchObject({ type: "hello_ack", workerId: "w1", status: "assigned" });
     expect(Worker.fromRegistry("w1")?.status).toBe("busy");
     expect(Worker.fromRegistry("w1")?.currentTaskId).toBe("1");
   });
@@ -1129,7 +1129,7 @@ describe("keepalive ping", () => {
       ws.once("open", resolve);
       ws.once("error", reject);
     });
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
 
     await new Promise<void>((resolve) => ws.once("ping", () => resolve()));
 
@@ -1144,16 +1144,16 @@ describe("stale close from old connection", () => {
     const wsA = await connect();
     await makeTask(taskManager, 1);
     const qA = makeQueue(wsA);
-    send(wsA, { type: "worker_hello", repo: "owner/repo", workerId: "worker-a", status: "idle" });
+    send(wsA, { type: "worker_hello", repo: "owner/repo", workerId: "worker-a", status: "ready" });
     await qA.next(); // hello_ack
     await qA.next(); // task_assigned
     await waitUntil(() => Worker.fromRegistry("worker-a")?.status === "busy");
 
     const wsA2 = await connect();
     const qA2 = makeQueue(wsA2);
-    send(wsA2, { type: "worker_hello", repo: "owner/repo", workerId: "worker-a", taskId: "1", status: "busy" });
+    send(wsA2, { type: "worker_hello", repo: "owner/repo", workerId: "worker-a", taskId: "1", status: "assigned" });
     const busyAck = await qA2.next(); // hello_ack busy
-    expect(busyAck).toMatchObject({ type: "hello_ack", status: "busy" });
+    expect(busyAck).toMatchObject({ type: "hello_ack", status: "assigned" });
 
     wsA.close();
     await new Promise<void>((r) => wsA.once("close", r));
@@ -1175,8 +1175,8 @@ describe("graceful shutdown", () => {
   it("closes all connected workers with close code 1001", async () => {
     const ws1 = await connect();
     const ws2 = await connect();
-    send(ws1, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
-    send(ws2, { type: "worker_hello", repo: "owner/repo", workerId: "w2", status: "idle" });
+    send(ws1, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
+    send(ws2, { type: "worker_hello", repo: "owner/repo", workerId: "w2", status: "ready" });
     await waitUntil(() => !!Worker.fromRegistry("w1") && !!Worker.fromRegistry("w2"));
 
     const close1 = new Promise<number>((resolve) => { ws1.once("close", (code) => resolve(code)); });
@@ -1198,7 +1198,7 @@ describe("graceful shutdown", () => {
 
     const ws = new WebSocket(`ws://localhost:${testPort}/worker`);
     await new Promise<void>((resolve, reject) => { ws.once("open", resolve); ws.once("error", reject); });
-    ws.send(JSON.stringify({ type: "worker_hello", repo: "owner/repo", workerId: "w-shutdown", status: "idle" }));
+    ws.send(JSON.stringify({ type: "worker_hello", repo: "owner/repo", workerId: "w-shutdown", status: "ready" }));
     await waitUntil(() => !!Worker.fromRegistry("w-shutdown"));
 
     await localForemanWss.shutdown();

--- a/tests/foreman.worker-db.test.ts
+++ b/tests/foreman.worker-db.test.ts
@@ -18,13 +18,13 @@ beforeEach(async () => {
 });
 
 describe("Worker DB persistence", () => {
-  it("register writes worker to DB with status idle", async () => {
+  it("register writes worker to DB with status ready", async () => {
     const repo = fakeRepo("owner/repo", 1, "new");
     Worker.register("w1", fakeWs(), repo);
     await new Promise((r) => setTimeout(r, 20));
     const { data } = await (db.from as any)("workers")
       .select("*").eq("worker_id", "w1").maybeSingle();
-    expect(data).toMatchObject({ worker_id: "w1", status: "idle", num_connections: 1 });
+    expect(data).toMatchObject({ worker_id: "w1", status: "ready", num_connections: 1 });
   });
 
   it("reconnect increments num_connections", async () => {
@@ -40,7 +40,7 @@ describe("Worker DB persistence", () => {
     expect(data?.num_connections).toBe(2);
   });
 
-  it("assign updates status to busy and sets current_task_id", async () => {
+  it("assign updates status to assigned and sets current_task_id", async () => {
     const repo = fakeRepo("owner/repo", 1, "new");
     const w = Worker.register("w1", fakeWs(), repo);
     const task = { taskId: "42" } as any;
@@ -48,11 +48,11 @@ describe("Worker DB persistence", () => {
     await new Promise((r) => setTimeout(r, 20));
     const { data } = await (db.from as any)("workers")
       .select("*").eq("worker_id", "w1").maybeSingle();
-    expect(data?.status).toBe("busy");
+    expect(data?.status).toBe("assigned");
     expect(data?.current_task_id).toBe("42");
   });
 
-  it("release updates status to idle and clears current_task_id", async () => {
+  it("release updates status to ready and clears current_task_id", async () => {
     const repo = fakeRepo("owner/repo", 1, "new");
     const w = Worker.register("w1", fakeWs(), repo);
     const task = { taskId: "42" } as any;
@@ -61,7 +61,7 @@ describe("Worker DB persistence", () => {
     await new Promise((r) => setTimeout(r, 20));
     const { data } = await (db.from as any)("workers")
       .select("*").eq("worker_id", "w1").maybeSingle();
-    expect(data?.status).toBe("idle");
+    expect(data?.status).toBe("ready");
     expect(data?.current_task_id).toBeNull();
   });
 

--- a/tests/helpers/memory-db.ts
+++ b/tests/helpers/memory-db.ts
@@ -60,7 +60,7 @@ export function createMemoryTaskDb(): SupabaseClient<Database> {
       insert(rowData: WorkerRow) {
         const now = new Date().toISOString();
         const row: WorkerRow = {
-          status: "idle",
+          status: "ready",
           current_task_id: null,
           first_connected_at: now,
           last_connected_at: now,

--- a/tests/pipeline.test.ts
+++ b/tests/pipeline.test.ts
@@ -432,11 +432,11 @@ describe("pipeline: worker disconnect/reclaim", () => {
       repo: "owner/repo",
       workerId: "w-reclaim",
       taskId: "70",
-      status: "busy",
+      status: "assigned",
     });
     const ack2 = await q2.next();
     expect(ack2.type).toBe("hello_ack");
-    expect((ack2 as any).status).toBe("busy");
+    expect((ack2 as any).status).toBe("assigned");
 
     // 4. Task must still show as assigned in DB (not reverted to pending)
     const dbRow = await getDbTask("70");
@@ -500,7 +500,7 @@ describe("pipeline: dependency blocking", () => {
     send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w-blocked", status: "ready" });
     const ack = await q.next();
     expect(ack.type).toBe("hello_ack");
-    expect((ack as any).status).toBe("idle");
+    expect((ack as any).status).toBe("ready");
 
     // 2. Issue #92 depends on issue #91 (via body text). Issue #91 is open.
     await foremanWss.routeEvent("evt-1", "issues", labeledPayload(92, "Depends on #91"));

--- a/tests/pipeline.test.ts
+++ b/tests/pipeline.test.ts
@@ -311,7 +311,7 @@ describe("pipeline: happy path and queued-then-assigned", () => {
     // 3. Worker connects; hello_ack + task_assigned arrive
     const ws = await connect();
     const q = makeQueue(ws);
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w1", status: "ready" });
     const ack = await q.next();
     expect(ack.type).toBe("hello_ack");
 
@@ -352,7 +352,7 @@ describe("pipeline: happy path and queued-then-assigned", () => {
     // 3. Worker connects later
     const ws = await connect();
     const q = makeQueue(ws);
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w2", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w2", status: "ready" });
     const ack = await q.next();
     expect(ack.type).toBe("hello_ack");
 
@@ -404,7 +404,7 @@ describe("pipeline: worker disconnect/reclaim", () => {
     await foremanWss.routeEvent("evt-1", "issues", labeledPayload(70));
     const ws1 = await connect();
     const q1 = makeQueue(ws1);
-    send(ws1, { type: "worker_hello", repo: "owner/repo", workerId: "w-reclaim", status: "idle" });
+    send(ws1, { type: "worker_hello", repo: "owner/repo", workerId: "w-reclaim", status: "ready" });
     await q1.next(); // hello_ack
     await q1.next(); // task_assigned
 
@@ -497,7 +497,7 @@ describe("pipeline: dependency blocking", () => {
     // 1. Connect an idle worker
     const ws = await connect();
     const q = makeQueue(ws);
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w-blocked", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w-blocked", status: "ready" });
     const ack = await q.next();
     expect(ack.type).toBe("hello_ack");
     expect((ack as any).status).toBe("idle");
@@ -565,7 +565,7 @@ describe("pipeline: PR events forwarded and logged to DB", () => {
     await foremanWss.routeEvent("evt-1", "issues", labeledPayload(100));
     const ws = await connect();
     const q = makeQueue(ws);
-    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w-pr", status: "idle" });
+    send(ws, { type: "worker_hello", repo: "owner/repo", workerId: "w-pr", status: "ready" });
     await q.next(); // hello_ack
     await q.next(); // task_assigned
     await q.next(); // event_notification: issues/labeled (queued at enqueue time, flushed on assign)

--- a/tests/smoke.ts
+++ b/tests/smoke.ts
@@ -245,15 +245,15 @@ async function run(): Promise<void> {
     ]);
   }
 
-  // Send worker_hello and wait for hello_ack (status: "idle").
+  // Send worker_hello and wait for hello_ack (status: "ready").
   // The repo must match the webhook's repository so the task and worker are scoped to the same repo.
   const FAKE_WORKER_REPO = "test/test";
-  ws.send(JSON.stringify({ type: "worker_hello", repo: FAKE_WORKER_REPO, workerId, status: "idle" }));
+  ws.send(JSON.stringify({ type: "worker_hello", repo: FAKE_WORKER_REPO, workerId, status: "ready" }));
   const ack = await withTimeout(nextWsMsg(), TIMEOUT_MS, "hello_ack");
-  if (ack.type !== "hello_ack" || ack.status !== "idle") {
-    throw new Error(`Expected hello_ack idle, got: ${JSON.stringify(ack)}`);
+  if (ack.type !== "hello_ack" || ack.status !== "ready") {
+    throw new Error(`Expected hello_ack ready, got: ${JSON.stringify(ack)}`);
   }
-  process.stderr.write("[fake-worker] hello_ack received — worker is idle\n");
+  process.stderr.write("[fake-worker] hello_ack received — worker is ready\n");
 
   // If the repo is new, activate it so the foreman will assign tasks to this worker.
   if (ack.repoStatus === "new") {

--- a/tests/worker.claim.test.ts
+++ b/tests/worker.claim.test.ts
@@ -277,7 +277,7 @@ describe("when in hello_sent state (waiting for hello_ack)", () => {
     const handler = await getClaimHandler(session);
     await handler("42");
 
-    sendForemanMsg(fakeWs, { type: "hello_ack", workerId: AGENT_ID, status: "idle", repoStatus: "active" });
+    sendForemanMsg(fakeWs, { type: "hello_ack", workerId: AGENT_ID, status: "ready", repoStatus: "active" });
     await new Promise<void>((r) => setImmediate(r));
 
     const msg = sentClaimTask(fakeWs);
@@ -289,13 +289,13 @@ describe("when in hello_sent state (waiting for hello_ack)", () => {
     const handler = await getClaimHandler(session);
     await handler("42");
 
-    sendForemanMsg(fakeWs, { type: "hello_ack", workerId: AGENT_ID, status: "idle", repoStatus: "active" });
+    sendForemanMsg(fakeWs, { type: "hello_ack", workerId: AGENT_ID, status: "ready", repoStatus: "active" });
     await new Promise<void>((r) => setImmediate(r));
     fakeWs.send.mockClear();
 
     // Simulate a second hello_ack (reconnect scenario)
     (session as any).connectionState = "hello_sent";
-    sendForemanMsg(fakeWs, { type: "hello_ack", workerId: AGENT_ID, status: "idle", repoStatus: "active" });
+    sendForemanMsg(fakeWs, { type: "hello_ack", workerId: AGENT_ID, status: "ready", repoStatus: "active" });
     await new Promise<void>((r) => setImmediate(r));
 
     expect(sentClaimTask(fakeWs)).toBeUndefined();
@@ -312,7 +312,7 @@ describe("when worker mode is not active", () => {
     expect(session.isActive).toBe(true);
   });
 
-  it("includes claimTaskId in the worker_hello when connecting", async () => {
+  it("sends worker_hello with status='reserved' (not 'ready') when connecting with a pending claim", async () => {
     const handler = await getClaimHandler(session);
     await handler("42");
     // Fire the open event — this triggers the hello send in connect()'s open handler
@@ -321,31 +321,42 @@ describe("when worker mode is not active", () => {
 
     const hello = sentHello(fakeWs);
     expect(hello).toBeDefined();
-    expect(hello?.claimTaskId).toBe("42");
-    expect(hello?.status).toBe("idle");
+    expect(hello?.status).toBe("reserved");
+    // claimTaskId is no longer sent in the hello — claim_task is sent separately
+    expect(hello?.claimTaskId).toBeUndefined();
   });
 
-  it("does not send a separate claim_task message when fresh-connecting", async () => {
+  it("sends claim_task after receiving hello_ack, not on open", async () => {
     const handler = await getClaimHandler(session);
     await handler("42");
     fakeWs.emit("open");
     await new Promise<void>((r) => setImmediate(r));
 
+    // claim_task not sent yet — waiting for hello_ack
     expect(sentClaimTask(fakeWs)).toBeUndefined();
+
+    // Now receive hello_ack
+    sendForemanMsg(fakeWs, { type: "hello_ack", workerId: AGENT_ID, status: "reserved", repoStatus: "active" });
+    await new Promise<void>((r) => setImmediate(r));
+
+    const claim = sentClaimTask(fakeWs);
+    expect(claim).toBeDefined();
+    expect(claim?.taskId).toBe("42");
   });
 
-  it("clears the pending claim after the hello so reconnect does not re-send claimTaskId", async () => {
+  it("reconnect also connects as 'reserved' (pending claim is not cleared until hello_ack)", async () => {
     const handler = await getClaimHandler(session);
     await handler("42");
     fakeWs.emit("open");
     await new Promise<void>((r) => setImmediate(r));
 
-    // Simulate reconnect: reset the send mock and fire open again
+    // Simulate reconnect without receiving ack: pending claim is still set
     fakeWs.send.mockClear();
     fakeWs.emit("open");
     await new Promise<void>((r) => setImmediate(r));
 
     const hello2 = sentHello(fakeWs);
+    expect(hello2?.status).toBe("reserved");
     expect(hello2?.claimTaskId).toBeUndefined();
   });
 });

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -479,7 +479,7 @@ describe("reconnect", () => {
     expect(wsFactory).toHaveBeenCalledTimes(2);
 
     // Simulate successful reconnect — hello_ack resets attempts to 0
-    sendMsg(ws2, { type: "hello_ack", status: "idle" });
+    sendMsg(ws2, { type: "hello_ack", status: "ready" });
 
     // Now disconnect again — should use attempt 0 delay (500ms), not attempt 1 (1000ms)
     ws2.emit("close", 1006, Buffer.from(""));
@@ -560,7 +560,7 @@ describe("connection status bar", () => {
 
   it("shows Connected in status text after hello_ack", () => {
     fakeWs.emit("open");
-    sendMsg(fakeWs, { type: "hello_ack", status: "idle" });
+    sendMsg(fakeWs, { type: "hello_ack", status: "ready" });
     expect(fmtStatus(sb)).toContain("Connected");
   });
 
@@ -785,7 +785,7 @@ describe("hello_ack handshake — buffering", () => {
       expect(newWs.send).not.toHaveBeenCalled();
 
       // Send hello_ack → buffer should be flushed
-      sendMsg(newWs, { type: "hello_ack", workerId: AGENT_ID, status: "busy" });
+      sendMsg(newWs, { type: "hello_ack", workerId: AGENT_ID, status: "assigned" });
       expect(newWs.send).toHaveBeenCalledOnce();
       const sent = JSON.parse(newWs.send.mock.calls[0][0]);
       expect(sent).toEqual({ type: "task_complete", workerId: AGENT_ID, taskId: "42" });
@@ -983,7 +983,7 @@ describe("hello_ack handshake — buffering", () => {
       expect(newWs.send).not.toHaveBeenCalled();
 
       // hello_ack idle — task was reverted on foreman side; but worker flushes anyway
-      sendMsg(newWs, { type: "hello_ack", workerId: AGENT_ID, status: "idle" });
+      sendMsg(newWs, { type: "hello_ack", workerId: AGENT_ID, status: "ready" });
       expect(newWs.send).toHaveBeenCalledOnce();
       const sent = JSON.parse(newWs.send.mock.calls[0][0]);
       expect(sent.type).toBe("task_complete");
@@ -994,9 +994,9 @@ describe("hello_ack handshake — buffering", () => {
   });
 
   it("hello_ack is passed to display.printForemanMessage", () => {
-    sendMsg(fakeWs, { type: "hello_ack", workerId: AGENT_ID, status: "idle" });
+    sendMsg(fakeWs, { type: "hello_ack", workerId: AGENT_ID, status: "ready" });
     expect(display.printForemanMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "hello_ack", workerId: AGENT_ID, status: "idle" })
+      expect.objectContaining({ type: "hello_ack", workerId: AGENT_ID, status: "ready" })
     );
   });
 });
@@ -1398,7 +1398,7 @@ describe("stop() with active task", () => {
       pickFn: async () => 0, // first option = "No, keep working" = cancel
     });
     await s.start();
-    sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "idle" });
+    sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "ready" });
     sendMsg(ws, { type: "task_assigned", taskId: "99", issue: makeIssue() });
     s.takeNextPrompt();
 
@@ -1415,7 +1415,7 @@ describe("stop() with active task", () => {
       pickFn: async () => 1, // second option = "Yes, quit anyway" = quit
     });
     await s.start();
-    sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "idle" });
+    sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "ready" });
     sendMsg(ws, { type: "task_assigned", taskId: "99", issue: makeIssue() });
     s.takeNextPrompt();
 
@@ -1881,7 +1881,7 @@ describe("heartbeat", () => {
     vi.useFakeTimers();
     const { ws } = await makeHeartbeatSession();
     ws.emit("open");
-    sendMsg(ws, { type: "hello_ack", status: "idle" });
+    sendMsg(ws, { type: "hello_ack", status: "ready" });
 
     expect(ws.ping).not.toHaveBeenCalled();
     vi.advanceTimersByTime(25000);
@@ -1892,7 +1892,7 @@ describe("heartbeat", () => {
     vi.useFakeTimers();
     const { ws } = await makeHeartbeatSession();
     ws.emit("open");
-    sendMsg(ws, { type: "hello_ack", status: "idle" });
+    sendMsg(ws, { type: "hello_ack", status: "ready" });
 
     vi.advanceTimersByTime(25000); // first ping sent, isAlive set to false
     ws.emit("pong");               // pong received, isAlive reset to true
@@ -1905,7 +1905,7 @@ describe("heartbeat", () => {
     vi.useFakeTimers();
     const { ws } = await makeHeartbeatSession();
     ws.emit("open");
-    sendMsg(ws, { type: "hello_ack", status: "idle" });
+    sendMsg(ws, { type: "hello_ack", status: "ready" });
 
     vi.advanceTimersByTime(25000); // first ping sent, isAlive set to false
     ws.emit("ping");               // foreman's heartbeat ping resets isAlive to true
@@ -1918,7 +1918,7 @@ describe("heartbeat", () => {
     vi.useFakeTimers();
     const { ws } = await makeHeartbeatSession();
     ws.emit("open");
-    sendMsg(ws, { type: "hello_ack", status: "idle" });
+    sendMsg(ws, { type: "hello_ack", status: "ready" });
 
     vi.advanceTimersByTime(25000); // first ping sent, isAlive set to false
     // no pong emitted
@@ -1931,7 +1931,7 @@ describe("heartbeat", () => {
     vi.useFakeTimers();
     const { ws, s } = await makeHeartbeatSession();
     ws.emit("open");
-    sendMsg(ws, { type: "hello_ack", status: "idle" });
+    sendMsg(ws, { type: "hello_ack", status: "ready" });
     expect(fmtStatus(s.agentStatus)).toContain("Connected");
 
     vi.advanceTimersByTime(25000); // ping sent
@@ -1944,7 +1944,7 @@ describe("heartbeat", () => {
     vi.useFakeTimers();
     const { ws, factory } = await makeHeartbeatSession();
     ws.emit("open");
-    sendMsg(ws, { type: "hello_ack", status: "idle" });
+    sendMsg(ws, { type: "hello_ack", status: "ready" });
 
     vi.advanceTimersByTime(25000); // ping sent
     vi.advanceTimersByTime(25000); // no pong → terminate
@@ -1957,7 +1957,7 @@ describe("heartbeat", () => {
     vi.useFakeTimers();
     const { ws } = await makeHeartbeatSession();
     ws.emit("open");
-    sendMsg(ws, { type: "hello_ack", status: "idle" });
+    sendMsg(ws, { type: "hello_ack", status: "ready" });
 
     vi.advanceTimersByTime(25000); // first ping sent
     expect(ws.ping).toHaveBeenCalledOnce();
@@ -1978,7 +1978,7 @@ describe("heartbeat", () => {
     vi.useFakeTimers();
     const { ws } = await makeHeartbeatSession();
     ws.emit("open");
-    sendMsg(ws, { type: "hello_ack", status: "idle" });
+    sendMsg(ws, { type: "hello_ack", status: "ready" });
 
     vi.advanceTimersByTime(25000); // first ping sent
 
@@ -2190,7 +2190,7 @@ describe("repo activation flow", () => {
   it("when repoStatus is 'new', shows activation prompt before transitioning", async () => {
     const pickFn = vi.fn().mockResolvedValue(0); // "Yes, activate"
     const { sess, ws } = await makeSessionWithPick(pickFn);
-    sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "idle", repoStatus: "new" });
+    sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "ready", repoStatus: "new" });
     await new Promise((r) => setTimeout(r, 10));
     expect(pickFn).toHaveBeenCalledWith(expect.arrayContaining(["Yes, activate", "No, skip"]));
   });
@@ -2198,7 +2198,7 @@ describe("repo activation flow", () => {
   it("when user confirms activation, sends activate_repo to the foreman", async () => {
     const pickFn = vi.fn().mockResolvedValue(0); // "Yes, activate"
     const { sess, ws } = await makeSessionWithPick(pickFn);
-    sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "idle", repoStatus: "new" });
+    sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "ready", repoStatus: "new" });
     await new Promise((r) => setTimeout(r, 10));
     const sent = ws.send.mock.calls.map(([d]: [string]) => JSON.parse(d));
     const activateMsg = sent.find((m) => m.type === "activate_repo");
@@ -2209,7 +2209,7 @@ describe("repo activation flow", () => {
   it("when user confirms, does NOT yet transition to registered (waits for repo_activated)", async () => {
     const pickFn = vi.fn().mockResolvedValue(0); // "Yes, activate"
     const { sess, ws } = await makeSessionWithPick(pickFn);
-    sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "idle", repoStatus: "new" });
+    sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "ready", repoStatus: "new" });
     // No task has been assigned — still no pending prompts
     expect(sess.hasPendingPrompts()).toBe(false); // no task prompt yet
   });
@@ -2217,7 +2217,7 @@ describe("repo activation flow", () => {
   it("when repo_activated is received, transitions to registered and can accept tasks", async () => {
     const pickFn = vi.fn().mockResolvedValue(0); // "Yes, activate"
     const { sess, ws } = await makeSessionWithPick(pickFn);
-    sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "idle", repoStatus: "new" });
+    sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "ready", repoStatus: "new" });
     await new Promise((r) => setTimeout(r, 10));
     // Foreman responds with repo_activated
     sendMsg(ws, { type: "repo_activated", workerId: AGENT_ID });
@@ -2230,7 +2230,7 @@ describe("repo activation flow", () => {
   it("when user declines activation, does not send activate_repo to the foreman", async () => {
     const pickFn = vi.fn().mockResolvedValue(1); // "No, skip"
     const { sess, ws } = await makeSessionWithPick(pickFn);
-    sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "idle", repoStatus: "new" });
+    sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "ready", repoStatus: "new" });
     await new Promise((r) => setTimeout(r, 10));
     const sent = ws.send.mock.calls.map(([d]: [string]) => JSON.parse(d));
     const activateMsg = sent.find((m) => m.type === "activate_repo");
@@ -2240,7 +2240,7 @@ describe("repo activation flow", () => {
   it("when user declines activation, worker mode ends (isActive = false)", async () => {
     const pickFn = vi.fn().mockResolvedValue(1); // "No, skip"
     const { sess, ws } = await makeSessionWithPick(pickFn);
-    sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "idle", repoStatus: "new" });
+    sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "ready", repoStatus: "new" });
     await new Promise((r) => setTimeout(r, 10));
     expect(sess.isActive).toBe(false);
   });
@@ -2250,7 +2250,7 @@ describe("repo activation flow", () => {
     const { sess, ws } = await makeSessionWithPick(pickFn);
     const onPromptsReady = vi.fn();
     sess.on("prompts_ready", onPromptsReady);
-    sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "idle", repoStatus: "new" });
+    sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "ready", repoStatus: "new" });
     // stop() awaits refreshBranch() (a git command) before we emit, so wait longer
     await vi.waitFor(() => expect(onPromptsReady).toHaveBeenCalled(), { timeout: 2000 });
   });
@@ -2258,7 +2258,7 @@ describe("repo activation flow", () => {
   it("when repoStatus is 'active', transitions normally without showing activation prompt", async () => {
     const pickFn = vi.fn().mockResolvedValue(0);
     const { sess, ws } = await makeSessionWithPick(pickFn);
-    sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "idle", repoStatus: "active" });
+    sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "ready", repoStatus: "active" });
     await new Promise((r) => setTimeout(r, 10));
     expect(pickFn).not.toHaveBeenCalled();
   });
@@ -2266,7 +2266,7 @@ describe("repo activation flow", () => {
   it("activation prompt includes the repo name from options", async () => {
     const pickFn = vi.fn().mockResolvedValue(0);
     const { disp, ws } = await makeSessionWithPick(pickFn, "acme/my-project");
-    sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "idle", repoStatus: "new" });
+    sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "ready", repoStatus: "new" });
     await new Promise((r) => setTimeout(r, 10));
     const printedLines = disp.print.mock.calls.map(([l]: [string]) => l);
     expect(printedLines.some((l) => l.includes("acme/my-project"))).toBe(true);
@@ -2275,7 +2275,7 @@ describe("repo activation flow", () => {
   it("emits prompts_ready after repo_activated so the main loop can re-start stdin listening", async () => {
     const pickFn = vi.fn().mockResolvedValue(0); // "Yes, activate"
     const { sess, ws } = await makeSessionWithPick(pickFn);
-    sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "idle", repoStatus: "new" });
+    sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "ready", repoStatus: "new" });
     await new Promise((r) => setTimeout(r, 10));
 
     let emitted = false;
@@ -2304,7 +2304,7 @@ function makeSessionWithPickResult(pickResult: number): { s: WorkerController; w
 describe("transitionToIdle — Waiting for tasks message", () => {
   it("prints 'Waiting for tasks...' on hello_ack idle", () => {
     display.print.mockClear();
-    sendMsg(fakeWs, { type: "hello_ack", workerId: AGENT_ID, status: "idle" });
+    sendMsg(fakeWs, { type: "hello_ack", workerId: AGENT_ID, status: "ready" });
     const printed = display.print.mock.calls.map(([l]: [string]) => stripAnsi(l)).join("\n");
     expect(printed).toContain("Waiting for tasks");
   });
@@ -2314,7 +2314,7 @@ describe("transitionToIdle — Waiting for tasks message", () => {
     sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
     session.takeNextPrompt();
     display.print.mockClear();
-    sendMsg(fakeWs, { type: "hello_ack", workerId: AGENT_ID, status: "busy" });
+    sendMsg(fakeWs, { type: "hello_ack", workerId: AGENT_ID, status: "assigned" });
     const printed = display.print.mock.calls.map(([l]: [string]) => stripAnsi(l)).join("\n");
     expect(printed).not.toContain("Waiting for tasks");
   });
@@ -2333,7 +2333,7 @@ describe("transitionToIdle — Waiting for tasks message", () => {
     const { s, ws } = makeSessionWithPickResult(0); // 0 = "Yes, activate"
     await s.start();
     ws.emit("open");
-    sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "idle", repoStatus: "new" });
+    sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "ready", repoStatus: "new" });
     await new Promise(r => setTimeout(r, 0)); // let async pick resolve
     display.print.mockClear();
     sendMsg(ws, { type: "repo_activated", workerId: AGENT_ID });


### PR DESCRIPTION
## Summary

- Replaces the `idle | busy` wire protocol with three explicit states: `ready`, `reserved`, `assigned`
- Removes `claimTaskId` from `worker_hello`; claim now uses `status: "reserved"` + separate `claim_task` message
- Adds `nextState` to `task_complete` so a worker can complete a task and stay reserved (not auto-assigned)
- Adds `worker_ready` message for transitioning from `reserved` → `ready` without a goodbye/hello round-trip
- Adds `Worker.isAvailable` in-memory flag; `Worker.getIdle()` now excludes reserved workers
- Refactors `handleIdleHello` → `handleReadyHello`, `handleBusyHello` → `handleAssignedHello`, `handleClaimHello` → `handleReservedHello`

## Acceptance criteria

- [x] A worker can connect as `reserved`, claim a specific task, and begin work without triggering auto-assignment
- [x] A worker can complete a task and transition to `reserved`, then later send `worker_ready` to opt in to auto-assignment
- [x] `worker_hello` no longer has a `claimTaskId` field
- [x] All existing behaviors (reconnect reclaim, cross-repo cancel, repo activation flow) continue to work
- [x] All tests pass

## Test plan

- `npm test` — 1657 tests pass
- `npx tsc --noEmit` — zero type errors
- `npm run lint` — no new lint errors

Closes #968

🤖 Generated with [Claude Code](https://claude.com/claude-code)