### PR TITLE
refactor: remove dead Worker.markAvailable() method

### DIFF
--- a/src/foreman/models/worker.ts
+++ b/src/foreman/models/worker.ts
@@ -251,12 +251,6 @@ export class Worker extends ActiveRecord {
     Worker.events.emit("changed");
   }
 
-  /** Mark as available for auto-assignment (ready state). */
-  markAvailable(): void {
-    this.status = "ready";
-    Worker.events.emit("changed");
-  }
-
   /**
    * Transition to ready: reverts any active task back to pending, then releases
    * the worker. Safe to call from reserved or assigned states.


### PR DESCRIPTION
## Summary

- Removes `Worker.markAvailable()` from `src/foreman/models/worker.ts` — it was unreachable dead code since #980 replaced its only call site with `becomeReady()`
- No tests referenced the method; no test changes needed

## Test plan

- [x] `npx tsc --noEmit` — passes clean
- [x] `npm test` — all 1681 unit tests pass

Closes #987

🤖 Generated with [Claude Code](https://claude.com/claude-code)