### PR TITLE
fix: reset event-pause state when a new task is assigned

### DIFF
--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -972,8 +972,13 @@ export class WorkerController extends EventEmitter {
       this.currentIssue = msg.issue;
       this.prIsClosed = false;
       this.issueClosed = msg.issue.status === "closed";
+      // Reset event state so the new task starts with a clean slate.
+      this._eventsPaused = false;
+      this.pendingEvents = [];
+      if (this.debounceTimer) { clearTimeout(this.debounceTimer); this.debounceTimer = null; }
       this.agentStatus.update({ taskNumber: msg.issue.number, prNumber: msg.issue.prNumber ?? undefined });
       this.agentStatus.resetTaskStats();
+      this._syncPendingEventsStatus();
       void this.agentStatus.refreshBranch();
       const initialPrompt = buildInitialPrompt(msg.issue, !!this.workspaceController?.workspace);
       this.display.print(c.sageGreen(initialPrompt));

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -110,6 +110,39 @@ describe("task_assigned", () => {
     const printCalls = display.print.mock.calls.map(args => stripAnsi(String(args[0])));
     expect(printCalls.some(s => s.includes(issue.title))).toBe(true);
   });
+
+  it("clears eventsPaused when task_assigned is received while paused", () => {
+    session.pauseEvents();
+    expect(session.eventsPaused).toBe(true);
+
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue: makeIssue() });
+
+    expect(session.eventsPaused).toBe(false);
+  });
+
+  it("discards pending events from prior task when task_assigned is received while paused", () => {
+    // Assign and activate a first task so events can be queued.
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "41", issue: makeIssue(1) });
+    session.takeNextPrompt();
+    // Queue an event for the first task then pause.
+    sendMsg(fakeWs, { type: "event_notification", taskId: "41", event: makeEvent("issue_comment") });
+    session.pauseEvents();
+    expect(session.pendingEventsCount).toBe(1);
+
+    // New task arrives.
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue: makeIssue(2) });
+
+    expect(session.eventsPaused).toBe(false);
+    expect(session.pendingEventsCount).toBe(0);
+  });
+
+  it("agentStatus reflects unpaused state after task_assigned clears eventsPaused", () => {
+    session.pauseEvents();
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue: makeIssue() });
+
+    expect(sb.eventsPaused).toBe(false);
+    expect(sb.pendingEventsCount).toBe(0);
+  });
 });
 
 // ── Event handling during a running query ─────────────────────────────────────


### PR DESCRIPTION
## Summary

- When `task_assigned` is received, `_eventsPaused` is now reset to `false` and `pendingEvents` is cleared
- Any in-flight debounce timer for the old task is also cancelled
- `agentStatus` is synced immediately so the status bar no longer shows "Events paused" at the start of a new task

## Root cause

`pauseEvents()` is called when the user starts typing while in the waiting state (e.g. after `/worker:done`, pressing Enter). If a new task arrived while the worker was in that paused state, the `task_assigned` handler left `_eventsPaused = true` and the stale `pendingEvents` array intact, so every new task started with events already paused.

## Test plan

- [ ] Three new unit tests in `tests/worker.test.ts` under the `task_assigned` describe block:
  - `clears eventsPaused when task_assigned is received while paused`
  - `discards pending events from prior task when task_assigned is received while paused`
  - `agentStatus reflects unpaused state after task_assigned clears eventsPaused`
- [ ] All 1694 tests pass (`npm test`)
- [ ] `npx tsc --noEmit` clean

Closes #990

🤖 Generated with [Claude Code](https://claude.com/claude-code)