### PR TITLE
fix: preserve option label during text entry (textEntryPrefix)

### DIFF
--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -501,7 +501,7 @@ export class WorkerController extends EventEmitter {
   /** Normalises the three picker sources (real Picker / test pickFn / none) into a PickResult. */
   private async postTaskPick(options: string[]): Promise<PickResult> {
     if (this.picker) {
-      return this.picker.pick(options, { textEntryIndex: 1 });
+      return this.picker.pick(options, { textEntryIndex: 1, textEntryPrefix: "Claim a specific task: " });
     }
     if (this.options?.pickFn) {
       const r = await this.options.pickFn(options);

--- a/src/agent/views/picker.ts
+++ b/src/agent/views/picker.ts
@@ -21,6 +21,8 @@ export type PickConfig = {
   lastIsTextEntry?: boolean;
   /** Treat the option at this index as an inline text-entry row. Takes precedence over lastIsTextEntry. */
   textEntryIndex?: number;
+  /** Prefix shown in the text-entry row while typing. Defaults to "Other: ". */
+  textEntryPrefix?: string;
 };
 
 export type PickResult =
@@ -85,12 +87,13 @@ export class Picker {
       let done = false;
       const count = options.length;
       const otherIdx = config?.textEntryIndex ?? (lastIsTextEntry ? count - 1 : -1);
+      const textEntryPrefix = config?.textEntryPrefix ?? "Other: ";
       let textMode = false;
       let textBuf = "";
 
       const renderLine = (i: number): string => {
         const marker = (i === currentIdx) ? "✓ " : undefined;
-        const text = (i === otherIdx && textMode) ? `Other: ${textBuf}` : options[i];
+        const text = (i === otherIdx && textMode) ? `${textEntryPrefix}${textBuf}` : options[i];
         return Picker.pickerLine(text, i === idx, marker);
       };
 
@@ -99,8 +102,8 @@ export class Picker {
       }
 
       function positionTextCursor() {
-        // Move up from below last line to Other row, position after "▶ Other: " + textBuf
-        process.stdout.write(`\x1b[${count - otherIdx}A\r\x1b[${10 + textBuf.length}C`);
+        // Move up from below last line to text-entry row; position after "▶ " (3 cols) + prefix + textBuf
+        process.stdout.write(`\x1b[${count - otherIdx}A\r\x1b[${3 + textEntryPrefix.length + textBuf.length}C`);
       }
 
       function redraw() {

--- a/tests/picker.test.ts
+++ b/tests/picker.test.ts
@@ -238,6 +238,71 @@ describe("Picker: textEntryIndex allows text entry on any option", () => {
   });
 });
 
+// ── Issue #1007: textEntryPrefix preserves option label during text entry ──────
+//
+// Bug: the text-entry row replaced its label with "Other: <typed text>" as soon
+// as the user started typing. A meaningful label like "Claim a specific task:"
+// disappeared mid-interaction.
+//
+// Fix: PickConfig accepts an optional textEntryPrefix. When set, it is used as
+// the visible prefix in text mode instead of the hard-coded "Other: " string.
+// The cursor-positioning math in positionTextCursor() also uses the actual
+// prefix length rather than the hard-coded 10.
+
+describe("Picker: textEntryPrefix option (issue #1007)", () => {
+  afterEach(() => {
+    process.stdin.removeAllListeners("data");
+    vi.restoreAllMocks();
+  });
+
+  it("renders custom prefix in text mode instead of 'Other: '", async () => {
+    const written: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+      written.push(String(chunk));
+      return true;
+    });
+    const picker = new Picker();
+
+    const prefix = "Claim a specific task: ";
+    const promise = picker.pick(
+      ["Option A", "Claim a specific task:", "Option C"],
+      { textEntryIndex: 1, textEntryPrefix: prefix },
+    );
+    process.stdin.emit("data", "\x11"); // navigate to index 1 → text mode
+    process.stdin.emit("data", "t");
+    process.stdin.emit("data", "\r");
+    await promise;
+
+    const all = written.join("");
+    expect(all).toContain("Claim a specific task: ");
+    expect(all).not.toContain("Other: t");
+  });
+
+  it("positions cursor after actual prefix length, not hard-coded 10", async () => {
+    const written: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+      written.push(String(chunk));
+      return true;
+    });
+    const picker = new Picker();
+
+    const prefix = "Claim a specific task: "; // 23 chars → cursor col = 3 + 23 = 26
+    const promise = picker.pick(
+      ["Option A", "Claim a specific task:", "Option C"],
+      { textEntryIndex: 1, textEntryPrefix: prefix },
+    );
+    process.stdin.emit("data", "\x11"); // navigate → triggers positionTextCursor with empty buf
+    process.stdin.emit("data", "\x03"); // cancel
+    await promise;
+
+    const all = written.join("");
+    // Cursor should move right by 3 (▶ space) + 23 (prefix) = 26 columns
+    expect(all).toContain("\x1b[26C");
+    // Must NOT use the old hard-coded 10 value for this prefix
+    expect(all).not.toContain("\x1b[10C");
+  });
+});
+
 describe("Picker: ^C cancels cleanly without calling process.exit (issue #887)", () => {
   afterEach(() => {
     process.stdin.removeAllListeners("data");


### PR DESCRIPTION
## Summary

- Adds `textEntryPrefix?: string` to `PickConfig` so callers can supply a custom visible prefix for the text-entry row instead of the hard-coded `"Other: "` string
- Fixes cursor-positioning math in `positionTextCursor()` to use the actual prefix length (`3 + prefix.length`) rather than the hard-coded `10`
- Updates `WorkerController.postTaskPick()` to pass `textEntryPrefix: "Claim a specific task: "`, so the row reads `"Claim a specific task: task-123"` as the user types instead of `"Other: task-123"`

## Test plan

- [x] Two new tests added to `tests/picker.test.ts`:
  - `renders custom prefix in text mode instead of 'Other: '` — captures stdout and asserts the custom prefix appears and `"Other: "` does not
  - `positions cursor after actual prefix length, not hard-coded 10` — checks the cursor escape code uses `3 + prefix.length` columns
- [x] All 20 picker tests pass
- [x] Full unit test suite passes (only pre-existing Supabase-dependent failures)
- [x] `npx tsc --noEmit` clean

Closes #1007

🤖 Generated with [Claude Code](https://claude.com/claude-code)