### PR TITLE
fix: sort pull_request/opened first in multi-event prompt

### DIFF
--- a/src/agent/worker-prompts.ts
+++ b/src/agent/worker-prompts.ts
@@ -231,12 +231,14 @@ const SORT_PRIORITY: Record<string, number> = {
   pull_request: 5,
 };
 
+function eventSortKey(event: Wire.WebhookEvent): number {
+  // pull_request/opened goes first so the worker sees PR creation before CI noise
+  if (event.name === "pull_request" && event.payload?.action === "opened") return 0;
+  return SORT_PRIORITY[event.name] ?? 4;
+}
+
 function sortEvents(events: Wire.WebhookEvent[]): Wire.WebhookEvent[] {
-  return [...events].sort((a, b) => {
-    const pa = SORT_PRIORITY[a.name] ?? 4;
-    const pb = SORT_PRIORITY[b.name] ?? 4;
-    return pa - pb;
-  });
+  return [...events].sort((a, b) => eventSortKey(a) - eventSortKey(b));
 }
 
 // ── Event formatter table ─────────────────────────────────────────────────────

--- a/tests/worker-prompts.test.ts
+++ b/tests/worker-prompts.test.ts
@@ -481,6 +481,39 @@ describe("buildEventPrompt — pipeline behavior", () => {
     expect(commentIdx).toBeLessThan(checkIdx);
   });
 
+  it("pull_request/opened sorts before check_suite events", () => {
+    const events: Wire.WebhookEvent[] = [
+      { id: "e1", name: "check_suite", payload: { action: "completed", check_suite: { conclusion: "success", name: "CI" } } },
+      { id: "e2", name: "pull_request", payload: { action: "opened", pull_request: { number: 42 } } },
+    ];
+    const p = buildEventPrompt(events);
+    const prIdx = p.indexOf("PR #42 has been created");
+    const checkIdx = p.indexOf("Checks succeeded");
+    expect(prIdx).toBeLessThan(checkIdx);
+  });
+
+  it("pull_request/auto_merge_enabled sorts after check_suite events", () => {
+    const events: Wire.WebhookEvent[] = [
+      { id: "e1", name: "pull_request", payload: { action: "auto_merge_enabled", pull_request: { number: 42 } } },
+      { id: "e2", name: "check_suite", payload: { action: "completed", check_suite: { conclusion: "success", name: "CI" } } },
+    ];
+    const p = buildEventPrompt(events);
+    const prIdx = p.indexOf("Auto-merge was enabled");
+    const checkIdx = p.indexOf("Checks succeeded");
+    expect(checkIdx).toBeLessThan(prIdx);
+  });
+
+  it("pull_request/opened sorts before issue_comment", () => {
+    const events: Wire.WebhookEvent[] = [
+      { id: "e1", name: "issue_comment", payload: { issue: { number: 1 }, comment: { body: "feedback here" } } },
+      { id: "e2", name: "pull_request", payload: { action: "opened", pull_request: { number: 42 } } },
+    ];
+    const p = buildEventPrompt(events);
+    const prIdx = p.indexOf("PR #42 has been created");
+    const commentIdx = p.indexOf("feedback here");
+    expect(prIdx).toBeLessThan(commentIdx);
+  });
+
   it("check_suite failure → mentions failed check names and instructs to fix", () => {
     const events: Wire.WebhookEvent[] = [
       { id: "e1", name: "check_suite", payload: { action: "completed", check_suite: { conclusion: "failure", name: "CI / tests" } } },


### PR DESCRIPTION
## Summary

- `pull_request/opened` events now sort to the beginning of multi-event prompts (priority 0), so the worker sees PR creation before CI noise or user feedback
- All other `pull_request` actions (e.g. `closed`, `auto_merge_enabled`) retain their existing low-priority sort position (priority 5)
- Extracted an `eventSortKey` helper that is action-aware for `pull_request` events; the existing `SORT_PRIORITY` table is unchanged

## Test plan

- [x] New test: `pull_request/opened` sorts before `check_suite` events
- [x] New test: `pull_request/auto_merge_enabled` sorts after `check_suite` events (unchanged behavior)
- [x] New test: `pull_request/opened` sorts before `issue_comment` (i.e., before everything)
- [x] All 54 worker-prompts tests pass; no regressions in the full suite

Closes #984

🤖 Generated with [Claude Code](https://claude.com/claude-code)