### PR TITLE
docs: comment on doExit() ownership in the routing loop

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -362,6 +362,8 @@ export class BrunelAgent {
 
       if (action.type === "command") {
         const result = await registry.execute(action.name, action.args);
+        // doExit() is always called here, never inside individual command handlers,
+        // so every "exit" return value gets the same terminal cleanup regardless of source.
         if (result === "exit") {
           await doExit();
           break;


### PR DESCRIPTION
Adds a one-line comment at the `result === "exit"` branch in the routing loop documenting the invariant established in #981: `doExit()` is always called by the routing loop, never inside individual command handlers. This prevents a recurrence of the bug where a new command returning `"exit"` skips terminal cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)