### PR TITLE
fix: prevent ghost intervals and redundant redraws in status bar

### DIFF
--- a/src/agent/views/display.ts
+++ b/src/agent/views/display.ts
@@ -255,6 +255,13 @@ export class Display {
 
   /** Start the animated query-progress bar, polling getText() every 500ms. */
   startBar(getText: () => string): void {
+    // Clear any existing interval before creating a new one. Without this, a
+    // second startBar() call (e.g. after a tool-permission prompt restarts the
+    // bar) leaves the old interval running with its stale getText closure. Two
+    // intervals firing at the same 500ms cadence then alternate between
+    // different getText outputs, producing the rapid back-and-forth blink
+    // reported in issue #986.
+    if (this._interval) { clearInterval(this._interval); this._interval = null; }
     this.clearBar();
     this.active = true;
     this._getText = getText;
@@ -262,7 +269,7 @@ export class Display {
     this.drawBar();
     this._interval = setInterval(() => {
       this.clearBar();
-      this._text = getText();
+      this._text = this._getText!();
       this.drawBar();
     }, 500);
   }
@@ -325,8 +332,15 @@ export class Display {
   /** Refresh the persistent status line text and redraw. Called on agentStatus "change". */
   private _updatePersistent(): void {
     if (!this.persistentActive) return;
-    this.clearBar();
     this._persistentText = this.renderer.fmtStatusBar(this.agentStatus, (this.getColumns() ?? W) - 1);
+    // When the animation interval is running and no interactive prompt is
+    // active, skip the full clearBar+drawBar — the interval will pick up the
+    // updated text on its next tick. This prevents extra clear/redraw cycles
+    // between interval ticks that cause the status line to flicker (issue #986).
+    // When inputStatus is set, ask() owns the screen and needs drawBar() to
+    // fire its inputStatus callback for proper multiline-prompt redraw.
+    if (this.active && !this.inputStatus) return;
+    this.clearBar();
     this.drawBar();
   }
 }

--- a/tests/display.status-bar-intervals.test.ts
+++ b/tests/display.status-bar-intervals.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { stripAnsi } from "./helpers.js";
+import { getConfig } from "../src/config.js";
+import { Display } from "../src/agent/views/display.js";
+import { AgentStatus } from "../src/agent/models/agent-status.js";
+
+function captureWrites(fn: () => void): string {
+  let output = "";
+  const spy = vi.spyOn(process.stdout, "write").mockImplementation((s: unknown) => { output += String(s); return true; });
+  fn();
+  spy.mockRestore();
+  return output;
+}
+
+let display: Display;
+let agentStatus: AgentStatus;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  agentStatus = new AgentStatus({ agentId: "test-agent" });
+  display = new Display(getConfig(), agentStatus);
+});
+
+afterEach(() => {
+  display.stopBar();
+  display.stopPersistentBar();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+// ── Bug #986: ghost interval from repeated startBar() calls ──────────────────
+//
+// startBar() did not clear this._interval before creating a new setInterval.
+// A second startBar() call (e.g. after a tool-permission prompt) left the
+// first interval running with its own captured getText closure. Two intervals
+// then fired alternately — each writing different text — producing the rapid
+// back-and-forth blink described in the bug report.
+
+describe("startBar() – no ghost interval on repeated calls", () => {
+  it("only shows the second getText after startBar() is called twice without stopBar()", () => {
+    display.startBar(() => "text-A");
+
+    // Second call without stopBar() — should replace the first interval, not add a second.
+    display.startBar(() => "text-B");
+
+    const output = captureWrites(() => vi.advanceTimersByTime(500));
+
+    const plain = stripAnsi(output);
+    expect(plain).not.toContain("text-A");  // ghost interval must not fire
+    expect(plain).toContain("text-B");       // live interval must fire
+  });
+
+  it("stopBar() followed by startBar() still works correctly", () => {
+    display.startBar(() => "text-A");
+    display.stopBar();
+    display.startBar(() => "text-B");
+
+    const output = captureWrites(() => vi.advanceTimersByTime(500));
+
+    const plain = stripAnsi(output);
+    expect(plain).not.toContain("text-A");
+    expect(plain).toContain("text-B");
+  });
+
+  it("three startBar() calls in a row produce only the last getText text", () => {
+    display.startBar(() => "text-A");
+    display.startBar(() => "text-B");
+    display.startBar(() => "text-C");
+
+    const output = captureWrites(() => vi.advanceTimersByTime(500));
+
+    const plain = stripAnsi(output);
+    expect(plain).not.toContain("text-A");
+    expect(plain).not.toContain("text-B");
+    expect(plain).toContain("text-C");
+  });
+});
+
+// ── Bug #986: _updatePersistent() causing redundant redraws while interval runs
+//
+// When the 500ms animation interval is running it already redraws both bars on
+// every tick. _updatePersistent() (called on every agentStatus "change" event)
+// used to unconditionally call clearBar()+drawBar() as well, causing extra
+// clear/redraw cycles between interval ticks — the visual flicker reported as
+// "two different models/views with overlapping timers".
+//
+// Fix: when the primary-bar interval is active, _updatePersistent() should
+// only refresh _persistentText and let the next interval tick do the redraw.
+
+describe("_updatePersistent() – no extra redraws while interval is running", () => {
+  it("agentStatus change while interval is active does not write to stdout between ticks", () => {
+    display.startBar(() => "primary-text");
+    display.startPersistentBar();
+
+    // Capture writes that happen purely from the agentStatus change
+    // (between interval ticks — no vi.advanceTimersByTime here).
+    const writesFromChange = captureWrites(() => {
+      agentStatus.update({ connectionStatus: "handshaking" });
+    });
+
+    // No stdout output should have occurred between interval ticks.
+    expect(writesFromChange).toBe("");
+  });
+
+  it("agentStatus change while interval is NOT active still triggers an immediate redraw", () => {
+    // Only the persistent bar is running — no animation interval.
+    display.startPersistentBar();
+
+    const writesFromChange = captureWrites(() => {
+      agentStatus.update({ connectionStatus: "connected" });
+    });
+
+    // The persistent bar should redraw immediately when no interval is running.
+    expect(writesFromChange).not.toBe("");
+  });
+
+  it("persistent text updated by agentStatus change is visible on the next interval tick", () => {
+    display.startBar(() => "primary-text");
+    display.startPersistentBar();
+
+    // Trigger a status update — should only update internal text, not redraw.
+    agentStatus.update({ connectionStatus: "connected" });
+    agentStatus.setWorkerModeActive(true);
+
+    // The next interval tick should draw both bars with the updated persistent text.
+    const output = captureWrites(() => vi.advanceTimersByTime(500));
+    const plain = stripAnsi(output);
+
+    expect(plain).toContain("primary-text");
+    expect(plain).toContain("Connected");  // from updated persistent status
+  });
+});


### PR DESCRIPTION
## Summary

- **Root cause 1 (ghost interval):** `startBar()` was creating a new `setInterval` without clearing the existing one. A second call — which happens after tool-permission or `AskUserQuestion` prompts restart the animated bar — left the old interval running with its stale `getText` closure. Two intervals firing at offset 500ms cadences then alternated between different `getText` outputs. Since each query run creates a fresh `QueryStats` with a randomly-chosen working verb, the two intervals showed different verbs, producing the rapid back-and-forth blink reported by the user.

- **Root cause 2 (redundant redraws):** `_updatePersistent()` was unconditionally calling `clearBar()+drawBar()` on every `agentStatus` "change" event, even when the 500ms animation interval was also running and would redraw both bars on its next tick anyway. This caused extra clear/redraw cycles between ticks that added to the visual flicker. Fixed by only updating `_persistentText` and deferring the redraw to the next interval tick — except when `ask()` is active (`inputStatus` is set), where the full redraw is still needed so the `inputStatus` callback fires for proper multiline-prompt cursor positioning.

## Test plan

- [x] New test file `tests/display.status-bar-intervals.test.ts` covers both fixes with behavioral stdout assertions
- [x] Confirmed tests failed before the fix and pass after
- [x] `tests/repl.multiline.test.ts` passes (the `inputStatus` carve-out preserves the multiline-prompt redraw behavior)
- [x] Full test suite: 1687/1687 non-DB tests pass, 0 new failures
- [x] TypeScript type-check clean
- [x] Lint: no new errors

Closes #986

🤖 Generated with [Claude Code](https://claude.com/claude-code)