### PR TITLE
feat: replay missed events on worker reconnect using webhook_events seqIds

### DIFF
--- a/shared/wire.ts
+++ b/shared/wire.ts
@@ -95,7 +95,7 @@ export interface TaskIssue {
 
 // Worker → Foreman messages
 export type WorkerMessage =
-  | { type: "worker_hello"; workerId: string; repo: string; taskId?: string; status: "ready" | "reserved" | "assigned"; workerSecret?: string }
+  | { type: "worker_hello"; workerId: string; repo: string; taskId?: string; status: "ready" | "reserved" | "assigned"; workerSecret?: string; lastSeenEventSeqId?: number }
   | { type: "task_complete"; workerId: string; taskId: string; nextState?: "ready" | "reserved"; stats?: { inputTokens: number; outputTokens: number; costUsd?: number } }
   | { type: "worker_goodbye"; workerId: string; taskId?: string; task_complete?: boolean; stats?: { inputTokens: number; outputTokens: number; costUsd?: number } }
   | { type: "activate_repo"; workerId: string }
@@ -106,7 +106,7 @@ export type WorkerMessage =
 // Foreman → Worker messages
 export type ForemanMessage =
   | { type: "task_assigned"; taskId: string; issue: TaskIssue }
-  | { type: "event_notification"; taskId: string; event: WebhookEvent }
+  | { type: "event_notification"; taskId: string; event: WebhookEvent; seqId?: number }
   | { type: "hello_ack"; workerId: string; status: "ready" | "reserved" | "assigned" | "cancelled"; repoStatus: "new" | "active" }
   | { type: "repo_activated"; workerId: string }
   | { type: "foreman_error"; message: string; fatal: boolean };

--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -131,6 +131,7 @@ export class WorkerController extends EventEmitter {
   private prIsClosed = false;
   private issueClosed = false;
   private _resetPromise: Promise<void> | null = null;
+  private lastSeenEventSeqId: number | undefined;
 
   // ── Pending claim (cleared by stop() and after sending) ───────────────────
   private _pendingClaimTaskId: string | undefined;
@@ -745,6 +746,7 @@ export class WorkerController extends EventEmitter {
     this._resetPromise = null;
     this._pendingClaimTaskId = undefined;
     this._isReserved = false;
+    this.lastSeenEventSeqId = undefined;
     this.ws = undefined;
     this.connectionState = "registered";
     this.bufferedMessages = [];
@@ -839,12 +841,14 @@ export class WorkerController extends EventEmitter {
       // transitionToRegistered() will send the claim_task message automatically.
       // Do NOT put _pendingClaimTaskId in the hello — it will be sent as claim_task.
       const hasPendingClaim = !!this._pendingClaimTaskId;
+      const isAssigned = !!this.currentTaskId;
       ws.send(JSON.stringify({
         type: "worker_hello",
         workerId: this.agentStatus.agentId,
         repo: this.repo,
         ...(this.currentTaskId !== undefined && { taskId: this.currentTaskId }),
-        status: this.currentTaskId ? "assigned" : (hasPendingClaim ? "reserved" : "ready"),
+        status: isAssigned ? "assigned" : (hasPendingClaim ? "reserved" : "ready"),
+        ...(isAssigned && this.lastSeenEventSeqId !== undefined && { lastSeenEventSeqId: this.lastSeenEventSeqId }),
       } satisfies Wire.WorkerMessage));
 
       this.connectionState = "hello_sent";
@@ -1012,6 +1016,7 @@ export class WorkerController extends EventEmitter {
       // Reset event state so the new task starts with a clean slate.
       this._eventsPaused = false;
       this.pendingEvents = [];
+      this.lastSeenEventSeqId = undefined;
       if (this.debounceTimer) { clearTimeout(this.debounceTimer); this.debounceTimer = null; }
       this.agentStatus.update({ taskNumber: msg.issue.number, prNumber: msg.issue.prNumber ?? undefined, workerReady: false });
       this.agentStatus.resetTaskStats();
@@ -1032,6 +1037,13 @@ export class WorkerController extends EventEmitter {
         // Ignore stale events forwarded for tasks we're no longer working on.
         this.display.print(c.darkGray(`[worker] ignoring event_notification for task ${msg.taskId} (current: ${this.currentTaskId ?? "none"})`));
         return;
+      }
+
+      // Track the highest sequence id seen so far; included in worker_hello on reconnect.
+      if (msg.seqId !== undefined) {
+        if (this.lastSeenEventSeqId === undefined || msg.seqId > this.lastSeenEventSeqId) {
+          this.lastSeenEventSeqId = msg.seqId;
+        }
       }
 
       const { event } = msg;

--- a/src/foreman/controllers/wss.ts
+++ b/src/foreman/controllers/wss.ts
@@ -30,11 +30,13 @@ function numProp(obj: unknown, key: string): number | null {
   return typeof val === "number" ? val : null;
 }
 
-export interface RouteResult { taskId: string | null; workerId: string | null; }
-
-function routeResult(task: { taskId: string; workerId: string | null } | null | undefined): RouteResult {
-  return { taskId: task?.taskId ?? null, workerId: task?.workerId ?? null };
-}
+/**
+ * The task and human-readable ref returned by per-event-type routing functions.
+ * `forward` controls whether the event should be forwarded to the worker
+ * (defaults to true when task is non-null). Set to false to log the task_id
+ * without notifying the worker (e.g. pull_request/synchronize).
+ */
+export interface RouteResult { task: Task | null; ref: string; forward?: boolean; }
 
 // ── ForemanWss class ──────────────────────────────────────────────────────────
 
@@ -180,27 +182,32 @@ export class ForemanWss {
       repoId = (await Repo.findOrCreate(repoFullName)).id;
     }
 
-    let taskId: string | null = null;
-    let workerId: string | null = null;
-
+    // Step 1: determine task (side effects, DB lookups) — no forwarding yet.
+    let task: Task | null = null;
+    let ref = "";
+    let forward = true;
     if (name === "pull_request") {
-      ({ taskId, workerId } = await this.routePrEvent(p, evt));
+      ({ task, ref, forward = true } = await this.routePrEvent(p, evt));
     } else if (name === "pull_request_review" || name === "pull_request_review_comment") {
-      ({ taskId, workerId } = await this.routePrReviewEvent(p, evt));
+      ({ task, ref } = await this.routePrReviewEvent(p, evt));
     } else if (name === "check_run" || name === "check_suite") {
-      ({ taskId, workerId } = await this.routeCheckEvent(p, evt, name));
+      ({ task, ref } = await this.routeCheckEvent(p, evt, name));
     } else {
       const issue = p.issue as R | undefined;
       const issueNumber = numProp(issue, "number");
       if (issueNumber !== null) {
-        ({ taskId, workerId } = await this.routeIssueEvent(p, evt, issue!, issueNumber));
+        ({ task, ref } = await this.routeIssueEvent(p, evt, issue!, issueNumber));
       }
     }
 
+    const taskId = task?.taskId ?? null;
+    const workerId = task?.workerId ?? null;
     const action = typeof p.action === "string" ? p.action : null;
     const webhookIssueNumber = typeof (p.issue as R | undefined)?.number === "number" ? (p.issue as R).number as number : null;
     const webhookPrNumber = typeof (p.pull_request as R | undefined)?.number === "number" ? (p.pull_request as R).number as number : null;
-    void WebhookEvent.log({
+
+    // Step 2: log to DB and obtain the durable sequence id.
+    const seqId = await WebhookEvent.log({
       deliveryId: id,
       eventName: name,
       action,
@@ -213,6 +220,10 @@ export class ForemanWss {
       workerId,
       payload: p,
     });
+
+    // Step 3: forward to the worker with the sequence id (unless explicitly suppressed).
+    if (task && forward) this.forwardEvent(task, evt, ref, seqId ?? undefined);
+
     this.adminWss?.broadcastLogEvent({
       kind: "webhook",
       id: this.nextBroadcastId++,
@@ -289,9 +300,10 @@ export class ForemanWss {
 
   private flushQueuedEvents(worker: Worker, task: Task): void {
     for (const evt of task.drainEvents()) {
+      const seqId = evt.id ?? undefined;
       const sent = this.sendMsg(
         worker,
-        { type: "event_notification", taskId: task.taskId, event: evt.toWorkerPayload() },
+        { type: "event_notification", taskId: task.taskId, event: evt.toWorkerPayload(), ...(seqId !== undefined && { seqId }) },
         { onError: (err) => {
           task.queueEvent(evt);
           this.workerLog(worker.workerId, `✗ event_notification send error — requeued #${task.issueNumber} ${evt.eventName}: ${fmtError(err)}`);
@@ -310,7 +322,25 @@ export class ForemanWss {
     this.sendMsg(worker, { type: "hello_ack", workerId: worker.workerId, status: "cancelled", repoStatus: worker.repo.status }, { logTaskId: task?.taskId });
   }
 
-  private async reclaimWorker(worker: Worker, task: Task): Promise<void> {
+  private async replayMissedEvents(worker: Worker, task: Task, lastSeenEventSeqId: number): Promise<void> {
+    let missed: import("../models/webhook-event.js").WebhookEvent[];
+    try {
+      missed = await WebhookEvent.queryMissedFor(task.taskId, lastSeenEventSeqId);
+    } catch (err) {
+      this.workerLog(worker.workerId, `ERROR querying missed events for #${task.issueNumber}: ${fmtError(err)}`);
+      return;
+    }
+    for (const evt of missed) {
+      const seqId = evt.id ?? undefined;
+      this.sendMsg(
+        worker,
+        { type: "event_notification", taskId: task.taskId, event: evt.toWorkerPayload(), ...(seqId !== undefined && { seqId }) },
+      );
+      this.workerLog(worker.workerId, `→ event_notification #${task.issueNumber} ${evt.eventName} (replay seqId=${seqId})`);
+    }
+  }
+
+  private async reclaimWorker(worker: Worker, task: Task, lastSeenEventSeqId?: number): Promise<void> {
     worker.assign(task);
     // Only call assign if task is not already complete (to preserve task status)
     if (task.status !== "complete") {
@@ -319,6 +349,11 @@ export class ForemanWss {
     // For complete tasks, the task stays complete while worker finishes cleanup/finalization work
     this.sendMsg(worker, { type: "hello_ack", workerId: worker.workerId, status: "assigned", repoStatus: worker.repo.status }, { logTaskId: task.taskId });
     this.flushQueuedEvents(worker, task);
+    // DB replay: send any events the worker missed while disconnected (covers zombie window
+    // and foreman restart scenarios). Runs after the in-memory flush; duplicates are acceptable.
+    if (lastSeenEventSeqId !== undefined) {
+      await this.replayMissedEvents(worker, task, lastSeenEventSeqId);
+    }
   }
 
   async handleWorkerHello(workerId: string, ws: WebSocket, msg: Extract<Wire.WorkerMessage, { type: "worker_hello" }>): Promise<void> {
@@ -343,7 +378,7 @@ export class ForemanWss {
     }
 
     if (msg.status === "assigned" && msg.taskId) {
-      await this.handleAssignedHello(workerId, msg.taskId, ws, repo);
+      await this.handleAssignedHello(workerId, msg.taskId, ws, repo, msg.lastSeenEventSeqId);
     } else if (msg.status === "reserved") {
       await this.handleReservedHello(workerId, ws, repo);
     } else {
@@ -407,7 +442,7 @@ export class ForemanWss {
    * 6. Live task, different worker → cancel
    * 7. Otherwise (live task, same or no worker) → reclaim
    */
-  async handleAssignedHello(workerId: string, claimedTaskId: string, ws: WebSocket, repo: Repo): Promise<void> {
+  async handleAssignedHello(workerId: string, claimedTaskId: string, ws: WebSocket, repo: Repo, lastSeenEventSeqId?: number): Promise<void> {
     try {
       const existing = await Task.get(claimedTaskId);
       const worker = Worker.register(workerId, ws, repo);
@@ -420,7 +455,7 @@ export class ForemanWss {
           placeholderTask = await Task.upsert(claimedTaskId, issueNumber, "", "", "", []);
         }
         if (placeholderTask) {
-          await this.reclaimWorker(worker, placeholderTask);
+          await this.reclaimWorker(worker, placeholderTask, lastSeenEventSeqId);
         } else {
           this.cancelWorker(worker, null);
         }
@@ -433,14 +468,14 @@ export class ForemanWss {
           this.cancelWorker(worker, existing);
         } else {
           this.workerLog(workerId, `hello busy task=#${claimedTaskId} — task already complete, reclaiming for finalization`);
-          await this.reclaimWorker(worker, existing);
+          await this.reclaimWorker(worker, existing, lastSeenEventSeqId);
         }
       } else if (existing.workerId && existing.workerId !== workerId) {
         this.workerLog(workerId, `hello busy task=#${claimedTaskId} — task taken by another worker`);
         this.cancelWorker(worker, existing);
       } else {
         this.workerLog(workerId, `hello busy task=#${claimedTaskId} — reclaimed`);
-        await this.reclaimWorker(worker, existing);
+        await this.reclaimWorker(worker, existing, lastSeenEventSeqId);
       }
     } catch (err) {
       log(`ERROR handleAssignedHello ${workerId}: ${fmtError(err)}`);
@@ -576,7 +611,7 @@ export class ForemanWss {
 
   // ── Routing ─────────────────────────────────────────────────────────────────
 
-  forwardEvent(task: Task, evt: WebhookEvent, ref: string): void {
+  forwardEvent(task: Task, evt: WebhookEvent, ref: string, seqId?: number): void {
     if (task.workerId) {
       const worker = Worker.fromRegistry(task.workerId);
       if (worker && worker.currentTask?.taskId !== task.taskId) {
@@ -589,7 +624,7 @@ export class ForemanWss {
       } else if (worker) {
         const sent = this.sendMsg(
           worker,
-          { type: "event_notification", taskId: task.taskId, event: evt.toWorkerPayload() },
+          { type: "event_notification", taskId: task.taskId, event: evt.toWorkerPayload(), ...(seqId !== undefined && { seqId }) },
           { onError: (err) => {
             task.queueEvent(evt);
             log(`[task ${ref}] ${evt.eventName} requeued (send error: ${fmtError(err)})`);
@@ -633,7 +668,8 @@ export class ForemanWss {
       });
       log(`[worker ${shortWorkerId(worker.workerId)}] → task_assigned #${task.issueNumber} "${task.title}"`);
       for (const evt of queued) {
-        this.sendMsg(worker, { type: "event_notification", taskId: task.taskId, event: evt.toWorkerPayload() });
+        const seqId = evt.id ?? undefined;
+        this.sendMsg(worker, { type: "event_notification", taskId: task.taskId, event: evt.toWorkerPayload(), ...(seqId !== undefined && { seqId }) });
         log(`[worker ${shortWorkerId(worker.workerId)}] → event_notification #${task.issueNumber} ${evt.eventName} (queued)`);
       }
     }
@@ -649,23 +685,20 @@ export class ForemanWss {
   async routePrEvent(p: R, evt: WebhookEvent): Promise<RouteResult> {
     const pr = p.pull_request as R | undefined;
     const prNumber = numProp(pr, "number");
-    if (prNumber === null) return routeResult(null);
+    if (prNumber === null) return { task: null, ref: "" };
 
     const repo = await this.resolveRepo(p);
     const manager = repo.taskManager;
+    const ref = `PR #${prNumber}`;
 
-    if (p.action === "synchronize") return routeResult(await repo.getTaskByPr(prNumber));
+    if (p.action === "synchronize") return { task: await repo.getTaskByPr(prNumber), ref, forward: false };
 
     if (p.action === "opened" && pr) {
-      const task = await manager.handlePrOpenedEvent(prNumber, String(pr.body ?? ""), strProp(pr.head, "ref"));
-      if (task) this.forwardEvent(task, evt, `PR #${prNumber}`);
-      return routeResult(task);
+      return { task: await manager.handlePrOpenedEvent(prNumber, String(pr.body ?? ""), strProp(pr.head, "ref")), ref };
     }
 
     if (p.action === "closed" && pr) {
-      const task = await manager.handlePrClosedEvent(prNumber, !!pr.merged);
-      if (task) this.forwardEvent(task, evt, `PR #${prNumber}`);
-      return routeResult(task);
+      return { task: await manager.handlePrClosedEvent(prNumber, !!pr.merged), ref };
     }
 
     if (p.action === "edited" && pr) {
@@ -675,23 +708,18 @@ export class ForemanWss {
         task = await manager.handlePrEditedEvent(prNumber, String(pr.body ?? ""), strProp(pr.head, "ref"));
       }
       if (!task) task = await repo.getTaskByPr(prNumber);
-      if (task) this.forwardEvent(task, evt, `PR #${prNumber}`);
-      return routeResult(task);
+      return { task, ref };
     }
 
-    const task = await repo.getTaskByPr(prNumber);
-    if (task) this.forwardEvent(task, evt, `PR #${prNumber}`);
-    return routeResult(task);
+    return { task: await repo.getTaskByPr(prNumber), ref };
   }
 
   async routePrReviewEvent(p: R, evt: WebhookEvent): Promise<RouteResult> {
     const pr = p.pull_request as R | undefined;
     const prNumber = numProp(pr, "number");
-    if (prNumber === null) return routeResult(null);
+    if (prNumber === null) return { task: null, ref: "" };
     const repo = await this.resolveRepo(p);
-    const task = await repo.getTaskByPr(prNumber);
-    if (task) this.forwardEvent(task, evt, `PR #${prNumber}`);
-    return routeResult(task);
+    return { task: await repo.getTaskByPr(prNumber), ref: `PR #${prNumber}` };
   }
 
   async routeCheckEvent(p: R, evt: WebhookEvent, name: string): Promise<RouteResult> {
@@ -706,8 +734,8 @@ export class ForemanWss {
       prs?.map((pr) => pr.number) ?? [],
       headBranch,
     );
-    if (found) { this.forwardEvent(found.task, evt, found.ref); return routeResult(found.task); }
-    return routeResult(null);
+    if (found) return { task: found.task, ref: found.ref };
+    return { task: null, ref: "" };
   }
 
   /**
@@ -816,9 +844,7 @@ export class ForemanWss {
   }
 
   async routeIssueEvent(p: R, evt: WebhookEvent, issue: R, issueNumber: number): Promise<RouteResult> {
-    const task = await this.applyIssueEffects(p, issue, issueNumber);
-    if (task) this.forwardEvent(task, evt, `#${issueNumber}`);
-    return routeResult(task);
+    return { task: await this.applyIssueEffects(p, issue, issueNumber), ref: `#${issueNumber}` };
   }
 
 }

--- a/src/foreman/models/webhook-event.ts
+++ b/src/foreman/models/webhook-event.ts
@@ -74,8 +74,11 @@ export class WebhookEvent extends ActiveRecord {
 
   // ── Persistence ─────────────────────────────────────────────────────────────
 
-  /** Insert into webhook_events. Returns a promise (usually ignored with `void`). */
-  static log(data: {
+  /**
+   * Insert into webhook_events. Returns the DB-assigned id on success, or null
+   * on error. Callers that only need fire-and-forget behavior can `void` the result.
+   */
+  static async log(data: {
     deliveryId: string | null;
     eventName: string;
     action: string | null;
@@ -87,20 +90,36 @@ export class WebhookEvent extends ActiveRecord {
     taskId: string | null;
     workerId: string | null;
     payload: Record<string, unknown>;
-  }): Promise<void> {
-    return WebhookEvent.insert({
-      delivery_id: data.deliveryId,
-      event_name: data.eventName,
-      action: data.action,
-      repo_id: data.repoId,
-      sender: data.sender,
-      issue_number: data.issueNumber,
-      pr_number: data.prNumber,
-      branch: data.branch,
-      task_id: data.taskId,
-      worker_id: data.workerId,
-      payload: data.payload as Json,
-    }).then(() => undefined).catch((err: unknown) => log(`[db] webhook_events insert error: ${fmtError(err)}`));
+  }): Promise<number | null> {
+    try {
+      const row = await WebhookEvent.insert({
+        delivery_id: data.deliveryId,
+        event_name: data.eventName,
+        action: data.action,
+        repo_id: data.repoId,
+        sender: data.sender,
+        issue_number: data.issueNumber,
+        pr_number: data.prNumber,
+        branch: data.branch,
+        task_id: data.taskId,
+        worker_id: data.workerId,
+        payload: data.payload as Json,
+      });
+      return (row as WebhookEvent).id ?? null;
+    } catch (err: unknown) {
+      log(`[db] webhook_events insert error: ${fmtError(err)}`);
+      return null;
+    }
+  }
+
+  /** Query events for a task that arrived after the given sequence id, ordered ascending. */
+  static async queryMissedFor(taskId: string, afterSeqId: number): Promise<WebhookEvent[]> {
+    const { data } = await WebhookEvent.select()
+      .eq("task_id", taskId)
+      .gt("id", afterSeqId)
+      .order("id", { ascending: true })
+      .limit(500);
+    return (data ?? []).map((r: Row) => new WebhookEvent(r));
   }
 
   // ── Queries ──────────────────────────────────────────────────────────────────

--- a/tests/foreman.event-handlers.test.ts
+++ b/tests/foreman.event-handlers.test.ts
@@ -1,6 +1,13 @@
 /**
  * Unit tests for the per-event-type routing functions:
  * routePrEvent, routePrReviewEvent, routeCheckEvent, routeIssueEvent.
+ *
+ * After the seqId refactor these functions return { task, ref } and do NOT
+ * call forwardEvent themselves — forwarding is done by routeEvent() after
+ * WebhookEvent.log() returns the DB-assigned sequence id.
+ *
+ * Tests here verify the task-determination and side-effect logic only.
+ * End-to-end forwarding behavior is covered in foreman.webhook-routing.test.ts.
  */
 import http from "http";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -25,7 +32,6 @@ function makeEvent(name = "pull_request"): WebhookEvent {
 interface TestDeps {
   wss: ForemanWss;
   sendMsg: ReturnType<typeof vi.fn>;
-  forwardEvent: ReturnType<typeof vi.spyOn>;
   taskManager: TaskManager;
 }
 
@@ -48,8 +54,7 @@ async function makeDeps(): Promise<TestDeps> {
     server: http.createServer(),
   });
   const sendMsg = vi.spyOn(wss, "sendMsg").mockImplementation(() => {});
-  const forwardEvent = vi.spyOn(wss, "forwardEvent");
-  return { wss, sendMsg, forwardEvent, taskManager };
+  return { wss, sendMsg, taskManager };
 }
 
 let logSpy: ReturnType<typeof vi.spyOn>;
@@ -71,33 +76,31 @@ afterEach(() => {
 
 describe("routePrEvent — missing PR number", () => {
   it("returns null task when pull_request has no number", async () => {
-    const { wss, forwardEvent } = await makeDeps();
+    const { wss } = await makeDeps();
     const result = await wss.routePrEvent({ pull_request: {} }, makeEvent());
-    expect(result).toEqual({ taskId: null, workerId: null });
-    expect(forwardEvent).not.toHaveBeenCalled();
+    expect(result.task).toBeNull();
   });
 });
 
 describe("routePrEvent — synchronize", () => {
-  it("returns the task without forwarding when action is synchronize", async () => {
+  it("returns the task with forward=false when action is synchronize", async () => {
     await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, repo_id: testRepoId });
-    const { wss, sendMsg, forwardEvent } = await makeDeps();
+    const { wss, sendMsg } = await makeDeps();
     const result = await wss.routePrEvent(
       { action: "synchronize", pull_request: { number: 99 }, repository: { full_name: "owner/repo" } },
       makeEvent(),
     );
-    expect(result.taskId).toBe("42");
+    expect(result.task?.taskId).toBe("42");
+    expect(result.forward).toBe(false);
+    // Routing functions do not forward — sendMsg is never called here
     expect(sendMsg).not.toHaveBeenCalled();
-    expect(forwardEvent).not.toHaveBeenCalled();
   });
 });
 
 describe("routePrEvent — opened", () => {
-  it("calls handlePrOpenedEvent and forwards event when a linked task is found", async () => {
-    const w = Worker.register("worker-1", fakeWs(), fakeRepo());
+  it("calls handlePrOpenedEvent and returns the linked task", async () => {
     const task = await seedTask({ task_id: "42", issue_number: 42, repo_id: testRepoId, worker_id: "worker-1", assigned_at: new Date().toISOString() });
-    w.assign(task);
-    const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
+    const { wss, taskManager } = await makeDeps();
     taskManager.handlePrOpenedEvent.mockResolvedValue(task);
     const result = await wss.routePrEvent(
       {
@@ -112,150 +115,123 @@ describe("routePrEvent — opened", () => {
       makeEvent(),
     );
     expect(taskManager.handlePrOpenedEvent).toHaveBeenCalledWith(99, "Closes #42", "feature-branch");
-    expect(forwardEvent).toHaveBeenCalledOnce();
-    expect(sendMsg).toHaveBeenCalledOnce();
-    expect(result.taskId).toBe("42");
+    expect(result.task?.taskId).toBe("42");
   });
 
-  it("returns null when handlePrOpenedEvent finds no linked issue", async () => {
-    const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
+  it("returns null task when handlePrOpenedEvent finds no linked issue", async () => {
+    const { wss, taskManager } = await makeDeps();
     taskManager.handlePrOpenedEvent.mockResolvedValue(null);
     const result = await wss.routePrEvent(
       { action: "opened", pull_request: { number: 99, body: "no link here", head: { ref: "branch" } }, repository: { full_name: "owner/repo" } },
       makeEvent(),
     );
-    expect(result).toEqual({ taskId: null, workerId: null });
-    expect(forwardEvent).not.toHaveBeenCalled();
-    expect(sendMsg).not.toHaveBeenCalled();
+    expect(result.task).toBeNull();
   });
 });
 
 describe("routePrEvent — closed without merge", () => {
-  it("calls handlePrClosedEvent and forwards the event to the task", async () => {
-    const w = Worker.register("worker-1", fakeWs(), fakeRepo());
+  it("calls handlePrClosedEvent and returns the task", async () => {
     const task = await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, repo_id: testRepoId, worker_id: "worker-1", assigned_at: new Date().toISOString() });
-    w.assign(task);
-    const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
+    const { wss, taskManager } = await makeDeps();
     taskManager.handlePrClosedEvent.mockResolvedValue(task);
     const result = await wss.routePrEvent(
       { action: "closed", pull_request: { number: 99, merged: false }, repository: { full_name: "owner/repo" } },
       makeEvent(),
     );
     expect(taskManager.handlePrClosedEvent).toHaveBeenCalledWith(99, false);
-    expect(forwardEvent).toHaveBeenCalledOnce();
-    expect(sendMsg).toHaveBeenCalledOnce();
-    expect(result.taskId).toBe("42");
+    expect(result.task?.taskId).toBe("42");
   });
 
-  it("returns null when no task owns the PR", async () => {
-    const { wss, forwardEvent, taskManager } = await makeDeps();
+  it("returns null task when no task owns the PR", async () => {
+    const { wss, taskManager } = await makeDeps();
     taskManager.handlePrClosedEvent.mockResolvedValue(null);
     const result = await wss.routePrEvent(
       { action: "closed", pull_request: { number: 99, merged: false }, repository: { full_name: "owner/repo" } },
       makeEvent(),
     );
-    expect(result).toEqual({ taskId: null, workerId: null });
-    expect(forwardEvent).not.toHaveBeenCalled();
+    expect(result.task).toBeNull();
   });
 });
 
 describe("routePrEvent — closed with merge", () => {
-  it("calls handlePrClosedEvent with merged=true and forwards the event", async () => {
-    const w = Worker.register("worker-1", fakeWs(), fakeRepo());
+  it("calls handlePrClosedEvent with merged=true and returns the task", async () => {
     const task = await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, repo_id: testRepoId, worker_id: "worker-1", assigned_at: new Date().toISOString() });
-    w.assign(task);
-    const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
+    const { wss, taskManager } = await makeDeps();
     taskManager.handlePrClosedEvent.mockResolvedValue(task);
     const result = await wss.routePrEvent(
       { action: "closed", pull_request: { number: 99, merged: true }, repository: { full_name: "owner/repo" } },
       makeEvent(),
     );
     expect(taskManager.handlePrClosedEvent).toHaveBeenCalledWith(99, true);
-    expect(forwardEvent).toHaveBeenCalledOnce();
-    expect(sendMsg).toHaveBeenCalledOnce();
-    expect(result.taskId).toBe("42");
+    expect(result.task?.taskId).toBe("42");
   });
 
-  it("returns null when no task owns the PR", async () => {
-    const { wss, forwardEvent } = await makeDeps();
+  it("returns null task when no task owns the PR", async () => {
+    const { wss } = await makeDeps();
     const result = await wss.routePrEvent(
       { action: "closed", pull_request: { number: 99, merged: true }, repository: { full_name: "owner/repo" } },
       makeEvent(),
     );
-    expect(result).toEqual({ taskId: null, workerId: null });
-    expect(forwardEvent).not.toHaveBeenCalled();
+    expect(result.task).toBeNull();
   });
 });
 
 describe("routePrEvent — passthrough", () => {
-  it("forwards other PR events to the task", async () => {
-    const w = Worker.register("worker-1", fakeWs(), fakeRepo());
-    const task = await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, repo_id: testRepoId, worker_id: "worker-1", assigned_at: new Date().toISOString() });
-    w.assign(task);
-    const { wss, sendMsg, forwardEvent } = await makeDeps();
+  it("returns the task for other PR events", async () => {
+    await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, repo_id: testRepoId, worker_id: "worker-1", assigned_at: new Date().toISOString() });
+    const { wss } = await makeDeps();
     const result = await wss.routePrEvent(
       { action: "labeled", pull_request: { number: 99 }, repository: { full_name: "owner/repo" } },
       makeEvent(),
     );
-    expect(forwardEvent).toHaveBeenCalledOnce();
-    expect(sendMsg).toHaveBeenCalledOnce();
-    expect(result.taskId).toBe("42");
+    expect(result.task?.taskId).toBe("42");
   });
 
   it("returns null task when no task owns the PR", async () => {
-    const { wss, forwardEvent } = await makeDeps();
+    const { wss } = await makeDeps();
     const result = await wss.routePrEvent(
       { action: "labeled", pull_request: { number: 99 }, repository: { full_name: "owner/repo" } },
       makeEvent(),
     );
-    expect(result).toEqual({ taskId: null, workerId: null });
-    expect(forwardEvent).not.toHaveBeenCalled();
+    expect(result.task).toBeNull();
   });
 });
 
 // ── routePrReviewEvent ────────────────────────────────────────────────────────
 
 describe("routePrReviewEvent", () => {
-  it("returns null when PR number is missing", async () => {
-    const { wss, forwardEvent } = await makeDeps();
+  it("returns null task when PR number is missing", async () => {
+    const { wss } = await makeDeps();
     const result = await wss.routePrReviewEvent({ pull_request: {} }, makeEvent("pull_request_review"));
-    expect(result).toEqual({ taskId: null, workerId: null });
-    expect(forwardEvent).not.toHaveBeenCalled();
+    expect(result.task).toBeNull();
   });
 
-  it("forwards review events to the task that owns the PR", async () => {
-    const w = Worker.register("worker-1", fakeWs(), fakeRepo());
-    const task = await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, repo_id: testRepoId, worker_id: "worker-1", assigned_at: new Date().toISOString() });
-    w.assign(task);
-    const { wss, sendMsg, forwardEvent } = await makeDeps();
+  it("returns the task that owns the PR", async () => {
+    await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, repo_id: testRepoId, worker_id: "worker-1", assigned_at: new Date().toISOString() });
+    const { wss } = await makeDeps();
     const result = await wss.routePrReviewEvent(
       { pull_request: { number: 99 }, repository: { full_name: "owner/repo" } },
       makeEvent("pull_request_review"),
     );
-    expect(forwardEvent).toHaveBeenCalledOnce();
-    expect(sendMsg).toHaveBeenCalledOnce();
-    expect(result.taskId).toBe("42");
+    expect(result.task?.taskId).toBe("42");
   });
 
-  it("returns null when no task owns the reviewed PR", async () => {
-    const { wss, forwardEvent } = await makeDeps();
+  it("returns null task when no task owns the reviewed PR", async () => {
+    const { wss } = await makeDeps();
     const result = await wss.routePrReviewEvent(
       { pull_request: { number: 99 }, repository: { full_name: "owner/repo" } },
       makeEvent("pull_request_review"),
     );
-    expect(result).toEqual({ taskId: null, workerId: null });
-    expect(forwardEvent).not.toHaveBeenCalled();
+    expect(result.task).toBeNull();
   });
 });
 
 // ── routeCheckEvent ───────────────────────────────────────────────────────────
 
 describe("routeCheckEvent — via PR number", () => {
-  it("forwards check_run to the task when getTaskForCheckEvent finds it by PR", async () => {
-    const w = Worker.register("worker-1", fakeWs(), fakeRepo());
+  it("returns the task when getTaskForCheckEvent finds it by PR (check_run)", async () => {
     const task = await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, repo_id: testRepoId, worker_id: "worker-1", assigned_at: new Date().toISOString() });
-    w.assign(task);
-    const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
+    const { wss, taskManager } = await makeDeps();
     taskManager.getTaskForCheckEvent.mockResolvedValue({ task, ref: "PR #99" });
     const result = await wss.routeCheckEvent(
       { check_run: { pull_requests: [{ number: 99 }] }, repository: { full_name: "owner/repo" } },
@@ -263,16 +239,12 @@ describe("routeCheckEvent — via PR number", () => {
       "check_run",
     );
     expect(taskManager.getTaskForCheckEvent).toHaveBeenCalledWith([99], "");
-    expect(forwardEvent).toHaveBeenCalledOnce();
-    expect(sendMsg).toHaveBeenCalledOnce();
-    expect(result.taskId).toBe("42");
+    expect(result.task?.taskId).toBe("42");
   });
 
-  it("forwards check_suite to the task when getTaskForCheckEvent finds it by PR", async () => {
-    const w = Worker.register("worker-1", fakeWs(), fakeRepo());
+  it("returns the task when getTaskForCheckEvent finds it by PR (check_suite)", async () => {
     const task = await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, repo_id: testRepoId, worker_id: "worker-1", assigned_at: new Date().toISOString() });
-    w.assign(task);
-    const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
+    const { wss, taskManager } = await makeDeps();
     taskManager.getTaskForCheckEvent.mockResolvedValue({ task, ref: "PR #99" });
     const result = await wss.routeCheckEvent(
       { check_suite: { pull_requests: [{ number: 99 }] }, repository: { full_name: "owner/repo" } },
@@ -280,18 +252,14 @@ describe("routeCheckEvent — via PR number", () => {
       "check_suite",
     );
     expect(taskManager.getTaskForCheckEvent).toHaveBeenCalledWith([99], "");
-    expect(forwardEvent).toHaveBeenCalledOnce();
-    expect(sendMsg).toHaveBeenCalledOnce();
-    expect(result.taskId).toBe("42");
+    expect(result.task?.taskId).toBe("42");
   });
 });
 
 describe("routeCheckEvent — via branch name", () => {
   it("passes head_branch to getTaskForCheckEvent for check_run", async () => {
-    const w = Worker.register("worker-1", fakeWs(), fakeRepo());
     const task = await seedTask({ task_id: "42", issue_number: 42, repo_id: testRepoId, worker_id: "worker-1", assigned_at: new Date().toISOString() });
-    w.assign(task);
-    const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
+    const { wss, taskManager } = await makeDeps();
     taskManager.getTaskForCheckEvent.mockResolvedValue({ task, ref: "branch feature-branch" });
     const result = await wss.routeCheckEvent(
       { check_run: { pull_requests: [], check_suite: { head_branch: "feature-branch" } }, repository: { full_name: "owner/repo" } },
@@ -299,16 +267,12 @@ describe("routeCheckEvent — via branch name", () => {
       "check_run",
     );
     expect(taskManager.getTaskForCheckEvent).toHaveBeenCalledWith([], "feature-branch");
-    expect(forwardEvent).toHaveBeenCalledOnce();
-    expect(sendMsg).toHaveBeenCalledOnce();
-    expect(result.taskId).toBe("42");
+    expect(result.task?.taskId).toBe("42");
   });
 
   it("passes head_branch to getTaskForCheckEvent for check_suite", async () => {
-    const w = Worker.register("worker-1", fakeWs(), fakeRepo());
     const task = await seedTask({ task_id: "42", issue_number: 42, repo_id: testRepoId, worker_id: "worker-1", assigned_at: new Date().toISOString() });
-    w.assign(task);
-    const { wss, sendMsg, forwardEvent, taskManager } = await makeDeps();
+    const { wss, taskManager } = await makeDeps();
     taskManager.getTaskForCheckEvent.mockResolvedValue({ task, ref: "branch feature-branch" });
     const result = await wss.routeCheckEvent(
       { check_suite: { pull_requests: [], head_branch: "feature-branch" }, repository: { full_name: "owner/repo" } },
@@ -316,20 +280,17 @@ describe("routeCheckEvent — via branch name", () => {
       "check_suite",
     );
     expect(taskManager.getTaskForCheckEvent).toHaveBeenCalledWith([], "feature-branch");
-    expect(forwardEvent).toHaveBeenCalledOnce();
-    expect(sendMsg).toHaveBeenCalledOnce();
-    expect(result.taskId).toBe("42");
+    expect(result.task?.taskId).toBe("42");
   });
 
-  it("returns null when getTaskForCheckEvent finds nothing", async () => {
-    const { wss, forwardEvent } = await makeDeps();
+  it("returns null task when getTaskForCheckEvent finds nothing", async () => {
+    const { wss } = await makeDeps();
     const result = await wss.routeCheckEvent(
       { check_run: { pull_requests: [], check_suite: { head_branch: "unknown-branch" } }, repository: { full_name: "owner/repo" } },
       makeEvent("check_run"),
       "check_run",
     );
-    expect(result).toEqual({ taskId: null, workerId: null });
-    expect(forwardEvent).not.toHaveBeenCalled();
+    expect(result.task).toBeNull();
   });
 });
 
@@ -338,7 +299,7 @@ describe("routeCheckEvent — via branch name", () => {
 describe("routeIssueEvent — enqueue on labeled", () => {
   it("calls handleIssueLabeledEvent and returns the enqueued task", async () => {
     const task = Task.fromTest({ task_id: "42", issue_number: 42, repo_id: testRepoId });
-    const { wss, forwardEvent, taskManager } = await makeDeps();
+    const { wss, taskManager } = await makeDeps();
     taskManager.handleIssueLabeledEvent.mockResolvedValue(task);
     const issue = { number: 42, title: "Do something", body: "details", state: "open", labels: [{ name: "brunel:ready" }] };
     const result = await wss.routeIssueEvent(
@@ -350,15 +311,12 @@ describe("routeIssueEvent — enqueue on labeled", () => {
     expect(taskManager.handleIssueLabeledEvent).toHaveBeenCalledWith(
       42, "Do something", "details", ["brunel:ready"], "open",
     );
-    expect(result).toEqual({ taskId: "42", workerId: null });
+    expect(result.task?.taskId).toBe("42");
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("enqueued via issues/labeled"));
-    // The labeled event is queued for the worker to receive once assigned; forwardEvent is called
-    // but sendMsg is not (no worker connected yet).
-    expect(forwardEvent).toHaveBeenCalledOnce();
   });
 
-  it("returns null when handleIssueLabeledEvent returns null (e.g. closed issue)", async () => {
-    const { wss, forwardEvent, taskManager } = await makeDeps();
+  it("returns null task when handleIssueLabeledEvent returns null (e.g. closed issue)", async () => {
+    const { wss, taskManager } = await makeDeps();
     taskManager.handleIssueLabeledEvent.mockResolvedValue(null);
     const issue = { number: 42, title: "Do something", body: "", state: "closed", labels: [{ name: "brunel:ready" }] };
     const result = await wss.routeIssueEvent(
@@ -368,12 +326,11 @@ describe("routeIssueEvent — enqueue on labeled", () => {
       42,
     );
     expect(taskManager.handleIssueLabeledEvent).toHaveBeenCalled();
-    expect(result).toEqual({ taskId: null, workerId: null });
-    expect(forwardEvent).not.toHaveBeenCalled();
+    expect(result.task).toBeNull();
   });
 
   it("ignores a labeled event for a different label", async () => {
-    const { wss, forwardEvent, taskManager } = await makeDeps();
+    const { wss, taskManager } = await makeDeps();
     const issue = { number: 42, title: "Do something", body: "", state: "open", labels: [] };
     const result = await wss.routeIssueEvent(
       { action: "labeled", label: { name: "other-label" }, repository: { full_name: "owner/repo" } },
@@ -382,15 +339,14 @@ describe("routeIssueEvent — enqueue on labeled", () => {
       42,
     );
     expect(taskManager.handleIssueLabeledEvent).not.toHaveBeenCalled();
-    expect(result).toEqual({ taskId: null, workerId: null });
-    expect(forwardEvent).not.toHaveBeenCalled();
+    expect(result.task).toBeNull();
   });
 });
 
 describe("routeIssueEvent — enqueue on opened", () => {
   it("calls handleIssueLabeledEvent when opened with the task label already attached", async () => {
     const task = Task.fromTest({ task_id: "42", issue_number: 42, repo_id: testRepoId });
-    const { wss, forwardEvent, taskManager } = await makeDeps();
+    const { wss, taskManager } = await makeDeps();
     taskManager.handleIssueLabeledEvent.mockResolvedValue(task);
     const issue = { number: 42, title: "Do something", body: "details", state: "open", labels: [{ name: "brunel:ready" }] };
     const result = await wss.routeIssueEvent(
@@ -400,12 +356,11 @@ describe("routeIssueEvent — enqueue on opened", () => {
       42,
     );
     expect(taskManager.handleIssueLabeledEvent).toHaveBeenCalled();
-    expect(result).toEqual({ taskId: "42", workerId: null });
-    expect(forwardEvent).toHaveBeenCalledOnce();
+    expect(result.task?.taskId).toBe("42");
   });
 
   it("does not call handleIssueLabeledEvent when opened without the task label", async () => {
-    const { wss, forwardEvent, taskManager } = await makeDeps();
+    const { wss, taskManager } = await makeDeps();
     const issue = { number: 42, title: "Do something", body: "", state: "open", labels: [] };
     const result = await wss.routeIssueEvent(
       { action: "opened", repository: { full_name: "owner/repo" } },
@@ -414,15 +369,14 @@ describe("routeIssueEvent — enqueue on opened", () => {
       42,
     );
     expect(taskManager.handleIssueLabeledEvent).not.toHaveBeenCalled();
-    expect(result).toEqual({ taskId: null, workerId: null });
-    expect(forwardEvent).not.toHaveBeenCalled();
+    expect(result.task).toBeNull();
   });
 });
 
 describe("routeIssueEvent — unlabeled (dequeue)", () => {
   it("dequeues the task when the task label is removed", async () => {
     await seedTask({ task_id: "42", issue_number: 42, repo_id: testRepoId });
-    const { wss, forwardEvent, taskManager } = await makeDeps();
+    const { wss, taskManager } = await makeDeps();
     const issue = { number: 42 };
     await wss.routeIssueEvent(
       { action: "unlabeled", label: { name: "brunel:ready" }, repository: { full_name: "owner/repo" } },
@@ -432,29 +386,27 @@ describe("routeIssueEvent — unlabeled (dequeue)", () => {
     );
     expect(taskManager.dequeueIssue).toHaveBeenCalledWith(42);
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("dequeued"));
-    // Worker does not need to know the label was removed
-    expect(forwardEvent).not.toHaveBeenCalled();
   });
 
   it("does not dequeue when a different label is removed", async () => {
     await seedTask({ task_id: "42", issue_number: 42, repo_id: testRepoId });
-    const { wss, forwardEvent, taskManager } = await makeDeps();
+    const { wss, taskManager } = await makeDeps();
     const issue = { number: 42 };
-    await wss.routeIssueEvent(
+    const result = await wss.routeIssueEvent(
       { action: "unlabeled", label: { name: "other-label" }, repository: { full_name: "owner/repo" } },
       makeEvent("issues"),
       issue,
       42,
     );
     expect(taskManager.dequeueIssue).not.toHaveBeenCalled();
-    // Non-task label removal falls through: task exists, so the event is forwarded to the worker
-    expect(forwardEvent).toHaveBeenCalledOnce();
+    // Non-task label removal falls through: task exists, so task is returned
+    expect(result.task?.taskId).toBe("42");
   });
 });
 
 describe("routeIssueEvent — closed", () => {
   it("calls closeIssue when an issue is closed", async () => {
-    const { wss, forwardEvent, taskManager } = await makeDeps();
+    const { wss, taskManager } = await makeDeps();
     const issue = { number: 42 };
     await wss.routeIssueEvent(
       { action: "closed", repository: { full_name: "owner/repo" } },
@@ -463,28 +415,26 @@ describe("routeIssueEvent — closed", () => {
       42,
     );
     expect(taskManager.closeIssue).toHaveBeenCalledWith(42);
-    // No tracked task → nothing to forward
-    expect(forwardEvent).not.toHaveBeenCalled();
   });
 
-  it("calls forwardEvent when a tracked task exists", async () => {
+  it("returns the tracked task when the issue is closed", async () => {
     await seedTask({ task_id: "42", issue_number: 42, repo_id: testRepoId });
-    const { wss, forwardEvent, taskManager } = await makeDeps();
+    const { wss, taskManager } = await makeDeps();
     const issue = { number: 42 };
-    await wss.routeIssueEvent(
+    const result = await wss.routeIssueEvent(
       { action: "closed", repository: { full_name: "owner/repo" } },
       makeEvent("issues"),
       issue,
       42,
     );
     expect(taskManager.closeIssue).toHaveBeenCalledWith(42);
-    expect(forwardEvent).toHaveBeenCalledOnce();
+    expect(result.task?.taskId).toBe("42");
   });
 });
 
 describe("routeIssueEvent — reopened", () => {
   it("calls reopenIssue when an issue is reopened", async () => {
-    const { wss, forwardEvent, taskManager } = await makeDeps();
+    const { wss, taskManager } = await makeDeps();
     const issue = { number: 42 };
     await wss.routeIssueEvent(
       { action: "reopened", repository: { full_name: "owner/repo" } },
@@ -493,31 +443,29 @@ describe("routeIssueEvent — reopened", () => {
       42,
     );
     expect(taskManager.reopenIssue).toHaveBeenCalledWith(42);
-    // No tracked task → nothing to forward
-    expect(forwardEvent).not.toHaveBeenCalled();
   });
 
-  it("calls forwardEvent when a tracked task exists", async () => {
+  it("returns the tracked task when the issue is reopened", async () => {
     await seedTask({ task_id: "42", issue_number: 42, repo_id: testRepoId });
-    const { wss, forwardEvent, taskManager } = await makeDeps();
+    const { wss, taskManager } = await makeDeps();
     const issue = { number: 42 };
-    await wss.routeIssueEvent(
+    const result = await wss.routeIssueEvent(
       { action: "reopened", repository: { full_name: "owner/repo" } },
       makeEvent("issues"),
       issue,
       42,
     );
     expect(taskManager.reopenIssue).toHaveBeenCalledWith(42);
-    expect(forwardEvent).toHaveBeenCalledOnce();
+    expect(result.task?.taskId).toBe("42");
   });
 });
 
 describe("routeIssueEvent — edited", () => {
   it("calls handleIssueBodyEditedEvent when the issue body is edited for a tracked task", async () => {
     await seedTask({ task_id: "42", issue_number: 42, repo_id: testRepoId });
-    const { wss, forwardEvent, taskManager } = await makeDeps();
+    const { wss, taskManager } = await makeDeps();
     const issue = { number: 42, body: "updated body" };
-    await wss.routeIssueEvent(
+    const result = await wss.routeIssueEvent(
       { action: "edited", changes: { body: { from: "old body" } }, repository: { full_name: "owner/repo" } },
       makeEvent("issues"),
       issue,
@@ -526,26 +474,26 @@ describe("routeIssueEvent — edited", () => {
     expect(taskManager.handleIssueBodyEditedEvent).toHaveBeenCalledWith(
       42, "updated body",
     );
-    expect(forwardEvent).toHaveBeenCalledOnce();
+    expect(result.task?.taskId).toBe("42");
   });
 
   it("does not call handleIssueBodyEditedEvent when the body was not changed", async () => {
     await seedTask({ task_id: "42", issue_number: 42, repo_id: testRepoId });
-    const { wss, forwardEvent, taskManager } = await makeDeps();
+    const { wss, taskManager } = await makeDeps();
     const issue = { number: 42, title: "updated title" };
-    await wss.routeIssueEvent(
+    const result = await wss.routeIssueEvent(
       { action: "edited", changes: { title: { from: "old title" } }, repository: { full_name: "owner/repo" } },
       makeEvent("issues"),
       issue,
       42,
     );
     expect(taskManager.handleIssueBodyEditedEvent).not.toHaveBeenCalled();
-    // Task exists, so the event is still forwarded even when body didn't change
-    expect(forwardEvent).toHaveBeenCalledOnce();
+    // Task exists, so task is still returned even when body didn't change
+    expect(result.task?.taskId).toBe("42");
   });
 
   it("does not call handleIssueBodyEditedEvent when the issue is not tracked", async () => {
-    const { wss, forwardEvent, taskManager } = await makeDeps();
+    const { wss, taskManager } = await makeDeps();
     const issue = { number: 42, body: "updated body" };
     await wss.routeIssueEvent(
       { action: "edited", changes: { body: { from: "old body" } }, repository: { full_name: "owner/repo" } },
@@ -554,7 +502,6 @@ describe("routeIssueEvent — edited", () => {
       42,
     );
     expect(taskManager.handleIssueBodyEditedEvent).not.toHaveBeenCalled();
-    expect(forwardEvent).not.toHaveBeenCalled();
   });
 
   it("persists updated body to DB when body is edited", async () => {
@@ -585,11 +532,9 @@ describe("routeIssueEvent — edited", () => {
 });
 
 describe("routeIssueEvent — passthrough forwarding", () => {
-  it("forwards other issue events to the tracked task", async () => {
-    const w = Worker.register("worker-1", fakeWs(), fakeRepo());
-    const task = await seedTask({ task_id: "42", issue_number: 42, repo_id: testRepoId, worker_id: "worker-1", assigned_at: new Date().toISOString() });
-    w.assign(task);
-    const { wss, sendMsg, forwardEvent } = await makeDeps();
+  it("returns the tracked task for other issue events", async () => {
+    await seedTask({ task_id: "42", issue_number: 42, repo_id: testRepoId, worker_id: "worker-1", assigned_at: new Date().toISOString() });
+    const { wss } = await makeDeps();
     const issue = { number: 42 };
     const result = await wss.routeIssueEvent(
       { action: "assigned", repository: { full_name: "owner/repo" } },
@@ -597,16 +542,12 @@ describe("routeIssueEvent — passthrough forwarding", () => {
       issue,
       42,
     );
-    expect(forwardEvent).toHaveBeenCalledOnce();
-    expect(sendMsg).toHaveBeenCalledOnce();
-    expect(result.taskId).toBe("42");
+    expect(result.task?.taskId).toBe("42");
   });
 
   it("routes issue_comment on a PR via getByPr fallback", async () => {
-    const w = Worker.register("worker-1", fakeWs(), fakeRepo());
-    const task = await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, repo_id: testRepoId, worker_id: "worker-1", assigned_at: new Date().toISOString() });
-    w.assign(task);
-    const { wss, sendMsg, forwardEvent } = await makeDeps();
+    await seedTask({ task_id: "42", issue_number: 42, pr_number: 99, repo_id: testRepoId, worker_id: "worker-1", assigned_at: new Date().toISOString() });
+    const { wss } = await makeDeps();
     const issue = { number: 99 }; // PR number in issue.number
     const result = await wss.routeIssueEvent(
       { action: "created", repository: { full_name: "owner/repo" } },
@@ -614,8 +555,6 @@ describe("routeIssueEvent — passthrough forwarding", () => {
       issue,
       99,
     );
-    expect(forwardEvent).toHaveBeenCalledOnce();
-    expect(sendMsg).toHaveBeenCalledOnce();
-    expect(result.taskId).toBe("42");
+    expect(result.task?.taskId).toBe("42");
   });
 });

--- a/tests/foreman.forward-event.test.ts
+++ b/tests/foreman.forward-event.test.ts
@@ -226,3 +226,33 @@ describe("forwardEvent — send failure recovery", () => {
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("not in registry"));
   });
 });
+
+// ── seqId propagation ─────────────────────────────────────────────────────────
+
+describe("forwardEvent — seqId in event_notification", () => {
+  it("includes seqId in the event_notification message when provided", () => {
+    const task = Task.fromTest({ task_id: "42", issue_number: 42, worker_id: "worker-1" });
+    const w = Worker.register("worker-1", fakeWs(), fakeRepo());
+    w.assign(task);
+    const { wss, sendMsg } = makeWss();
+
+    wss.forwardEvent(task, makeEvent(), "#42", 99);
+
+    expect(sendMsg).toHaveBeenCalledOnce();
+    const [, msg] = sendMsg.mock.calls[0];
+    expect((msg as any).seqId).toBe(99);
+  });
+
+  it("omits seqId from the event_notification message when not provided", () => {
+    const task = Task.fromTest({ task_id: "42", issue_number: 42, worker_id: "worker-1" });
+    const w = Worker.register("worker-1", fakeWs(), fakeRepo());
+    w.assign(task);
+    const { wss, sendMsg } = makeWss();
+
+    wss.forwardEvent(task, makeEvent(), "#42");
+
+    expect(sendMsg).toHaveBeenCalledOnce();
+    const [, msg] = sendMsg.mock.calls[0];
+    expect((msg as any).seqId).toBeUndefined();
+  });
+});

--- a/tests/foreman.hello-handlers.test.ts
+++ b/tests/foreman.hello-handlers.test.ts
@@ -11,6 +11,7 @@ import { Worker } from "../src/foreman/models/worker.js";
 import { Task } from "../src/foreman/models/task.js";
 import { TaskManager } from "../src/foreman/models/task-manager.js";
 import { ForemanMessage } from "../src/foreman/models/foreman-message.js";
+import { WebhookEvent } from "../src/foreman/models/webhook-event.js";
 import { Repo } from "../src/foreman/models/repo.js";
 import { fakeRepo, resetDb, seedTask, createTestTaskManager, createTestRepo } from "./helpers/task.js";
 import * as utils from "../src/utils.js";
@@ -186,6 +187,79 @@ describe("handleAssignedHello", () => {
         ([, msg]) => (msg as { type: string }).type === "event_notification"
       );
       expect(eventNotifs).toHaveLength(1);
+    });
+  });
+
+  describe("DB replay on reconnect (lastSeenEventSeqId)", () => {
+    it("replays missed events from DB when lastSeenEventSeqId is provided", async () => {
+      await seedTask({
+        task_id: "10",
+        issue_number: 10,
+        repo_id: taskManager.repo.id,
+        worker_id: "w1",
+        assigned_at: new Date().toISOString(),
+      });
+
+      // Simulate two events that arrived while the worker was disconnected
+      const evt1 = WebhookEvent.fromIncoming("d1", "issue_comment", {}) as any;
+      const evt2 = WebhookEvent.fromIncoming("d2", "pull_request", {}) as any;
+      // Give them synthetic DB ids (simulating rows fetched from webhook_events)
+      Object.assign(evt1, { id: 11 });
+      Object.assign(evt2, { id: 12 });
+
+      vi.spyOn(WebhookEvent, "queryMissedFor").mockResolvedValue([evt1, evt2]);
+
+      const { wss, sendMsg } = makeWss(taskManager);
+      // Worker reconnects claiming it last saw seqId=10
+      await wss.handleAssignedHello("w1", "10", fakeWs(), fakeRepo(), 10);
+
+      expect(WebhookEvent.queryMissedFor).toHaveBeenCalledWith("10", 10);
+
+      const replayNotifs = sendMsg.mock.calls.filter(
+        ([, msg]) => (msg as { type: string }).type === "event_notification"
+      );
+      expect(replayNotifs).toHaveLength(2);
+      expect((replayNotifs[0][1] as any).seqId).toBe(11);
+      expect((replayNotifs[1][1] as any).seqId).toBe(12);
+    });
+
+    it("does not call queryMissedFor when lastSeenEventSeqId is absent", async () => {
+      await seedTask({
+        task_id: "10",
+        issue_number: 10,
+        repo_id: taskManager.repo.id,
+        worker_id: "w1",
+        assigned_at: new Date().toISOString(),
+      });
+
+      const querySpy = vi.spyOn(WebhookEvent, "queryMissedFor").mockResolvedValue([]);
+
+      const { wss } = makeWss(taskManager);
+      await wss.handleAssignedHello("w1", "10", fakeWs(), fakeRepo());
+
+      expect(querySpy).not.toHaveBeenCalled();
+    });
+
+    it("logs an error and continues if queryMissedFor throws", async () => {
+      await seedTask({
+        task_id: "10",
+        issue_number: 10,
+        repo_id: taskManager.repo.id,
+        worker_id: "w1",
+        assigned_at: new Date().toISOString(),
+      });
+
+      vi.spyOn(WebhookEvent, "queryMissedFor").mockRejectedValue(new Error("DB down"));
+      const logSpy = vi.spyOn(utils, "log").mockImplementation(() => {});
+
+      const { wss, sendMsg } = makeWss(taskManager);
+      // Should not throw even if DB query fails
+      await expect(wss.handleAssignedHello("w1", "10", fakeWs(), fakeRepo(), 5)).resolves.toBeUndefined();
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("ERROR"));
+
+      // hello_ack should still have been sent
+      const ack = helloAck(sendMsg);
+      expect(ack?.status).toBe("assigned");
     });
   });
 });
@@ -693,7 +767,7 @@ describe("handleWorkerHello routing", () => {
       status: "assigned",
     });
 
-    expect(spy).toHaveBeenCalledWith("w1", "77", expect.anything(), expect.anything());
+    expect(spy).toHaveBeenCalledWith("w1", "77", expect.anything(), expect.anything(), undefined);
   });
 
   it("status='reserved' → routes to handleReservedHello", async () => {

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -2855,3 +2855,122 @@ describe("WorkspaceController.onForceDestroy", () => {
     expect(mockWs.checkSafety).not.toHaveBeenCalled();
   });
 });
+
+// ── lastSeenEventSeqId tracking ───────────────────────────────────────────────
+
+describe("lastSeenEventSeqId", () => {
+  function reconnectWithNewWs(): FakeWs {
+    const newWs = new FakeWs();
+    wsFactory.mockReturnValueOnce(newWs as any);
+    fakeWs.emit("close", 1000, Buffer.from(""));
+    vi.advanceTimersByTime(1); // delay=0 with Math.random mocked to 0
+    return newWs;
+  }
+
+  it("includes lastSeenEventSeqId in worker_hello when reconnecting with a task", () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    try {
+      const issue = makeIssue();
+      sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
+
+      // Receive an event_notification with seqId
+      sendMsg(fakeWs, { type: "event_notification", taskId: "42", event: makeEvent("issue_comment"), seqId: 7 });
+
+      const newWs = reconnectWithNewWs();
+      newWs.emit("open");
+
+      const helloCalls = newWs.send.mock.calls.filter((args) => {
+        const parsed = JSON.parse(args[0] as string);
+        return parsed.type === "worker_hello";
+      });
+      expect(helloCalls).toHaveLength(1);
+      const hello = JSON.parse(helloCalls[0][0] as string);
+      expect(hello.status).toBe("assigned");
+      expect(hello.lastSeenEventSeqId).toBe(7);
+    } finally {
+      vi.restoreAllMocks();
+      vi.useRealTimers();
+    }
+  });
+
+  it("omits lastSeenEventSeqId when no event_notification with seqId was received", () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    try {
+      const issue = makeIssue();
+      sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
+
+      // Receive an event_notification WITHOUT seqId
+      sendMsg(fakeWs, { type: "event_notification", taskId: "42", event: makeEvent("issue_comment") });
+
+      const newWs = reconnectWithNewWs();
+      newWs.emit("open");
+
+      const helloCalls = newWs.send.mock.calls.filter((args) => {
+        const parsed = JSON.parse(args[0] as string);
+        return parsed.type === "worker_hello";
+      });
+      expect(helloCalls).toHaveLength(1);
+      const hello = JSON.parse(helloCalls[0][0] as string);
+      expect(hello.lastSeenEventSeqId).toBeUndefined();
+    } finally {
+      vi.restoreAllMocks();
+      vi.useRealTimers();
+    }
+  });
+
+  it("tracks the highest seqId when multiple events arrive", () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    try {
+      const issue = makeIssue();
+      sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
+
+      sendMsg(fakeWs, { type: "event_notification", taskId: "42", event: makeEvent(), seqId: 5 });
+      sendMsg(fakeWs, { type: "event_notification", taskId: "42", event: makeEvent(), seqId: 3 }); // lower than previous
+      sendMsg(fakeWs, { type: "event_notification", taskId: "42", event: makeEvent(), seqId: 9 });
+
+      const newWs = reconnectWithNewWs();
+      newWs.emit("open");
+
+      const helloCalls = newWs.send.mock.calls.filter((args) => {
+        const parsed = JSON.parse(args[0] as string);
+        return parsed.type === "worker_hello";
+      });
+      const hello = JSON.parse(helloCalls[0][0] as string);
+      expect(hello.lastSeenEventSeqId).toBe(9);
+    } finally {
+      vi.restoreAllMocks();
+      vi.useRealTimers();
+    }
+  });
+
+  it("resets lastSeenEventSeqId when a new task is assigned", () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    try {
+      const issue = makeIssue();
+      sendMsg(fakeWs, { type: "task_assigned", taskId: "42", issue });
+      sendMsg(fakeWs, { type: "event_notification", taskId: "42", event: makeEvent(), seqId: 7 });
+
+      // Complete task, then receive a new task assignment
+      sendMsg(fakeWs, { type: "hello_ack", workerId: AGENT_ID, status: "ready", repoStatus: "active" });
+      sendMsg(fakeWs, { type: "task_assigned", taskId: "99", issue: makeIssue(2) });
+
+      const newWs = reconnectWithNewWs();
+      newWs.emit("open");
+
+      const helloCalls = newWs.send.mock.calls.filter((args) => {
+        const parsed = JSON.parse(args[0] as string);
+        return parsed.type === "worker_hello";
+      });
+      const hello = JSON.parse(helloCalls[0][0] as string);
+      // lastSeenEventSeqId should be absent because the new task has no events yet
+      expect(hello.lastSeenEventSeqId).toBeUndefined();
+    } finally {
+      vi.restoreAllMocks();
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **Wire protocol**: `event_notification` gains an optional `seqId` (the `webhook_events.id` for that row); `worker_hello` gains `lastSeenEventSeqId` (sent on reconnect when status is `"assigned"`)
- **Routing refactor**: Routing functions (`routePrEvent`, etc.) now return `{ task, ref }` without calling `forwardEvent()`. `routeEvent()` awaits `WebhookEvent.log()` to obtain the DB-assigned sequence id, then calls `forwardEvent(task, evt, ref, seqId)` — so every forwarded event carries its durable id
- **Reconnect replay**: On `worker_hello { status: "assigned", lastSeenEventSeqId }`, the foreman queries `webhook_events WHERE task_id = :id AND id > :seqId ORDER BY id ASC` and replays each row as `event_notification`, covering both the zombie-window and foreman-restart scenarios
- **Worker tracking**: Worker records the highest `seqId` seen per task and includes it in `worker_hello` on reconnect; resets to `undefined` on new task assignment

## Test plan

- [x] All 1773 unit tests pass (`npm test` — DB tests excluded, require live Supabase)
- [x] TypeScript type check clean (`npx tsc --noEmit`)
- [x] ESLint clean (`npm run lint`)
- [x] New tests: `forwardEvent` includes/omits `seqId`; `handleAssignedHello` replays DB events when `lastSeenEventSeqId` provided; worker tracks `lastSeenEventSeqId` across reconnects; resets on new task
- [x] `pull_request/synchronize` still does not forward to worker (preserved via `forward: false`)

Closes #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)