### PR TITLE
refactor: collapse worker:start and worker:ready into single command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Every `worker_hello` gets a `hello_ack` with one of four statuses before any tas
 
 Worker state transitions happen via dedicated messages while the worker stays connected:
 - `task_complete { nextState: "reserved" }` — complete a task; always sends `reserved` so the foreman holds the worker out of the auto-assignment pool while the post-task picker is showing. Pass `nextState: "reserved"` explicitly in the claim flow to skip the picker entirely.
-- `worker_ready` — transition from `reserved` → `ready`; sent after the user confirms "wait for next task" in the picker, by `/worker:ready`, or immediately in non-interactive mode
+- `worker_ready` — transition from `reserved` → `ready`; sent after the user confirms "wait for next task" in the picker, by `/worker:start` (or its alias `/worker:ready`), or immediately in non-interactive mode
 - `worker_reserved` — transition from `ready` → `reserved` without disconnecting; sent when the user presses `^C` while waiting (no task)
 
 The `/worker:claim` command connects with `status: "reserved"` (no `claimTaskId` in the hello), receives `hello_ack { status: "reserved" }`, then sends `claim_task { taskId }` separately. The foreman replies with `task_assigned` or a non-fatal `foreman_error`.

--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -583,7 +583,26 @@ export class WorkerController extends EventEmitter {
     });
     registry.register("start", {
       description: "Connect to the foreman and start accepting tasks",
-      handler: async () => { await this.start(); },
+      aliases: ["ready"],
+      handler: async () => {
+        if (!this._isActive) {
+          await this.start();
+          return undefined;
+        }
+        if (this.hasTask()) {
+          const taskInfo = this.getTaskConfirmInfo();
+          if (taskInfo) {
+            this.display.print(c.amber(`\nCurrently assigned task #${taskInfo.taskNumber}. Abandon this task?`));
+            const idx = await this.pickFnOrDefault()(["Yes, abandon and wait for new tasks", `No, stay with task #${taskInfo.taskNumber}`]);
+            if (idx !== 0) return undefined;
+            this.currentTaskId = undefined;
+            this.currentIssue = undefined;
+          }
+        }
+        this.sendWorkerReady();
+        this.transitionToIdle();
+        return undefined;
+      },
     });
     registry.register("stop", {
       description: "Disconnect from the foreman",
@@ -663,28 +682,6 @@ export class WorkerController extends EventEmitter {
         } else {
           this._pendingClaimTaskId = taskId;
         }
-        return undefined;
-      },
-    });
-    registry.register("ready", {
-      description: "Opt back into auto-assignment from a reserved state",
-      handler: async () => {
-        if (!this._isActive) {
-          await this.start();
-          return undefined;
-        }
-        if (this.hasTask()) {
-          const taskInfo = this.getTaskConfirmInfo();
-          if (taskInfo) {
-            this.display.print(c.amber(`\nCurrently assigned task #${taskInfo.taskNumber}. Abandon this task?`));
-            const idx = await this.pickFnOrDefault()(["Yes, abandon and wait for new tasks", `No, stay with task #${taskInfo.taskNumber}`]);
-            if (idx !== 0) return undefined;
-            this.currentTaskId = undefined;
-            this.currentIssue = undefined;
-          }
-        }
-        this.sendWorkerReady();
-        this.transitionToIdle();
         return undefined;
       },
     });

--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -582,7 +582,7 @@ export class WorkerController extends EventEmitter {
       },
     });
     registry.register("start", {
-      description: "Connect to the foreman and start accepting tasks",
+      description: "Start accepting tasks from the foreman",
       aliases: ["ready"],
       handler: async () => {
         if (!this._isActive) {

--- a/tests/worker.mode-switching.test.ts
+++ b/tests/worker.mode-switching.test.ts
@@ -176,7 +176,7 @@ describe("worker mode switching", () => {
     expect(capturedStatus?.workerModeActive).toBe(false);
   });
 
-  it("/worker:start when already active prints a message and does not create a second session", async () => {
+  it("/worker:start when already active transitions to ready without creating a second session", async () => {
     const agent = new BrunelAgent(getConfig());
     const printedMessages: string[] = [];
     vi.spyOn(agent.display, "print").mockImplementation((line) => {
@@ -187,14 +187,13 @@ describe("worker mode switching", () => {
     mockInput.ask.mockImplementation(() => {
       askCallCount++;
       if (askCallCount === 1) return Promise.resolve("/worker:start");
-      if (askCallCount === 2) return Promise.resolve("/worker:start"); // second start
+      if (askCallCount === 2) return Promise.resolve("/worker:start"); // second start while already connected
       return Promise.resolve("__eof__");
     });
 
     await runAgent(false, agent);
 
     expect(capturedControllers.list).toHaveLength(1); // only one controller activated
-    expect(printedMessages.some(m => m.includes("already active"))).toBe(true);
   });
 
   it("/worker:stop when not active prints a message", async () => {

--- a/tests/worker.start.test.ts
+++ b/tests/worker.start.test.ts
@@ -1,9 +1,8 @@
 /**
- * Unit tests for the /worker:ready command.
+ * Unit tests for the /worker:start command (with /worker:ready as alias).
  *
- * Tests the worker-side of opting back into auto-assignment: auto-starting
- * if not connected, prompting to abandon an active task, and the happy path
- * (sends worker_ready to foreman and prints "Waiting for tasks...").
+ * Tests: auto-starting if not connected, prompting to abandon an active task,
+ * and the happy path (sends worker_ready to foreman and prints "Waiting for tasks...").
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { EventEmitter } from "events";
@@ -40,7 +39,7 @@ class FakeWs extends EventEmitter {
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
-const AGENT_ID = "test-worker-ready-id";
+const AGENT_ID = "test-worker-start-id";
 
 function sentWorkerReady(ws: FakeWs): { type: string; workerId: string } | undefined {
   for (const call of ws.send.mock.calls) {
@@ -85,11 +84,11 @@ function makeSession(pickFn?: (options: string[]) => Promise<number>): WorkerCon
   );
 }
 
-async function getReadyHandler(s: WorkerController): Promise<(args: string) => Promise<void>> {
+async function getStartHandler(s: WorkerController): Promise<(args: string) => Promise<void>> {
   const reg = new CommandRegistry();
   s.registerCommands(reg.scoped("worker"));
-  const entry = reg.lookup("worker:ready");
-  if (!entry) throw new Error("worker:ready not registered");
+  const entry = reg.lookup("worker:start");
+  if (!entry) throw new Error("worker:start not registered");
   return entry.handler as (args: string) => Promise<void>;
 }
 
@@ -106,8 +105,15 @@ afterEach(() => { vi.useRealTimers(); });
 
 // ── Command registration ───────────────────────────────────────────────────────
 
-it("registers worker:ready command", () => {
-  expect(registry.lookup("worker:ready")).toBeDefined();
+it("registers worker:start as canonical command", () => {
+  expect(registry.lookup("worker:start")).toBeDefined();
+  expect(registry.lookup("worker:start")?.aliasFor).toBeUndefined();
+});
+
+it("registers worker:ready as alias for worker:start", () => {
+  const entry = registry.lookup("worker:ready");
+  expect(entry).toBeDefined();
+  expect(entry?.aliasFor).toBe("worker:start");
 });
 
 // ── Not active: auto-start ─────────────────────────────────────────────────────
@@ -115,13 +121,13 @@ it("registers worker:ready command", () => {
 describe("when worker mode is not active", () => {
   it("starts worker mode", async () => {
     expect(session.isActive).toBe(false);
-    const handler = await getReadyHandler(session);
+    const handler = await getStartHandler(session);
     await handler("");
     expect(session.isActive).toBe(true);
   });
 
   it("connects as ready (not reserved)", async () => {
-    const handler = await getReadyHandler(session);
+    const handler = await getStartHandler(session);
     await handler("");
     // Fire open to trigger hello send
     fakeWs.emit("open");
@@ -146,7 +152,7 @@ describe("when has an active task", () => {
     const s = makeSession(pickFn);
     await s.start();
     setupActiveTask(s);
-    const handler = await getReadyHandler(s);
+    const handler = await getStartHandler(s);
     await handler("");
     expect(pickFn).toHaveBeenCalled();
     const [options] = pickFn.mock.calls[0] as [string[]];
@@ -159,7 +165,7 @@ describe("when has an active task", () => {
     const s = makeSession(pickFn);
     await s.start();
     setupActiveTask(s);
-    const handler = await getReadyHandler(s);
+    const handler = await getStartHandler(s);
     await handler("");
     const msgs = printedMessages(display);
     expect(msgs.some(m => m.includes(String(FAKE_ISSUE.number)))).toBe(true);
@@ -171,7 +177,7 @@ describe("when has an active task", () => {
     await s.start();
     setupActiveTask(s);
     fakeWs.send.mockClear();
-    const handler = await getReadyHandler(s);
+    const handler = await getStartHandler(s);
     await handler("");
     expect(sentWorkerReady(fakeWs)).toBeUndefined();
     expect(sentGoodbye(fakeWs)).toBeUndefined();
@@ -183,7 +189,7 @@ describe("when has an active task", () => {
     await s.start();
     setupActiveTask(s);
     fakeWs.send.mockClear();
-    const handler = await getReadyHandler(s);
+    const handler = await getStartHandler(s);
     await handler("");
     expect(sentWorkerReady(fakeWs)).toBeDefined();
     expect(sentGoodbye(fakeWs)).toBeUndefined();
@@ -195,7 +201,7 @@ describe("when has an active task", () => {
     const s = makeSession(pickFn);
     await s.start();
     setupActiveTask(s);
-    const handler = await getReadyHandler(s);
+    const handler = await getStartHandler(s);
     await handler("");
     expect((s as any).currentTaskId).toBeUndefined();
   });
@@ -210,7 +216,7 @@ describe("when active and idle (no active task)", () => {
   });
 
   it("sends worker_ready with correct workerId", async () => {
-    const handler = await getReadyHandler(session);
+    const handler = await getStartHandler(session);
     await handler("");
     const msg = sentWorkerReady(fakeWs);
     expect(msg).toBeDefined();
@@ -219,7 +225,7 @@ describe("when active and idle (no active task)", () => {
   });
 
   it("prints 'Waiting for tasks...'", async () => {
-    const handler = await getReadyHandler(session);
+    const handler = await getStartHandler(session);
     await handler("");
     const msgs = printedMessages(display);
     expect(msgs.some(m => m.includes("Waiting for tasks"))).toBe(true);
@@ -236,7 +242,7 @@ describe("when socket is not open", () => {
   });
 
   it("does not send worker_ready when socket is closed", async () => {
-    const handler = await getReadyHandler(session);
+    const handler = await getStartHandler(session);
     await handler("");
     expect(sentWorkerReady(fakeWs)).toBeUndefined();
   });


### PR DESCRIPTION
## Summary

- `/worker:start` now has the full behavior of the old `/worker:ready`: auto-starts if not connected, prompts to abandon an active task, and transitions to the ready (auto-assignable) state
- `/worker:ready` is registered as an alias for `/worker:start`
- The old thin `/worker:start` (which only connected without transitioning to ready) is removed
- Renamed `tests/worker.ready.test.ts` → `tests/worker.start.test.ts` to match

## Test plan

- [ ] Unit tests in `worker.start.test.ts` cover: registration of `worker:start` as canonical and `worker:ready` as alias, auto-start when not active, abandon prompt with active task, happy path (sends `worker_ready`), socket-closed guard
- [ ] `worker.mode-switching.test.ts` updated: second `/worker:start` when already connected transitions to ready (no longer shows "already active")
- [ ] `npx tsc --noEmit` passes
- [ ] All non-DB tests pass

Closes #995

🤖 Generated with [Claude Code](https://claude.com/claude-code)