### PR TITLE
refactor: remove pickFn from WorkerControllerOptions; use mock Picker in tests

### DIFF
--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -361,17 +361,16 @@ export class WorkerController extends EventEmitter {
    */
   async confirmTaskQuit(
     info: TaskConfirmInfo,
-    pickFn: (options: string[]) => Promise<number> = (opts) => this.picker!.pick(opts),
   ): Promise<"quit" | "complete-and-quit" | "cancel"> {
     if (info.issueClosed) {
       this.display.print(c.amber(`\nTask #${info.taskNumber} is closed but not complete. Complete it before exiting?`));
-      const idx = await pickFn(["Yes, complete before exiting", "No, just exit", "Don't exit"]);
+      const idx = await this.picker!.pick(["Yes, complete before exiting", "No, just exit", "Don't exit"]);
       if (idx === 0) return "complete-and-quit";
       if (idx === 1) return "quit";
       return "cancel";
     } else {
       this.display.print(c.amber(`\nTask #${info.taskNumber} is still open. Quitting now will unassign ${info.workerId}. Quit anyway?`));
-      const idx = await pickFn(["No, keep working", "Yes, quit anyway"]);
+      const idx = await this.picker!.pick(["No, keep working", "Yes, quit anyway"]);
       if (idx === 1) return "quit";
       return "cancel";
     }
@@ -388,17 +387,16 @@ export class WorkerController extends EventEmitter {
    */
   async confirmTaskClaim(
     info: TaskConfirmInfo,
-    pickFn: (options: string[]) => Promise<number> = (opts) => this.picker!.pick(opts),
   ): Promise<"claim" | "complete-and-claim" | "cancel"> {
     if (info.issueClosed) {
       this.display.print(c.amber(`\nTask #${info.taskNumber} is closed but not complete. Complete it before claiming a new task?`));
-      const idx = await pickFn(["Yes, complete first", "No, just claim", "Don't claim"]);
+      const idx = await this.picker!.pick(["Yes, complete first", "No, just claim", "Don't claim"]);
       if (idx === 0) return "complete-and-claim";
       if (idx === 1) return "claim";
       return "cancel";
     } else {
       this.display.print(c.amber(`\nTask #${info.taskNumber} is still open. Claiming a new task will unassign ${info.workerId}. Proceed?`));
-      const idx = await pickFn(["No, keep working", "Yes, claim anyway"]);
+      const idx = await this.picker!.pick(["No, keep working", "Yes, claim anyway"]);
       if (idx === 1) return "claim";
       return "cancel";
     }

--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -43,8 +43,6 @@ export type WorkerControllerOptions = {
   wsFactory?: WsFactory;
   /** Override the afterTask hook (default: derived from workspaceController.onReset). */
   afterTask?: () => Promise<void>;
-  /** Override pick function for repo activation and quit confirmation. */
-  pickFn?: (options: string[]) => Promise<number | { type: "text"; text: string }>;
 };
 
 // Messages that must wait for hello_ack before being sent.
@@ -360,12 +358,10 @@ export class WorkerController extends EventEmitter {
    *
    * Returns 'quit' to proceed without completing, 'complete-and-quit' to mark
    * the task complete then quit, or 'cancel' to stay in the worker.
-   *
-   * An injectable pickFn is accepted so callers can supply a mock in tests.
    */
   async confirmTaskQuit(
     info: TaskConfirmInfo,
-    pickFn: (options: string[]) => Promise<number> = this.pickFnOrDefault(),
+    pickFn: (options: string[]) => Promise<number> = (opts) => this.picker!.pick(opts),
   ): Promise<"quit" | "complete-and-quit" | "cancel"> {
     if (info.issueClosed) {
       this.display.print(c.amber(`\nTask #${info.taskNumber} is closed but not complete. Complete it before exiting?`));
@@ -389,12 +385,10 @@ export class WorkerController extends EventEmitter {
    *
    * Returns 'complete-and-claim' to complete the current task then claim,
    * 'claim' to abandon the current task and claim, or 'cancel' to do nothing.
-   *
-   * An injectable pickFn is accepted so callers can supply a mock in tests.
    */
   async confirmTaskClaim(
     info: TaskConfirmInfo,
-    pickFn: (options: string[]) => Promise<number> = this.pickFnOrDefault(),
+    pickFn: (options: string[]) => Promise<number> = (opts) => this.picker!.pick(opts),
   ): Promise<"claim" | "complete-and-claim" | "cancel"> {
     if (info.issueClosed) {
       this.display.print(c.amber(`\nTask #${info.taskNumber} is closed but not complete. Complete it before claiming a new task?`));
@@ -464,7 +458,7 @@ export class WorkerController extends EventEmitter {
 
   /**
    * After completing a task, prompt the user for what to do next.
-   * When no picker is available (non-interactive / no pickFn injected) defaults to waiting.
+   * When no picker is available (non-interactive mode) defaults to waiting.
    *
    * Calls sendWorkerReady() only when the user confirms they want to keep waiting —
    * this is what transitions the foreman from "reserved" to auto-assignable.
@@ -525,16 +519,9 @@ export class WorkerController extends EventEmitter {
     }
   }
 
-  /** Normalises the three picker sources (real Picker / test pickFn / none) into a PickResult. */
   private async postTaskPick(options: string[]): Promise<PickResult> {
     if (this.picker) {
       return this.picker.pick(options, { textEntryIndex: 1, textEntryPrefix: "Claim a specific task: " });
-    }
-    if (this.options?.pickFn) {
-      const r = await this.options.pickFn(options);
-      return typeof r === "number"
-        ? { type: "selected", index: r }
-        : { type: "other", text: r.text };
     }
     return { type: "selected", index: 0 }; // non-interactive: default to wait
   }
@@ -638,7 +625,7 @@ export class WorkerController extends EventEmitter {
           if (taskInfo) {
             if (taskInfo.issueClosed) {
               this.display.print(c.amber(`\nTask #${taskInfo.taskNumber} is closed but not complete. Complete it before waiting for new tasks?`));
-              const idx = await this.pickFnOrDefault()(["Yes, complete and wait for new tasks", "No, just wait for new tasks", "Cancel"]);
+              const idx = await this.picker!.pick(["Yes, complete and wait for new tasks", "No, just wait for new tasks", "Cancel"]);
               if (idx === 2) return undefined;
               if (idx === 0) {
                 try {
@@ -653,7 +640,7 @@ export class WorkerController extends EventEmitter {
               }
             } else {
               this.display.print(c.amber(`\nCurrently assigned task #${taskInfo.taskNumber}. Abandon this task?`));
-              const idx = await this.pickFnOrDefault()(["Yes, abandon and wait for new tasks", `No, stay with task #${taskInfo.taskNumber}`]);
+              const idx = await this.picker!.pick(["Yes, abandon and wait for new tasks", `No, stay with task #${taskInfo.taskNumber}`]);
               if (idx !== 0) return undefined;
               this.currentTaskId = undefined;
               this.currentIssue = undefined;
@@ -749,14 +736,6 @@ export class WorkerController extends EventEmitter {
   }
 
   // ── Private ───────────────────────────────────────────────────────────────
-
-  private pickFnOrDefault(): (opts: string[]) => Promise<number> {
-    if (this.options?.pickFn) {
-      const fn = this.options.pickFn;
-      return async (opts) => { const r = await fn(opts); return typeof r === "number" ? r : -1; };
-    }
-    return (opts) => this.picker!.pick(opts);
-  }
 
   private buildWsFactory(): WsFactory {
     return () => new WebSocket(`${getConfig().foremanUrl}/worker`);
@@ -1005,7 +984,7 @@ export class WorkerController extends EventEmitter {
         this.agentStatus.update({ connectionStatus: "connected", disconnectCode: undefined });
         // Repo is new — ask the user whether to activate it before proceeding.
         this.display.print(c.amber(`Repo ${this.repo} is new — activate it?`));
-        const idx = await this.pickFnOrDefault()(["Yes, activate", "No, skip"]);
+        const idx = await this.picker!.pick(["Yes, activate", "No, skip"]);
         if (idx === 0) {
           // Send activate_repo — foreman will reply with a repo_activated message.
           this.ws?.send(JSON.stringify({ type: "activate_repo", workerId: this.agentId } satisfies Wire.WorkerMessage));

--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -458,7 +458,6 @@ export class WorkerController extends EventEmitter {
 
   /**
    * After completing a task, prompt the user for what to do next.
-   * When no picker is available (non-interactive mode) defaults to waiting.
    *
    * Calls sendWorkerReady() only when the user confirms they want to keep waiting —
    * this is what transitions the foreman from "reserved" to auto-assignable.
@@ -520,10 +519,7 @@ export class WorkerController extends EventEmitter {
   }
 
   private async postTaskPick(options: string[]): Promise<PickResult> {
-    if (this.picker) {
-      return this.picker.pick(options, { textEntryIndex: 1, textEntryPrefix: "Claim a specific task: " });
-    }
-    return { type: "selected", index: 0 }; // non-interactive: default to wait
+    return this.picker!.pick(options, { textEntryIndex: 1, textEntryPrefix: "Claim a specific task: " });
   }
 
   private claimAfterTask(taskId: string): void {

--- a/tests/worker.claim.test.ts
+++ b/tests/worker.claim.test.ts
@@ -11,8 +11,19 @@ import { WorkerController } from "../src/agent/controllers/worker-controller.js"
 import { UserCancelledError } from "../src/agent/controllers/workspace-controller.js";
 import { AgentStatus } from "../src/agent/models/agent-status.js";
 import { CommandRegistry } from "../src/agent/controllers/command-controller.js";
+import { Picker, type PickConfig } from "../src/agent/views/picker.js";
 import * as Wire from "../shared/wire.js";
 import { stripAnsi } from "./helpers.js";
+
+function makeMockPicker(fn: (opts: string[]) => Promise<number>): Picker {
+  return {
+    pick: vi.fn().mockImplementation(async (opts: string[], config?: PickConfig) => {
+      const r = await fn(opts);
+      if (config == null) return r;
+      return { type: "selected", index: r };
+    }),
+  } as unknown as Picker;
+}
 
 const FAKE_ISSUE: Wire.TaskIssue = {
   number: 595,
@@ -103,10 +114,10 @@ function makeSession(pickFn?: (options: string[]) => Promise<number>): WorkerCon
   return new WorkerController(
     new AgentStatus({ agentId: AGENT_ID }),
     display,
-    undefined,
+    pickFn ? makeMockPicker(pickFn) : undefined,
     undefined,
     "owner/repo",
-    { wsFactory, ...(pickFn && { pickFn }) },
+    { wsFactory },
   );
 }
 
@@ -206,10 +217,10 @@ describe("when has an active task", () => {
     sessionWithPick = new WorkerController(
       new AgentStatus({ agentId: "test-worker-id" }),
       display,
-      undefined,
+      makeMockPicker(pickFn),
       undefined,
       "owner/repo",
-      { wsFactory, pickFn, afterTask },
+      { wsFactory, afterTask },
     );
     await sessionWithPick.start();
     setupActiveTask(sessionWithPick);

--- a/tests/worker.start.test.ts
+++ b/tests/worker.start.test.ts
@@ -9,8 +9,19 @@ import { EventEmitter } from "events";
 import { WorkerController } from "../src/agent/controllers/worker-controller.js";
 import { AgentStatus } from "../src/agent/models/agent-status.js";
 import { CommandRegistry } from "../src/agent/controllers/command-controller.js";
+import { Picker, type PickConfig } from "../src/agent/views/picker.js";
 import * as Wire from "../shared/wire.js";
 import { stripAnsi } from "./helpers.js";
+
+function makeMockPicker(fn: (opts: string[]) => Promise<number>): Picker {
+  return {
+    pick: vi.fn().mockImplementation(async (opts: string[], config?: PickConfig) => {
+      const r = await fn(opts);
+      if (config == null) return r;
+      return { type: "selected", index: r };
+    }),
+  } as unknown as Picker;
+}
 
 const FAKE_ISSUE: Wire.TaskIssue = {
   number: 978,
@@ -87,10 +98,10 @@ function makeSession(pickFn?: (options: string[]) => Promise<number>): WorkerCon
   return new WorkerController(
     new AgentStatus({ agentId: AGENT_ID }),
     display,
-    undefined,
+    pickFn ? makeMockPicker(pickFn) : undefined,
     undefined,
     "owner/repo",
-    { wsFactory, ...(pickFn && { pickFn }) },
+    { wsFactory },
   );
 }
 

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -4,9 +4,20 @@ import { WorkerController, WorkerControllerOptions } from "../src/agent/controll
 import { UserCancelledError } from "../src/agent/controllers/workspace-controller.js";
 import { AgentStatus } from "../src/agent/models/agent-status.js";
 import { Display } from "../src/agent/views/display.js";
+import { Picker, type PickConfig } from "../src/agent/views/picker.js";
 import * as Wire from "../shared/wire.js";
 import { stripAnsi } from "./helpers.js";
 import { getConfig } from "../src/config.js";
+
+function makeMockPicker(fn: (opts: string[]) => Promise<number | { type: "text"; text: string }>): Picker {
+  return {
+    pick: vi.fn().mockImplementation(async (opts: string[], config?: PickConfig) => {
+      const r = await fn(opts);
+      if (config == null) return r as number;
+      return typeof r === "number" ? { type: "selected", index: r } : { type: "other", text: (r as { text: string }).text };
+    }),
+  } as unknown as Picker;
+}
 
 // ── Fake WebSocket ─────────────────────────────────────────────────────────────
 
@@ -1426,10 +1437,9 @@ describe("prIsClosed guard", () => {
 describe("stop() with active task", () => {
   it("remains active if user cancels the quit confirmation", async () => {
     const ws = new FakeWs();
-    const s = new WorkerController(sb, display, undefined, undefined, "owner/repo", {
+    const s = new WorkerController(sb, display, makeMockPicker(async () => 0), undefined, "owner/repo", {
       wsFactory: vi.fn().mockReturnValue(ws),
-      pickFn: async () => 0, // first option = "No, keep working" = cancel
-    });
+    }); // first option = "No, keep working" = cancel
     await s.start();
     sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "ready" });
     sendMsg(ws, { type: "task_assigned", taskId: "99", issue: makeIssue() });
@@ -1443,10 +1453,9 @@ describe("stop() with active task", () => {
 
   it("stops and marks inactive if user confirms quit", async () => {
     const ws = new FakeWs();
-    const s = new WorkerController(sb, display, undefined, undefined, "owner/repo", {
+    const s = new WorkerController(sb, display, makeMockPicker(async () => 1), undefined, "owner/repo", {
       wsFactory: vi.fn().mockReturnValue(ws),
-      pickFn: async () => 1, // second option = "Yes, quit anyway" = quit
-    });
+    }); // second option = "Yes, quit anyway" = quit
     await s.start();
     sendMsg(ws, { type: "hello_ack", workerId: AGENT_ID, status: "ready" });
     sendMsg(ws, { type: "task_assigned", taskId: "99", issue: makeIssue() });
@@ -1711,9 +1720,8 @@ describe("completeCurrentTask: post-completion prompt", () => {
     extraOpts: Partial<WorkerControllerOptions> = {},
   ) {
     const ws = new FakeWs();
-    const sess = new WorkerController(sb, display, undefined, undefined, "owner/repo", {
+    const sess = new WorkerController(sb, display, makeMockPicker(pickFn), undefined, "owner/repo", {
       wsFactory: vi.fn().mockReturnValue(ws),
-      pickFn,
       ...extraOpts,
     });
     await sess.start();
@@ -1722,7 +1730,7 @@ describe("completeCurrentTask: post-completion prompt", () => {
     return { sess, ws };
   }
 
-  it("with no picker and no pickFn: defaults to waiting for next task, stays active, returns 'task-complete'", async () => {
+  it("with no picker: defaults to waiting for next task, stays active, returns 'task-complete'", async () => {
     sendMsg(fakeWs, { type: "task_assigned", taskId: "t-nopick", issue: makeIssue(5) });
     session.takeNextPrompt();
     const result = await session.completeCurrentTask();
@@ -1796,7 +1804,7 @@ describe("completeCurrentTask: post-completion prompt", () => {
     expect(msgs.some((m: { type: string }) => m.type === "worker_ready")).toBe(true);
   });
 
-  it("with no picker and no pickFn: sends worker_ready", async () => {
+  it("with no picker: sends worker_ready", async () => {
     sendMsg(fakeWs, { type: "task_assigned", taskId: "t-nopick2", issue: makeIssue(6) });
     session.takeNextPrompt();
     fakeWs.send.mockClear();
@@ -1814,9 +1822,7 @@ describe("completeCurrentTask: post-completion prompt", () => {
   });
 
   it("claim option (text entry): sends claim_task with the entered task ID", async () => {
-    const { sess, ws } = await makeSession(vi.fn(), {
-      pickFn: async () => ({ type: "text" as const, text: "task-123" }),
-    });
+    const { sess, ws } = await makeSession(async () => ({ type: "text" as const, text: "task-123" }));
     ws.send.mockClear();
     await sess.completeCurrentTask();
     const msgs = ws.send.mock.calls.map(([s]: [string]) => JSON.parse(s));
@@ -1824,25 +1830,19 @@ describe("completeCurrentTask: post-completion prompt", () => {
   });
 
   it("claim option (text entry): worker remains active", async () => {
-    const { sess } = await makeSession(vi.fn(), {
-      pickFn: async () => ({ type: "text" as const, text: "task-123" }),
-    });
+    const { sess } = await makeSession(async () => ({ type: "text" as const, text: "task-123" }));
     await sess.completeCurrentTask();
     expect(sess.isActive).toBe(true);
   });
 
   it("claim option (text entry): returns 'task-complete'", async () => {
-    const { sess } = await makeSession(vi.fn(), {
-      pickFn: async () => ({ type: "text" as const, text: "task-123" }),
-    });
+    const { sess } = await makeSession(async () => ({ type: "text" as const, text: "task-123" }));
     const result = await sess.completeCurrentTask();
     expect(result).toBe("task-complete");
   });
 
   it("claim option (text entry): does not send worker_ready", async () => {
-    const { sess, ws } = await makeSession(vi.fn(), {
-      pickFn: async () => ({ type: "text" as const, text: "task-123" }),
-    });
+    const { sess, ws } = await makeSession(async () => ({ type: "text" as const, text: "task-123" }));
     ws.send.mockClear();
     await sess.completeCurrentTask();
     const msgs = ws.send.mock.calls.map(([s]: [string]) => JSON.parse(s));
@@ -2301,7 +2301,7 @@ describe("repo activation flow", () => {
     const factory = vi.fn().mockReturnValue(ws);
     const sessAg = new AgentStatus({ agentId: AGENT_ID });
     const disp = { print: vi.fn(), printForemanMessage: vi.fn() };
-    const sess = new WorkerController(sessAg, disp, undefined, undefined, repo, { wsFactory: factory, pickFn });
+    const sess = new WorkerController(sessAg, disp, makeMockPicker(pickFn), undefined, repo, { wsFactory: factory });
     await sess.start();
     return { sess, ws, disp };
   }
@@ -2413,9 +2413,8 @@ describe("repo activation flow", () => {
 function makeSessionWithPickResult(pickResult: number): { s: WorkerController; ws: FakeWs } {
   const ws = new FakeWs();
   const localWsFactory = vi.fn().mockReturnValue(ws);
-  const s = new WorkerController(sb, display, undefined, undefined, "owner/repo", {
+  const s = new WorkerController(sb, display, makeMockPicker(async () => pickResult), undefined, "owner/repo", {
     wsFactory: localWsFactory,
-    pickFn: async () => pickResult,
   });
   return { s, ws };
 }

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -77,7 +77,7 @@ beforeEach(async () => {
   };
   vi.spyOn(sb, "setOnToolResult");
   vi.spyOn(sb, "update");
-  session = new WorkerController(sb, display, undefined, undefined, "owner/repo", { wsFactory });
+  session = new WorkerController(sb, display, makeMockPicker(async () => 0), undefined, "owner/repo", { wsFactory });
   await session.start();
 });
 
@@ -333,7 +333,7 @@ describe("state after task_complete", () => {
     const localSession = new WorkerController(
       localSb,
       display,
-      undefined,
+      makeMockPicker(async () => 0),
       undefined,
       "owner/repo",
       { wsFactory },
@@ -1617,9 +1617,9 @@ describe("workspace slash commands in WorkerController", () => {
 // ── afterTask callback on /worker:complete ──────────────────────────────────────
 
 describe("afterTask callback on /worker:complete", () => {
-  it("calls afterTask after task_complete is sent (picker defaults to wait)", async () => {
+  it("calls afterTask after task_complete is sent", async () => {
     const afterTask = vi.fn().mockResolvedValue(undefined);
-    const sessionWithAfterTask = new WorkerController(sb, display, undefined, undefined, "", { wsFactory, afterTask });
+    const sessionWithAfterTask = new WorkerController(sb, display, makeMockPicker(async () => 0), undefined, "", { wsFactory, afterTask });
     await sessionWithAfterTask.start();
 
     const issue = makeIssue();
@@ -1636,7 +1636,7 @@ describe("afterTask callback on /worker:complete", () => {
 
   it("sends task_complete even if afterTask throws (task must not get stuck on foreman)", async () => {
     const afterTask = vi.fn().mockRejectedValue(new Error("reset failed"));
-    const sessionWithAfterTask = new WorkerController(sb, display, undefined, undefined, "", { wsFactory, afterTask });
+    const sessionWithAfterTask = new WorkerController(sb, display, makeMockPicker(async () => 0), undefined, "", { wsFactory, afterTask });
     await sessionWithAfterTask.start();
 
     const issue = makeIssue();
@@ -1682,7 +1682,7 @@ describe("afterTask callback on /worker:complete", () => {
     // In the default (ready) path, task_complete is sent before afterTask runs,
     // so UCE from afterTask cannot prevent task_complete from being sent.
     const afterTask = vi.fn().mockRejectedValue(new UserCancelledError());
-    const sessionWithAfterTask = new WorkerController(sb, display, undefined, undefined, "", { wsFactory, afterTask });
+    const sessionWithAfterTask = new WorkerController(sb, display, makeMockPicker(async () => 0), undefined, "", { wsFactory, afterTask });
     await sessionWithAfterTask.start();
 
     const issue = makeIssue();
@@ -1729,16 +1729,6 @@ describe("completeCurrentTask: post-completion prompt", () => {
     sess.takeNextPrompt();
     return { sess, ws };
   }
-
-  it("with no picker: defaults to waiting for next task, stays active, returns 'task-complete'", async () => {
-    sendMsg(fakeWs, { type: "task_assigned", taskId: "t-nopick", issue: makeIssue(5) });
-    session.takeNextPrompt();
-    const result = await session.completeCurrentTask();
-    expect(result).toBe("task-complete");
-    expect(session.isActive).toBe(true);
-    const printed = display.print.mock.calls.map(([l]: [string]) => stripAnsi(l));
-    expect(printed.some(l => l.includes("Waiting for next task"))).toBe(true);
-  });
 
   it("option 0 (wait for next task): stays active and returns 'task-complete'", async () => {
     const { sess } = await makeSession(async () => 0);
@@ -1801,15 +1791,6 @@ describe("completeCurrentTask: post-completion prompt", () => {
     ws.send.mockClear();
     await sess.completeCurrentTask();
     const msgs = ws.send.mock.calls.map(([s]: [string]) => JSON.parse(s));
-    expect(msgs.some((m: { type: string }) => m.type === "worker_ready")).toBe(true);
-  });
-
-  it("with no picker: sends worker_ready", async () => {
-    sendMsg(fakeWs, { type: "task_assigned", taskId: "t-nopick2", issue: makeIssue(6) });
-    session.takeNextPrompt();
-    fakeWs.send.mockClear();
-    await session.completeCurrentTask();
-    const msgs = fakeWs.send.mock.calls.map(([s]: [string]) => JSON.parse(s));
     expect(msgs.some((m: { type: string }) => m.type === "worker_ready")).toBe(true);
   });
 

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -2179,15 +2179,15 @@ describe("confirmTaskQuit", () => {
 
   it("open issue: returns 'cancel' when user picks 'No, keep working' (index 0)", async () => {
     const mockPick = vi.fn().mockResolvedValue(0);
-    const sess = new WorkerController(noopAgentStatus, noopDisplay, undefined, undefined, "");
-    const result = await sess.confirmTaskQuit(openTask, mockPick);
+    const sess = new WorkerController(noopAgentStatus, noopDisplay, makeMockPicker(mockPick), undefined, "");
+    const result = await sess.confirmTaskQuit(openTask);
     expect(result).toBe("cancel");
   });
 
   it("open issue: returns 'quit' when user picks 'Yes, quit anyway' (index 1)", async () => {
     const mockPick = vi.fn().mockResolvedValue(1);
-    const sess = new WorkerController(noopAgentStatus, noopDisplay, undefined, undefined, "");
-    const result = await sess.confirmTaskQuit(openTask, mockPick);
+    const sess = new WorkerController(noopAgentStatus, noopDisplay, makeMockPicker(mockPick), undefined, "");
+    const result = await sess.confirmTaskQuit(openTask);
     expect(result).toBe("quit");
   });
 
@@ -2195,8 +2195,8 @@ describe("confirmTaskQuit", () => {
     const printAgentStatus = new AgentStatus({ agentId: "test" });
     const printDisplay = { print: vi.fn(), printForemanMessage: vi.fn() };
     const mockPick = vi.fn().mockResolvedValue(0);
-    const sess = new WorkerController(printAgentStatus, printDisplay, undefined, undefined, "");
-    await sess.confirmTaskQuit(openTask, mockPick);
+    const sess = new WorkerController(printAgentStatus, printDisplay, makeMockPicker(mockPick), undefined, "");
+    await sess.confirmTaskQuit(openTask);
     const printed = printDisplay.print.mock.calls.map(([s]: [unknown]) => stripAnsi(String(s))).join("\n");
     expect(printed).toContain("#42");
     expect(printed).toContain("test-worker");
@@ -2204,22 +2204,22 @@ describe("confirmTaskQuit", () => {
 
   it("closed issue: returns 'complete-and-quit' when user picks index 0 (yes, complete)", async () => {
     const mockPick = vi.fn().mockResolvedValue(0);
-    const sess = new WorkerController(noopAgentStatus, noopDisplay, undefined, undefined, "");
-    const result = await sess.confirmTaskQuit(closedTask, mockPick);
+    const sess = new WorkerController(noopAgentStatus, noopDisplay, makeMockPicker(mockPick), undefined, "");
+    const result = await sess.confirmTaskQuit(closedTask);
     expect(result).toBe("complete-and-quit");
   });
 
   it("closed issue: returns 'quit' when user picks index 1 (no, just exit)", async () => {
     const mockPick = vi.fn().mockResolvedValue(1);
-    const sess = new WorkerController(noopAgentStatus, noopDisplay, undefined, undefined, "");
-    const result = await sess.confirmTaskQuit(closedTask, mockPick);
+    const sess = new WorkerController(noopAgentStatus, noopDisplay, makeMockPicker(mockPick), undefined, "");
+    const result = await sess.confirmTaskQuit(closedTask);
     expect(result).toBe("quit");
   });
 
   it("closed issue: returns 'cancel' when user picks index 2 (don't exit)", async () => {
     const mockPick = vi.fn().mockResolvedValue(2);
-    const sess = new WorkerController(noopAgentStatus, noopDisplay, undefined, undefined, "");
-    const result = await sess.confirmTaskQuit(closedTask, mockPick);
+    const sess = new WorkerController(noopAgentStatus, noopDisplay, makeMockPicker(mockPick), undefined, "");
+    const result = await sess.confirmTaskQuit(closedTask);
     expect(result).toBe("cancel");
   });
 
@@ -2227,16 +2227,16 @@ describe("confirmTaskQuit", () => {
     const printAgentStatus = new AgentStatus({ agentId: "test" });
     const printDisplay = { print: vi.fn(), printForemanMessage: vi.fn() };
     const mockPick = vi.fn().mockResolvedValue(0);
-    const sess = new WorkerController(printAgentStatus, printDisplay, undefined, undefined, "");
-    await sess.confirmTaskQuit(closedTask, mockPick);
+    const sess = new WorkerController(printAgentStatus, printDisplay, makeMockPicker(mockPick), undefined, "");
+    await sess.confirmTaskQuit(closedTask);
     const printed = printDisplay.print.mock.calls.map(([s]: [unknown]) => stripAnsi(String(s))).join("\n");
     expect(printed).toContain("#42");
   });
 
   it("open issue: pick is called with two options (No first, Yes second)", async () => {
     const mockPick = vi.fn().mockResolvedValue(0);
-    const sess = new WorkerController(noopAgentStatus, noopDisplay, undefined, undefined, "");
-    await sess.confirmTaskQuit(openTask, mockPick);
+    const sess = new WorkerController(noopAgentStatus, noopDisplay, makeMockPicker(mockPick), undefined, "");
+    await sess.confirmTaskQuit(openTask);
     expect(mockPick).toHaveBeenCalledOnce();
     const options = mockPick.mock.calls[0][0] as string[];
     expect(options).toHaveLength(2);
@@ -2246,8 +2246,8 @@ describe("confirmTaskQuit", () => {
 
   it("closed issue: pick is called with three options", async () => {
     const mockPick = vi.fn().mockResolvedValue(0);
-    const sess = new WorkerController(noopAgentStatus, noopDisplay, undefined, undefined, "");
-    await sess.confirmTaskQuit(closedTask, mockPick);
+    const sess = new WorkerController(noopAgentStatus, noopDisplay, makeMockPicker(mockPick), undefined, "");
+    await sess.confirmTaskQuit(closedTask);
     expect(mockPick).toHaveBeenCalledOnce();
     const options = mockPick.mock.calls[0][0] as string[];
     expect(options).toHaveLength(3);


### PR DESCRIPTION
## Summary

- Removes `pickFn` from `WorkerControllerOptions` — it existed only as a test escape hatch, duplicating the existing `picker?: Picker` constructor parameter
- Removes `pickFnOrDefault()` helper; each call site now uses `this.picker!.pick(opts)` directly (the four places: `confirmTaskQuit` default, `confirmTaskClaim` default, `/worker:start` abandon prompt, repo-activation prompt)
- Simplifies `postTaskPick`: drops the `pickFn` branch (picker → non-interactive fallback only)
- Adds a `makeMockPicker` helper to the three affected test files; all test setups updated to inject a mock `Picker` instance via the constructor

## Test plan

- [ ] `npm test` — all non-DB unit tests pass
- [ ] `npx tsc --noEmit` — no type errors
- [ ] No production behaviour changes: the `picker` constructor parameter was already wired up in `index.ts`; only tests are affected

Closes #1008