### PR TITLE
feat: autocomplete commands via un-namespaced prefix matches

### DIFF
--- a/src/agent/controllers/command-controller.ts
+++ b/src/agent/controllers/command-controller.ts
@@ -40,20 +40,50 @@ export type DispatchResult =
 /**
  * Filter CommandSuggestion objects by substring of name or description.
  * Case-insensitive. Empty query returns all commands.
- * Sort order: prefix matches of name, then non-prefix name substring matches,
- * then description-only matches.
+ * Sort order:
+ *   1. Prefix matches of any colon-separated suffix, ordered by depth (fewer
+ *      leading segments removed = higher priority). `/st` matches `/status`
+ *      (depth 0) before `/worker:start` (depth 1) before `/foo:bar:stuff`
+ *      (depth 2). `/worker:st` matches `/worker:status` (depth 0) before
+ *      `/foo:worker:status` (depth 1).
+ *   2. Non-prefix name substring matches (e.g. `event` in `resume-events`).
+ *   3. Description-only substring matches.
  */
 export function filterCommands(query: string, commands: CommandSuggestion[]): CommandSuggestion[] {
   if (query === "") return commands;
   const q = query.toLowerCase();
-  const prefixName = commands.filter(c => c.name.toLowerCase().startsWith(q));
-  const substringName = commands.filter(
-    c => !c.name.toLowerCase().startsWith(q) && c.name.toLowerCase().includes(q),
-  );
-  const descOnly = commands.filter(
-    c => !c.name.toLowerCase().includes(q) && c.description.toLowerCase().includes(q),
-  );
-  return [...prefixName, ...substringName, ...descOnly];
+
+  type Scored = { cmd: CommandSuggestion; depth: number };
+  const prefixMatches: Scored[] = [];
+  const substringName: CommandSuggestion[] = [];
+  const descOnly: CommandSuggestion[] = [];
+
+  for (const c of commands) {
+    const name = c.name.toLowerCase();
+    const segments = name.split(":");
+
+    // Find the shallowest depth at which q is a prefix of a colon-joined suffix.
+    let minDepth = -1;
+    for (let i = 0; i < segments.length; i++) {
+      if (segments.slice(i).join(":").startsWith(q)) {
+        minDepth = i;
+        break;
+      }
+    }
+
+    if (minDepth >= 0) {
+      prefixMatches.push({ cmd: c, depth: minDepth });
+    } else if (name.includes(q)) {
+      substringName.push(c);
+    } else if (c.description.toLowerCase().includes(q)) {
+      descOnly.push(c);
+    }
+  }
+
+  // Stable sort by depth so shallower (more absolute) matches rank first.
+  prefixMatches.sort((a, b) => a.depth - b.depth);
+
+  return [...prefixMatches.map(s => s.cmd), ...substringName, ...descOnly];
 }
 
 export interface CommandEntry {

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { CommandRegistry, CommandController } from "../src/agent/controllers/command-controller.js";
+import { CommandRegistry, CommandController, filterCommands } from "../src/agent/controllers/command-controller.js";
 import { registerTestCommands } from "./helpers.js";
 
 let registry: CommandController;
@@ -164,5 +164,112 @@ describe("each registered entry shape", () => {
     for (const entry of registry.registry.listAll()) {
       expect(entry.description, `${entry.name} should have description`).toBeTruthy();
     }
+  });
+});
+
+// ── filterCommands ────────────────────────────────────────────────────────────
+
+describe("filterCommands", () => {
+  it("empty query returns all commands", () => {
+    const cmds = [{ name: "foo", description: "" }, { name: "bar", description: "" }];
+    expect(filterCommands("", cmds)).toEqual(cmds);
+  });
+
+  it("prefix of full name matches", () => {
+    const result = filterCommands("ex", [{ name: "exit", description: "" }]);
+    expect(result.map(c => c.name)).toEqual(["exit"]);
+  });
+
+  it("non-prefix substring of name matches", () => {
+    const result = filterCommands("xit", [{ name: "exit", description: "" }]);
+    expect(result.map(c => c.name)).toEqual(["exit"]);
+  });
+
+  it("description-only match returns command", () => {
+    const result = filterCommands("suite", [
+      { name: "run-tests", description: "Run the test suite" },
+    ]);
+    expect(result.map(c => c.name)).toEqual(["run-tests"]);
+  });
+
+  it("prefix of last segment matches a namespaced command", () => {
+    const result = filterCommands("comp", [{ name: "worker:complete", description: "" }]);
+    expect(result.map(c => c.name)).toEqual(["worker:complete"]);
+  });
+
+  it("case-insensitive segment prefix match", () => {
+    const result = filterCommands("COMP", [{ name: "worker:complete", description: "" }]);
+    expect(result.map(c => c.name)).toEqual(["worker:complete"]);
+  });
+
+  it("depth-0 prefix match comes before depth-1 segment prefix match", () => {
+    const result = filterCommands("st", [
+      { name: "worker:start", description: "" },
+      { name: "status",       description: "" },
+    ]);
+    expect(result.map(c => c.name)).toEqual(["status", "worker:start"]);
+  });
+
+  it("depth-1 segment prefix match comes before non-prefix substring match", () => {
+    // "st" is a prefix of the "start" segment in "worker:start" (depth 1)
+    // "st" is NOT a prefix of any segment in "some-stuff" (substring only)
+    const result = filterCommands("st", [
+      { name: "some-stuff",   description: "" },
+      { name: "worker:start", description: "" },
+    ]);
+    expect(result.map(c => c.name)).toEqual(["worker:start", "some-stuff"]);
+  });
+
+  it("depth-1 segment prefix match comes before depth-2 segment prefix match", () => {
+    // "st" → "start" at depth 1 in "worker:start", "stuff" at depth 2 in "foo:bar:stuff"
+    const result = filterCommands("st", [
+      { name: "foo:bar:stuff", description: "" },
+      { name: "worker:start",  description: "" },
+    ]);
+    expect(result.map(c => c.name)).toEqual(["worker:start", "foo:bar:stuff"]);
+  });
+
+  it("full sort order: depth-0, depth-1, depth-2, substring, description", () => {
+    const result = filterCommands("st", [
+      { name: "foo:bar:stuff",  description: "" },
+      { name: "some-stuff",     description: "" },
+      { name: "worker:start",   description: "" },
+      { name: "status",         description: "" },
+      { name: "brainstorm",     description: "Start something" },
+    ]);
+    expect(result.map(c => c.name)).toEqual([
+      "status",
+      "worker:start",
+      "foo:bar:stuff",
+      "some-stuff",
+      "brainstorm",
+    ]);
+  });
+
+  it("sort order: prefix name match before description-only match", () => {
+    const result = filterCommands("run", [
+      { name: "brainstorm", description: "Run ideas by the AI" },
+      { name: "run-tests",  description: "Execute the suite" },
+    ]);
+    expect(result.map(c => c.name)).toEqual(["run-tests", "brainstorm"]);
+  });
+
+  it("/worker:st matches /worker:status at depth 0 before /foo:worker:status at depth 1", () => {
+    const result = filterCommands("worker:st", [
+      { name: "foo:worker:status", description: "" },
+      { name: "worker:status",     description: "" },
+    ]);
+    expect(result.map(c => c.name)).toEqual(["worker:status", "foo:worker:status"]);
+  });
+
+  it("non-prefix substring of full name stays as substring match (not promoted to prefix)", () => {
+    // "event" does not start any segment of "something-events" or "worker:resume-events"
+    const result = filterCommands("event", [
+      { name: "something-events",    description: "" },
+      { name: "worker:resume-events", description: "" },
+    ]);
+    expect(result).toHaveLength(2);
+    // Both are substring matches; order preserved from input
+    expect(result.map(c => c.name)).toEqual(["something-events", "worker:resume-events"]);
   });
 });

--- a/tests/repl.autocomplete.test.ts
+++ b/tests/repl.autocomplete.test.ts
@@ -682,6 +682,35 @@ describe("ask() - substring and description autocomplete", () => {
       expect(result).toBe("/run-tests"); // prefix match before description match
     });
   });
+
+  it("un-namespaced query matches namespaced command via segment prefix", async () => {
+    const namespacedCmds = (): CommandSuggestion[] => [
+      { name: "worker:complete", description: "Complete the task" },
+    ];
+    await withFakeStdin(async (stdin) => {
+      const p = testInput.ask("> ", namespacedCmds);
+      stdin.push("/comp");
+      stdin.push("\r"); // Enter picks the only match
+      const result = await p;
+      expect(result).toBe("/worker:complete");
+    });
+  });
+
+  it("sort order: segment prefix match ranked before non-prefix substring match", async () => {
+    // "/st" is a prefix of the "start" segment in "worker:start" (depth 1)
+    // "/st" is NOT a prefix of any segment in "restart" (substring match only)
+    const mixedCmds = (): CommandSuggestion[] => [
+      { name: "restart",     description: "" },
+      { name: "worker:start", description: "" },
+    ];
+    await withFakeStdin(async (stdin) => {
+      const p = testInput.ask("> ", mixedCmds);
+      stdin.push("/st");
+      stdin.push("\r"); // Enter picks first match
+      const result = await p;
+      expect(result).toBe("/worker:start"); // segment prefix beats substring
+    });
+  });
 });
 
 // ── Arrow navigation in autocomplete ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `/comp` now matches `/worker:complete` as a depth-1 segment-prefix match (not just a substring match)
- Sort order within prefix matches is now by depth: full-name prefix (depth 0) → last-segment prefix (depth 1) → deeper-segment prefix (depth 2) — so `/st` shows `/status` first, then `/worker:start`, then `/foo:bar:stuff`
- The existing sort groups (non-prefix substring, description-only) are unchanged and still rank below all segment-prefix matches

## Implementation

Changed `filterCommands` in `src/agent/controllers/command-controller.ts` to scan each colon-separated suffix of the command name for a prefix match, recording the minimum "depth" (number of leading segments removed). Results are stable-sorted by depth ascending.

## Test plan

- [ ] New unit tests in `tests/commands.test.ts` cover all five sort groups and depth ordering
- [ ] New integration tests in `tests/repl.autocomplete.test.ts` verify `/comp → /worker:complete` and segment-prefix sort over substring
- [ ] Type-check and lint pass cleanly
- [ ] Full non-DB test suite passes (DB tests require `supabase start`)

Closes #993

🤖 Generated with [Claude Code](https://claude.com/claude-code)