### PR TITLE
fix: exit cleanly when user picks 'Exit' after /worker:complete

### DIFF
--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -459,7 +459,7 @@ export class WorkerController extends EventEmitter {
       "Wait to be assigned the next task",
       "Choose a specific task to work on",
       "Stop working for now",
-      "Quit and exit",
+      "Exit",
     ]);
 
     switch (idx) {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -190,7 +190,6 @@ export class BrunelAgent {
           await workerController.stop();
           if (workerController.isActive) return undefined; // user cancelled
         }
-        await doExit();
         return "exit";
       },
     });
@@ -363,7 +362,10 @@ export class BrunelAgent {
 
       if (action.type === "command") {
         const result = await registry.execute(action.name, action.args);
-        if (result === "exit") break;
+        if (result === "exit") {
+          await doExit();
+          break;
+        }
         continue;
       }
 

--- a/tests/worker.main.test.ts
+++ b/tests/worker.main.test.ts
@@ -270,13 +270,21 @@ describe("workerMain exit behavior", () => {
   });
 
   it("exits cleanly (no process.exit) when user types /exit in worker mode", async () => {
-    // /exit calls stop() then doExit(), then returns "exit" to break the loop.
+    // /exit calls stop() then returns "exit"; the routing loop calls doExit() and breaks.
     mockInput.ask.mockResolvedValue("/exit");
     const { exitCalled } = await runWorkerMain();
     expect(exitCalled).toBe(false);
   });
 
   it("destroys workspace before exiting when workspace is safe", async () => {
+    await runWorkerMain();
+    expect(fakeWorkspace.destroy).toHaveBeenCalledOnce();
+  });
+
+  it("destroys workspace when user types /exit", async () => {
+    // Regression: /exit now returns "exit" without calling doExit() itself;
+    // the routing loop is responsible for calling doExit() on any "exit" result.
+    mockInput.ask.mockResolvedValue("/exit");
     await runWorkerMain();
     expect(fakeWorkspace.destroy).toHaveBeenCalledOnce();
   });

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1714,7 +1714,7 @@ describe("completeCurrentTask: post-completion prompt", () => {
     expect(printed.some(l => l.includes("/worker:claim"))).toBe(false);
   });
 
-  it("option 3 (quit and exit): stops worker mode and returns 'exit'", async () => {
+  it("option 3 (exit): stops worker mode and returns 'exit'", async () => {
     const { sess } = await makeSession(async () => 3);
     const result = await sess.completeCurrentTask();
     expect(result).toBe("exit");
@@ -1729,7 +1729,7 @@ describe("completeCurrentTask: post-completion prompt", () => {
       expect.stringContaining("Wait"),
       expect.stringContaining("specific task"),
       expect.stringContaining("Stop working"),
-      expect.stringContaining("Quit"),
+      expect.stringContaining("Exit"),
     ]);
   });
 


### PR DESCRIPTION
## Summary

- When `/worker:complete` is run and the user picks the exit option in the post-task picker, the command returns `"exit"` but `doExit()` was never called — leaving stdin open and the process hanging.
- Root cause: `doExit()` was only called inside the `/exit` command handler, not by the routing loop itself. So any other command returning `"exit"` (i.e. `/worker:complete`) skipped terminal cleanup.
- Fix: move `doExit()` into the routing loop so every command that returns `"exit"` goes through the same cleanup path. Also renames the redundant "Quit and exit" picker option to just "Exit".

## Test plan

- [ ] `npm test` passes (1666 tests, DB tests excluded as usual)
- [ ] `npx tsc --noEmit` passes
- [ ] Updated existing test label "option 3 (quit and exit)" → "option 3 (exit)"
- [ ] Updated test expectation for the picker option label (`"Quit"` → `"Exit"`)
- [ ] Added regression test: "destroys workspace when user types /exit" — verifies the routing loop calls `doExit()` for commands returning `"exit"`

Closes #979

🤖 Generated with [Claude Code](https://claude.com/claude-code)