### PR TITLE
perf: defer workspace reset until after the post-task picker

### DIFF
--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -328,12 +328,7 @@ export class WorkerController extends EventEmitter {
   }
 
   private async buildCompleteGoodbyeOpts(): Promise<{ task_complete: true; stats?: { inputTokens: number; outputTokens: number; costUsd?: number } }> {
-    if (this._activeAfterTask) {
-      try { await this._activeAfterTask(); } catch (err) {
-        if (err instanceof UserCancelledError) throw err;
-        this.display.print(c.amber(`afterTask failed: ${fmtError(err)}`));
-      }
-    }
+    // No afterTask reset here — the workspace will be destroyed when the process exits.
     const { taskInputTokens, taskOutputTokens, taskCostUsd } = this.agentStatus;
     const hasStats = taskInputTokens > 0 || taskOutputTokens > 0 || taskCostUsd != null;
     const statsStr = fmtTaskStats(taskInputTokens, taskOutputTokens, taskCostUsd);
@@ -416,12 +411,18 @@ export class WorkerController extends EventEmitter {
   }
 
   /**
-   * Complete the current task: call afterTask hook, send task_complete, reset state,
-   * then prompt the user for what to do next.
+   * Complete the current task: send task_complete, reset state, then prompt the user
+   * for what to do next.
    *
    * Always sends nextState: "reserved" to the foreman so it doesn't auto-assign a new
    * task while the picker is showing. promptAfterTaskComplete() calls sendWorkerReady()
    * only after the user confirms they want to keep waiting.
+   *
+   * For the claim flow (nextState: "reserved"), afterTask runs before task_complete so
+   * a UserCancelledError can abort the completion if the workspace has unsafe changes.
+   * For the default flow (nextState: "ready"), afterTask is deferred to after the picker
+   * so the picker appears immediately; the exit option skips afterTask entirely since
+   * the workspace is about to be destroyed.
    *
    * Pass "reserved" explicitly to skip the picker entirely (claim flow — the caller
    * handles the next action, e.g. sendClaimTask).
@@ -431,11 +432,11 @@ export class WorkerController extends EventEmitter {
    */
   async completeCurrentTask(nextState: "ready" | "reserved" = "ready"): Promise<"task-complete" | "exit" | undefined> {
     if (!this.currentTaskId) return undefined;
-    if (this._activeAfterTask) {
+    if (nextState === "reserved" && this._activeAfterTask) {
+      // Claim flow: run afterTask before marking complete so UserCancelledError can
+      // abort if the workspace has unsafe changes.
       try { await this._activeAfterTask(); } catch (err) {
         if (err instanceof UserCancelledError) throw err;
-        // Log but don't abort — the task IS complete even if workspace cleanup fails.
-        // Returning early here would leave the task stuck on the foreman forever.
         this.display.print(c.amber(`afterTask failed: ${fmtError(err)}`));
       }
     }
@@ -469,6 +470,9 @@ export class WorkerController extends EventEmitter {
    * this is what transitions the foreman from "reserved" to auto-assignable.
    *
    * Option 1 ("Claim a specific task:") uses inline text entry via textEntryIndex: 1.
+   *
+   * afterTask (workspace reset) runs after the picker for all options except Exit,
+   * where it is skipped entirely since the workspace will be destroyed on exit.
    */
   private async promptAfterTaskComplete(): Promise<"task-complete" | "exit"> {
     // task_complete was already sent to the foreman by completeCurrentTask().
@@ -483,18 +487,41 @@ export class WorkerController extends EventEmitter {
 
     if (result.type === "other") {
       const taskId = result.text.trim();
+      await this.runAfterTaskReset();
       if (taskId) this.claimAfterTask(taskId);
       return "task-complete";
     }
 
     const index = result.type === "selected" ? result.index : -1;
     switch (index) {
-      case 2: await this.stop(); return "task-complete";
-      case 3: await this.stop(); return "exit";
+      case 2:
+        await this.runAfterTaskReset();
+        await this.stop();
+        return "task-complete";
+      case 3:
+        // exit: skip reset — workspace will be destroyed
+        await this.stop();
+        return "exit";
       default:
+        await this.runAfterTaskReset();
         this.sendWorkerReady();
         this.display.print(c.sageGreen("Waiting for next task..."));
         return "task-complete";
+    }
+  }
+
+  /** Run afterTask (workspace reset) after the picker, swallowing errors non-fatally. */
+  private async runAfterTaskReset(): Promise<void> {
+    if (!this._activeAfterTask) return;
+    try {
+      await this._activeAfterTask();
+    } catch (err) {
+      if (err instanceof UserCancelledError) {
+        this.display.print(c.amber("Workspace reset cancelled."));
+        return;
+      }
+      // Log but don't abort — task_complete was already sent.
+      this.display.print(c.amber(`afterTask failed: ${fmtError(err)}`));
     }
   }
 

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1608,7 +1608,7 @@ describe("workspace slash commands in WorkerController", () => {
 // ── afterTask callback on /worker:complete ──────────────────────────────────────
 
 describe("afterTask callback on /worker:complete", () => {
-  it("calls afterTask before sending task_complete to foreman", async () => {
+  it("calls afterTask after task_complete is sent (picker defaults to wait)", async () => {
     const afterTask = vi.fn().mockResolvedValue(undefined);
     const sessionWithAfterTask = new WorkerController(sb, display, undefined, undefined, "", { wsFactory, afterTask });
     await sessionWithAfterTask.start();
@@ -1618,9 +1618,11 @@ describe("afterTask callback on /worker:complete", () => {
     sessionWithAfterTask.takeNextPrompt();
 
     await sessionWithAfterTask.completeCurrentTask();
+    // task_complete is sent first (before afterTask runs)
+    const firstMsg = JSON.parse(fakeWs.send.mock.calls[0][0]);
+    expect(firstMsg.type).toBe("task_complete");
+    // afterTask is called after the picker
     expect(afterTask).toHaveBeenCalledOnce();
-    const sentMsg = JSON.parse(fakeWs.send.mock.calls[0][0]);
-    expect(sentMsg.type).toBe("task_complete");
   });
 
   it("sends task_complete even if afterTask throws (task must not get stuck on foreman)", async () => {
@@ -1649,7 +1651,8 @@ describe("afterTask callback on /worker:complete", () => {
     expect(firstMsg.type).toBe("task_complete");
   });
 
-  it("does NOT send task_complete when afterTask throws UserCancelledError", async () => {
+  it("claim flow: does NOT send task_complete when afterTask throws UserCancelledError", async () => {
+    // In the claim (reserved) path, afterTask runs before task_complete so UCE can abort.
     const afterTask = vi.fn().mockRejectedValue(new UserCancelledError());
     const sessionWithAfterTask = new WorkerController(sb, display, undefined, undefined, "", { wsFactory, afterTask });
     await sessionWithAfterTask.start();
@@ -1659,14 +1662,16 @@ describe("afterTask callback on /worker:complete", () => {
     sessionWithAfterTask.takeNextPrompt();
 
     const sendCountBefore = fakeWs.send.mock.calls.length;
-    try { await sessionWithAfterTask.completeCurrentTask(); } catch { /* UserCancelledError expected */ }
+    try { await sessionWithAfterTask.completeCurrentTask("reserved"); } catch { /* UserCancelledError expected */ }
     const taskCompleteSent = fakeWs.send.mock.calls
       .slice(sendCountBefore)
       .some(([data]: [string]) => JSON.parse(data).type === "task_complete");
     expect(taskCompleteSent).toBe(false);
   });
 
-  it("preserves task state when afterTask throws UserCancelledError", async () => {
+  it("ready flow: sends task_complete even when afterTask throws UserCancelledError", async () => {
+    // In the default (ready) path, task_complete is sent before afterTask runs,
+    // so UCE from afterTask cannot prevent task_complete from being sent.
     const afterTask = vi.fn().mockRejectedValue(new UserCancelledError());
     const sessionWithAfterTask = new WorkerController(sb, display, undefined, undefined, "", { wsFactory, afterTask });
     await sessionWithAfterTask.start();
@@ -1675,7 +1680,25 @@ describe("afterTask callback on /worker:complete", () => {
     sendMsg(fakeWs, { type: "task_assigned", taskId: "t1", issue });
     sessionWithAfterTask.takeNextPrompt();
 
-    try { await sessionWithAfterTask.completeCurrentTask(); } catch { /* UserCancelledError expected */ }
+    const sendCountBefore = fakeWs.send.mock.calls.length;
+    await sessionWithAfterTask.completeCurrentTask(); // ready path: UCE handled gracefully
+    const taskCompleteSent = fakeWs.send.mock.calls
+      .slice(sendCountBefore)
+      .some(([data]: [string]) => JSON.parse(data).type === "task_complete");
+    expect(taskCompleteSent).toBe(true);
+  });
+
+  it("claim flow: preserves task state when afterTask throws UserCancelledError", async () => {
+    // In the claim (reserved) path, UCE from afterTask prevents task_complete and keeps the task.
+    const afterTask = vi.fn().mockRejectedValue(new UserCancelledError());
+    const sessionWithAfterTask = new WorkerController(sb, display, undefined, undefined, "", { wsFactory, afterTask });
+    await sessionWithAfterTask.start();
+
+    const issue = makeIssue();
+    sendMsg(fakeWs, { type: "task_assigned", taskId: "t1", issue });
+    sessionWithAfterTask.takeNextPrompt();
+
+    try { await sessionWithAfterTask.completeCurrentTask("reserved"); } catch { /* UserCancelledError expected */ }
     expect(sessionWithAfterTask.hasTask()).toBe(true);
   });
 });
@@ -1728,6 +1751,13 @@ describe("completeCurrentTask: post-completion prompt", () => {
     const result = await sess.completeCurrentTask();
     expect(result).toBe("task-complete");
     expect(sess.isActive).toBe(false);
+  });
+
+  it("option 3 (exit): does NOT call afterTask (workspace will be destroyed)", async () => {
+    const afterTask = vi.fn().mockResolvedValue(undefined);
+    const { sess } = await makeSession(async () => 3, { afterTask });
+    await sess.completeCurrentTask();
+    expect(afterTask).not.toHaveBeenCalled();
   });
 
   it("option 3 (exit): stops worker mode and returns 'exit'", async () => {
@@ -1932,7 +1962,9 @@ describe("stop — complete-and-quit", () => {
     expect(goodbye.stats).toBeUndefined();
   });
 
-  it("does NOT stop when afterTask throws UserCancelledError during complete-and-quit", async () => {
+  it("complete-and-quit: skips afterTask (workspace is about to be destroyed anyway)", async () => {
+    // afterTask (workspace reset) is not called during complete-and-quit because
+    // the workspace will be destroyed when the process exits — resetting first is wasteful.
     const afterTask = vi.fn().mockRejectedValue(new UserCancelledError());
     const s = new WorkerController(sb, display, undefined, undefined, "owner/repo", { wsFactory, afterTask });
     await s.start();
@@ -1944,8 +1976,9 @@ describe("stop — complete-and-quit", () => {
     await s.stop();
 
     const msgs = fakeWs.send.mock.calls.map(([d]: [string]) => JSON.parse(d));
-    expect(msgs.find((m: { type: string }) => m.type === "worker_goodbye")).toBeUndefined();
-    expect(s.isActive).toBe(true);
+    expect(msgs.find((m: { type: string }) => m.type === "worker_goodbye")).toBeDefined();
+    expect(s.isActive).toBe(false);
+    expect(afterTask).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

- The workspace reset (afterTask hook) now runs **after** the post-task picker, not before it, so the picker appears immediately with no delay.
- The **Exit** option in the picker skips the reset entirely — the workspace gets destroyed on exit anyway, so resetting first was wasted work.
- The **complete-and-quit** flow (quitting with a task in progress) also skips the reset for the same reason.
- The **claim** path (`/worker:claim` while a task is assigned) preserves the original eager-reset behavior so `UserCancelledError` from unsafe changes can still abort the completion before a new task is claimed.

## Test plan

- [ ] All existing tests pass (1758 tests, `npm test`)
- [ ] New tests cover: Exit skips afterTask, `UserCancelledError` handling split between ready vs claim paths, complete-and-quit skips afterTask
- [ ] TypeScript type check passes (`npx tsc --noEmit`)

Closes #1011

🤖 Generated with [Claude Code](https://claude.com/claude-code)