### PR TITLE
fix: auto-dismiss post-task picker when new task arrives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,8 +56,8 @@ Every `worker_hello` gets a `hello_ack` with one of four statuses before any tas
 - `cancelled` — task was taken or completed; worker should reset and become idle
 
 Worker state transitions happen via dedicated messages while the worker stays connected:
-- `task_complete { nextState?: "ready" | "reserved" }` — complete a task and declare next state; defaults to `"ready"`
-- `worker_ready` — transition from `reserved` → `ready` (e.g., after claiming a specific task or deciding to accept work)
+- `task_complete { nextState: "reserved" }` — complete a task; always sends `reserved` so the foreman holds the worker out of the auto-assignment pool while the post-task picker is showing. Pass `nextState: "reserved"` explicitly in the claim flow to skip the picker entirely.
+- `worker_ready` — transition from `reserved` → `ready`; sent after the user confirms "wait for next task" in the picker (or immediately in non-interactive mode)
 
 The `/worker:claim` command connects with `status: "reserved"` (no `claimTaskId` in the hello), receives `hello_ack { status: "reserved" }`, then sends `claim_task { taskId }` separately. The foreman replies with `task_assigned` or a non-fatal `foreman_error`.
 

--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -440,6 +440,9 @@ export class WorkerController extends EventEmitter {
    * After completing a task, prompt the user for what to do next.
    * Falls back to "wait for next task" silently when no picker is available
    * (e.g. non-interactive environments or tests that don't inject a pickFn).
+   *
+   * Auto-dismisses with "wait for next task" if a new task is assigned while
+   * the picker is showing, so the routing loop can proceed without user input.
    */
   private async promptAfterTaskComplete(): Promise<"task-complete" | "exit"> {
     const pickFn = this.options?.pickFn ?? (this.picker ? (opts: string[]) => this.picker!.pick(opts) : null);
@@ -449,13 +452,42 @@ export class WorkerController extends EventEmitter {
       return "task-complete";
     }
 
-    const idx = await pickFn([
+    // If a task was already enqueued before we reached the picker, skip it.
+    if (this.hasPendingPrompts()) {
+      this.display.print(c.sageGreen("Waiting for next task..."));
+      return "task-complete";
+    }
+
+    // Race the picker against a prompts_ready event. If a new task is assigned
+    // while the picker is showing, auto-dismiss and proceed to the task.
+    let dismissHandler: (() => void) | undefined;
+    const dismissedByTask = new Promise<void>((resolve) => {
+      dismissHandler = resolve;
+      this.once("prompts_ready", resolve);
+    });
+
+    const pickerP = pickFn([
       "Wait to be assigned the next task",
       "Choose a specific task to work on",
       "Stop working for now",
       "Quit and exit",
     ]);
 
+    const winner = await Promise.race([
+      pickerP.then(idx => ({ type: "pick" as const, idx })),
+      dismissedByTask.then(() => ({ type: "dismiss" as const })),
+    ]);
+
+    // Clean up the dismiss listener whether or not it fired.
+    this.off("prompts_ready", dismissHandler!);
+
+    if (winner.type === "dismiss") {
+      this.picker?.cancel(); // erase the picker UI from the terminal
+      this.display.print(c.sageGreen("Waiting for next task..."));
+      return "task-complete";
+    }
+
+    const { idx } = winner;
     switch (idx) {
       case 1:
         await this.stop();

--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -295,7 +295,8 @@ export class WorkerController extends EventEmitter {
 
   /** Send worker_ready to opt back into auto-assignment from a reserved state. */
   sendWorkerReady(): void {
-    if (this.ws?.readyState === WebSocket.OPEN) {
+    // Guard with connectionState so this is never sent before hello_ack (e.g. during reconnect).
+    if (this.ws?.readyState === WebSocket.OPEN && this.connectionState === "registered") {
       this.ws.send(JSON.stringify({
         type: "worker_ready",
         workerId: this.agentStatus.agentId,
@@ -395,11 +396,12 @@ export class WorkerController extends EventEmitter {
    * Complete the current task: call afterTask hook, send task_complete, reset state,
    * then prompt the user for what to do next.
    *
-   * nextState defaults to "ready" (worker becomes eligible for auto-assignment).
-   * Pass "reserved" when the caller intends to immediately claim a specific task —
-   * this prevents the foreman from auto-assigning while the claim is in flight.
-   * When "reserved", the picker is skipped and "task-complete" is returned immediately
-   * so the caller can continue with its own follow-up action (e.g. sendClaimTask).
+   * Always sends nextState: "reserved" to the foreman so it doesn't auto-assign a new
+   * task while the picker is showing. promptAfterTaskComplete() calls sendWorkerReady()
+   * only after the user confirms they want to keep waiting.
+   *
+   * Pass "reserved" explicitly to skip the picker entirely (claim flow — the caller
+   * handles the next action, e.g. sendClaimTask).
    *
    * Returns 'task-complete' if the worker should remain (or become) idle,
    * 'exit' if the user chose to quit, or undefined if no task was assigned.
@@ -420,7 +422,7 @@ export class WorkerController extends EventEmitter {
       type: "task_complete",
       workerId: this.agentStatus.agentId,
       taskId: this.currentTaskId,
-      ...(nextState !== "ready" && { nextState }),
+      nextState: "reserved",
       ...(hasStats && { stats: { inputTokens: taskInputTokens, outputTokens: taskOutputTokens, costUsd: taskCostUsd } }),
     });
     const taskNumber = this.currentIssue!.number;
@@ -441,53 +443,25 @@ export class WorkerController extends EventEmitter {
    * Falls back to "wait for next task" silently when no picker is available
    * (e.g. non-interactive environments or tests that don't inject a pickFn).
    *
-   * Auto-dismisses with "wait for next task" if a new task is assigned while
-   * the picker is showing, so the routing loop can proceed without user input.
+   * Calls sendWorkerReady() only when the user confirms they want to keep waiting —
+   * this is what transitions the foreman from "reserved" to auto-assignable.
    */
   private async promptAfterTaskComplete(): Promise<"task-complete" | "exit"> {
     const pickFn = this.options?.pickFn ?? (this.picker ? (opts: string[]) => this.picker!.pick(opts) : null);
 
     if (!pickFn) {
+      this.sendWorkerReady();
       this.display.print(c.sageGreen("Waiting for next task..."));
       return "task-complete";
     }
 
-    // If a task was already enqueued before we reached the picker, skip it.
-    if (this.hasPendingPrompts()) {
-      this.display.print(c.sageGreen("Waiting for next task..."));
-      return "task-complete";
-    }
-
-    // Race the picker against a prompts_ready event. If a new task is assigned
-    // while the picker is showing, auto-dismiss and proceed to the task.
-    let dismissHandler: (() => void) | undefined;
-    const dismissedByTask = new Promise<void>((resolve) => {
-      dismissHandler = resolve;
-      this.once("prompts_ready", resolve);
-    });
-
-    const pickerP = pickFn([
+    const idx = await pickFn([
       "Wait to be assigned the next task",
       "Choose a specific task to work on",
       "Stop working for now",
       "Quit and exit",
     ]);
 
-    const winner = await Promise.race([
-      pickerP.then(idx => ({ type: "pick" as const, idx })),
-      dismissedByTask.then(() => ({ type: "dismiss" as const })),
-    ]);
-
-    // Clean up the dismiss listener whether or not it fired.
-    this.off("prompts_ready", dismissHandler!);
-
-    if (winner.type === "dismiss") {
-      this.picker?.cancel(); // erase the picker UI from the terminal
-      this.display.print(c.sageGreen("Waiting for next task..."));
-      return "task-complete";
-    }
-
-    const { idx } = winner;
     switch (idx) {
       case 1:
         await this.stop();
@@ -500,6 +474,7 @@ export class WorkerController extends EventEmitter {
         await this.stop();
         return "exit";
       default:
+        this.sendWorkerReady();
         this.display.print(c.sageGreen("Waiting for next task..."));
         return "task-complete";
     }

--- a/src/agent/views/picker.ts
+++ b/src/agent/views/picker.ts
@@ -53,17 +53,6 @@ export type PickerDisplay = { clearBar(): void; drawBar(): void };
 export class Picker {
   constructor(private display?: PickerDisplay, private onStart?: () => void) {}
 
-  /** Stored by pick() so cancel() can dismiss the active menu from outside. */
-  private _cancelFn: (() => void) | null = null;
-
-  /**
-   * Cancel the currently-active pick(), if any. Erases the menu and resolves
-   * with the first option (index 0). No-op if no pick is in progress.
-   */
-  cancel(): void {
-    this._cancelFn?.();
-  }
-
   /** Formats a single picker row: adds marker and dims non-selected rows. */
   private static pickerLine(text: string, isSelected: boolean, marker?: string): string {
     const prefix = isSelected ? "▶ " : (marker ?? "  ");
@@ -85,7 +74,6 @@ export class Picker {
     const lastIsTextEntry = config?.lastIsTextEntry ?? false;
     const hasConfig = config != null;
     const { display } = this;
-    const self = this;
 
     this.onStart?.();
     display?.clearBar();
@@ -141,20 +129,10 @@ export class Picker {
 
       function finish(result: number | PickResult) {
         done = true;
-        self._cancelFn = null;
         process.stdin.removeListener("data", onData);
         display?.drawBar();
         resolve(result);
       }
-
-      // Allow external callers (e.g. routing loop) to dismiss this picker when
-      // a new task arrives, rather than waiting for user input.
-      self._cancelFn = () => {
-        if (!done) {
-          eraseMenu();
-          finish(hasConfig ? { type: "selected", index: 0 } as PickResult : 0);
-        }
-      };
 
       function onData(raw: string) {
         if (done) return;

--- a/src/agent/views/picker.ts
+++ b/src/agent/views/picker.ts
@@ -53,6 +53,17 @@ export type PickerDisplay = { clearBar(): void; drawBar(): void };
 export class Picker {
   constructor(private display?: PickerDisplay, private onStart?: () => void) {}
 
+  /** Stored by pick() so cancel() can dismiss the active menu from outside. */
+  private _cancelFn: (() => void) | null = null;
+
+  /**
+   * Cancel the currently-active pick(), if any. Erases the menu and resolves
+   * with the first option (index 0). No-op if no pick is in progress.
+   */
+  cancel(): void {
+    this._cancelFn?.();
+  }
+
   /** Formats a single picker row: adds marker and dims non-selected rows. */
   private static pickerLine(text: string, isSelected: boolean, marker?: string): string {
     const prefix = isSelected ? "▶ " : (marker ?? "  ");
@@ -74,6 +85,7 @@ export class Picker {
     const lastIsTextEntry = config?.lastIsTextEntry ?? false;
     const hasConfig = config != null;
     const { display } = this;
+    const self = this;
 
     this.onStart?.();
     display?.clearBar();
@@ -129,10 +141,20 @@ export class Picker {
 
       function finish(result: number | PickResult) {
         done = true;
+        self._cancelFn = null;
         process.stdin.removeListener("data", onData);
         display?.drawBar();
         resolve(result);
       }
+
+      // Allow external callers (e.g. routing loop) to dismiss this picker when
+      // a new task arrives, rather than waiting for user input.
+      self._cancelFn = () => {
+        if (!done) {
+          eraseMenu();
+          finish(hasConfig ? { type: "selected", index: 0 } as PickResult : 0);
+        }
+      };
 
       function onData(raw: string) {
         if (done) return;

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1732,6 +1732,42 @@ describe("completeCurrentTask: post-completion prompt", () => {
       expect.stringContaining("Quit"),
     ]);
   });
+
+  it("skips picker and returns 'task-complete' when a task is already queued on entry", async () => {
+    const mockPick = vi.fn().mockResolvedValue(0);
+    const { sess, ws } = await makeSession(mockPick);
+    // Queue a new task before completing the current one; enqueuePrompt sets hasPendingPrompts()
+    sendMsg(ws, { type: "task_assigned", taskId: "t-pre", issue: makeIssue(99) });
+    const result = await sess.completeCurrentTask();
+    expect(result).toBe("task-complete");
+    expect(mockPick).not.toHaveBeenCalled();
+    const printed = display.print.mock.calls.map(([l]: [string]) => stripAnsi(l));
+    expect(printed.some(l => l.includes("Waiting for next task"))).toBe(true);
+  });
+
+  it("auto-dismisses picker and returns 'task-complete' when prompts_ready fires while picker is showing", async () => {
+    // pickFn signals when it has been called, then blocks indefinitely.
+    let signalPickShowing!: () => void;
+    const pickShowingP = new Promise<void>(r => { signalPickShowing = r; });
+    const { sess, ws } = await makeSession(async () => {
+      signalPickShowing();
+      return new Promise<number>(() => {}); // never resolves
+    });
+
+    const resultP = sess.completeCurrentTask();
+
+    // Wait until pickFn has been invoked — the once("prompts_ready") listener is
+    // already registered at this point (it is set up before pickFn is called).
+    await pickShowingP;
+
+    // Sending task_assigned emits prompts_ready, which dismisses the picker race.
+    sendMsg(ws, { type: "task_assigned", taskId: "t-mid", issue: makeIssue(88) });
+
+    const result = await resultP;
+    expect(result).toBe("task-complete");
+    const printed = display.print.mock.calls.map(([l]: [string]) => stripAnsi(l));
+    expect(printed.some(l => l.includes("Waiting for next task"))).toBe(true);
+  });
 });
 
 // ── sendGoodbye ───────────────────────────────────────────────────────────────

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -224,7 +224,7 @@ describe("completeCurrentTask", () => {
     await session.completeCurrentTask();
 
     const sent = JSON.parse(fakeWs.send.mock.calls[0][0]);
-    expect(sent).toEqual({ type: "task_complete", workerId: AGENT_ID, taskId: "42" });
+    expect(sent).toEqual({ type: "task_complete", workerId: AGENT_ID, taskId: "42", nextState: "reserved" });
   });
 
   it("returns 'task-complete' so the main loop can hide the prompt", async () => {
@@ -788,7 +788,7 @@ describe("hello_ack handshake — buffering", () => {
       sendMsg(newWs, { type: "hello_ack", workerId: AGENT_ID, status: "assigned" });
       expect(newWs.send).toHaveBeenCalledOnce();
       const sent = JSON.parse(newWs.send.mock.calls[0][0]);
-      expect(sent).toEqual({ type: "task_complete", workerId: AGENT_ID, taskId: "42" });
+      expect(sent).toEqual({ type: "task_complete", workerId: AGENT_ID, taskId: "42", nextState: "reserved" });
     } finally {
       vi.restoreAllMocks();
       vi.useRealTimers();
@@ -1586,7 +1586,7 @@ describe("afterTask callback on /worker:complete", () => {
 
     await sessionWithAfterTask.completeCurrentTask();
     expect(afterTask).toHaveBeenCalledOnce();
-    const sentMsg = JSON.parse(fakeWs.send.mock.calls.at(-1)![0]);
+    const sentMsg = JSON.parse(fakeWs.send.mock.calls[0][0]);
     expect(sentMsg.type).toBe("task_complete");
   });
 
@@ -1612,8 +1612,8 @@ describe("afterTask callback on /worker:complete", () => {
     sendMsg(fakeWs, { type: "task_assigned", taskId: "t1", issue });
     session.takeNextPrompt();
     await session.completeCurrentTask();
-    const lastMsg = JSON.parse(fakeWs.send.mock.calls.at(-1)![0]);
-    expect(lastMsg.type).toBe("task_complete");
+    const firstMsg = JSON.parse(fakeWs.send.mock.calls[0][0]);
+    expect(firstMsg.type).toBe("task_complete");
   });
 
   it("does NOT send task_complete when afterTask throws UserCancelledError", async () => {
@@ -1733,40 +1733,38 @@ describe("completeCurrentTask: post-completion prompt", () => {
     ]);
   });
 
-  it("skips picker and returns 'task-complete' when a task is already queued on entry", async () => {
-    const mockPick = vi.fn().mockResolvedValue(0);
-    const { sess, ws } = await makeSession(mockPick);
-    // Queue a new task before completing the current one; enqueuePrompt sets hasPendingPrompts()
-    sendMsg(ws, { type: "task_assigned", taskId: "t-pre", issue: makeIssue(99) });
-    const result = await sess.completeCurrentTask();
-    expect(result).toBe("task-complete");
-    expect(mockPick).not.toHaveBeenCalled();
-    const printed = display.print.mock.calls.map(([l]: [string]) => stripAnsi(l));
-    expect(printed.some(l => l.includes("Waiting for next task"))).toBe(true);
+  it("sends task_complete with nextState: reserved so foreman does not auto-assign during picker", async () => {
+    const { sess, ws } = await makeSession(async () => 0);
+    ws.send.mockClear();
+    await sess.completeCurrentTask();
+    const msgs = ws.send.mock.calls.map(([s]: [string]) => JSON.parse(s));
+    const complete = msgs.find((m: { type: string }) => m.type === "task_complete");
+    expect(complete?.nextState).toBe("reserved");
   });
 
-  it("auto-dismisses picker and returns 'task-complete' when prompts_ready fires while picker is showing", async () => {
-    // pickFn signals when it has been called, then blocks indefinitely.
-    let signalPickShowing!: () => void;
-    const pickShowingP = new Promise<void>(r => { signalPickShowing = r; });
-    const { sess, ws } = await makeSession(async () => {
-      signalPickShowing();
-      return new Promise<number>(() => {}); // never resolves
-    });
+  it("option 0 (wait for next task): sends worker_ready to opt back into auto-assignment", async () => {
+    const { sess, ws } = await makeSession(async () => 0);
+    ws.send.mockClear();
+    await sess.completeCurrentTask();
+    const msgs = ws.send.mock.calls.map(([s]: [string]) => JSON.parse(s));
+    expect(msgs.some((m: { type: string }) => m.type === "worker_ready")).toBe(true);
+  });
 
-    const resultP = sess.completeCurrentTask();
+  it("with no picker and no pickFn: sends worker_ready", async () => {
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "t-nopick2", issue: makeIssue(6) });
+    session.takeNextPrompt();
+    fakeWs.send.mockClear();
+    await session.completeCurrentTask();
+    const msgs = fakeWs.send.mock.calls.map(([s]: [string]) => JSON.parse(s));
+    expect(msgs.some((m: { type: string }) => m.type === "worker_ready")).toBe(true);
+  });
 
-    // Wait until pickFn has been invoked — the once("prompts_ready") listener is
-    // already registered at this point (it is set up before pickFn is called).
-    await pickShowingP;
-
-    // Sending task_assigned emits prompts_ready, which dismisses the picker race.
-    sendMsg(ws, { type: "task_assigned", taskId: "t-mid", issue: makeIssue(88) });
-
-    const result = await resultP;
-    expect(result).toBe("task-complete");
-    const printed = display.print.mock.calls.map(([l]: [string]) => stripAnsi(l));
-    expect(printed.some(l => l.includes("Waiting for next task"))).toBe(true);
+  it("option 2 (stop working): does not send worker_ready", async () => {
+    const { sess, ws } = await makeSession(async () => 2);
+    ws.send.mockClear();
+    await sess.completeCurrentTask();
+    const msgs = ws.send.mock.calls.map(([s]: [string]) => JSON.parse(s));
+    expect(msgs.some((m: { type: string }) => m.type === "worker_ready")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

**Root cause**: \`completeCurrentTask()\` sent \`task_complete\` (with the default \`nextState: \"ready\"\`) before showing the post-task picker. The foreman immediately released the worker into the assignment pool, so a new \`task_assigned\` could arrive while the user was still choosing what to do.

- Always send \`nextState: \"reserved\"\` in \`task_complete\` so the foreman holds the worker out of the pool while the picker is showing
- \`promptAfterTaskComplete()\` calls \`sendWorkerReady()\` only after the user confirms option 0 ("Wait for next task") or when there is no picker (non-interactive)
- Options 1–3 (choose/stop/quit) call \`stop()\` instead — no \`worker_ready\` sent
- Guard \`sendWorkerReady()\` with \`connectionState === \"registered\"\` so it is never sent before \`hello_ack\` during reconnect
- Remove the \`prompts_ready\` race from the earlier approach — no longer needed since the foreman cannot assign while reserved

## Test plan

- [x] \`sends task_complete with nextState: reserved\` — foreman never sees "ready" during picker
- [x] \`option 0 (wait): sends worker_ready\` — opts back in after confirmation
- [x] \`with no picker and no pickFn: sends worker_ready\` — non-interactive path also opts in
- [x] \`option 2 (stop working): does not send worker_ready\` — stopping never opts in
- [x] Updated \`toEqual\` assertions on \`task_complete\` (now includes \`nextState: \"reserved\"\`)
- [x] All 186 worker tests pass; \`tsc --noEmit\` clean

Closes #973

🤖 Generated with [Claude Code](https://claude.com/claude-code)