### PR TITLE
feat: add /worker:reconnect command for immediate reconnection

### DIFF
--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -145,6 +145,7 @@ export class WorkerController extends EventEmitter {
   private connectionState: "hello_sent" | "registered" = "registered";
   private bufferedMessages: BufferableMessage[] = [];
   private reconnectAttempts = 0;
+  private _reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private _stopped = false;
 
   // ── Reserved state ────────────────────────────────────────────────────────
@@ -728,6 +729,18 @@ export class WorkerController extends EventEmitter {
         return undefined;
       },
     });
+    registry.register("reconnect", {
+      description: "Immediately reconnect to the foreman, cancelling any backoff delay",
+      handler: async () => {
+        if (!this._isActive) {
+          this.display.print(c.amber("Worker mode is not active."));
+          return undefined;
+        }
+        this.display.print(c.sageGreen("Reconnecting..."));
+        this.forceReconnect();
+        return undefined;
+      },
+    });
   }
 
   // ── Private ───────────────────────────────────────────────────────────────
@@ -751,6 +764,10 @@ export class WorkerController extends EventEmitter {
     this.connectionState = "registered";
     this.bufferedMessages = [];
     this.reconnectAttempts = 0;
+    if (this._reconnectTimer) {
+      clearTimeout(this._reconnectTimer);
+      this._reconnectTimer = null;
+    }
     this.currentAc = null;
     this._queryRunning = false;
     this._eventsPaused = false;
@@ -903,7 +920,7 @@ export class WorkerController extends EventEmitter {
         disconnectCode: code,
         reconnectAt: Date.now() + delay,
       });
-      setTimeout(() => this.connect(), delay);
+      this._reconnectTimer = setTimeout(() => this.connect(), delay);
     });
 
     ws.on("error", (err: Error) => {
@@ -913,6 +930,24 @@ export class WorkerController extends EventEmitter {
       // (e.g. some TLS negotiation failures on older Node.js / ws versions).
       ws.terminate();
     });
+  }
+
+  /**
+   * Cancel any pending backoff timer, tear down the current socket, and
+   * immediately open a fresh connection. Called by /worker:reconnect.
+   */
+  private forceReconnect(): void {
+    if (this._reconnectTimer) {
+      clearTimeout(this._reconnectTimer);
+      this._reconnectTimer = null;
+    }
+    // Nullify this.ws before terminating so the close handler's stale-socket
+    // guard treats the old socket as stale and skips scheduling another reconnect.
+    const oldWs = this.ws;
+    this.ws = undefined;
+    this.reconnectAttempts = 0;
+    oldWs?.terminate();
+    this.connect();
   }
 
   private async handleMessage(msg: Wire.ForemanMessage): Promise<void> {

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -538,6 +538,126 @@ describe("reconnect", () => {
   });
 });
 
+// ── /worker:reconnect command ─────────────────────────────────────────────────
+
+describe("/worker:reconnect command", () => {
+  function registerAndGetHandler(): (args: string) => Promise<unknown> {
+    const handlers: Record<string, (args: string) => Promise<unknown>> = {};
+    const registry = {
+      register: (name: string, def: { handler: (args: string) => Promise<unknown> }) => {
+        handlers[name] = def.handler;
+      },
+    } as unknown as import("../src/agent/controllers/command-controller.js").CommandRegistry;
+    session.registerCommands(registry);
+    return handlers["reconnect"]!;
+  }
+
+  it("prints an amber message when worker mode is not active", async () => {
+    await session.stop();
+    const handler = registerAndGetHandler();
+    display.print.mockClear();
+    await handler("");
+    const printed = display.print.mock.calls.map(args => stripAnsi(String(args[0]))).join("\n");
+    expect(printed).toContain("not active");
+  });
+
+  it("cancels a pending backoff timer and reconnects immediately without advancing time", async () => {
+    vi.useFakeTimers();
+    try {
+      // Disconnect to start the backoff timer
+      fakeWs.emit("close", 1006, Buffer.from(""));
+      expect(wsFactory).toHaveBeenCalledTimes(1); // timer pending, not yet fired
+
+      const newWs = new FakeWs();
+      wsFactory.mockReturnValueOnce(newWs);
+
+      const handler = registerAndGetHandler();
+      await handler(""); // should connect immediately, no timer advance needed
+
+      expect(wsFactory).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("terminates an existing open connection before reconnecting", async () => {
+    vi.useFakeTimers();
+    try {
+      const newWs = new FakeWs();
+      wsFactory.mockReturnValueOnce(newWs);
+
+      const handler = registerAndGetHandler();
+      await handler("");
+
+      expect(fakeWs.terminate).toHaveBeenCalledOnce();
+      expect(wsFactory).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resets reconnect attempt counter so the next backoff uses attempt 0 delay", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    try {
+      // Build up backoff: disconnect twice to reach attempt 1 (1000ms delay)
+      const ws2 = new FakeWs();
+      wsFactory.mockReturnValueOnce(ws2);
+      fakeWs.emit("close", 1006, Buffer.from(""));
+      vi.advanceTimersByTime(501); // attempt 0 fires at ~500ms
+      expect(wsFactory).toHaveBeenCalledTimes(2);
+
+      // ws2 closes — attempt 1 timer (1000ms) is now pending
+      ws2.emit("close", 1006, Buffer.from(""));
+
+      // Force reconnect — should fire immediately and reset the counter
+      const ws3 = new FakeWs();
+      wsFactory.mockReturnValueOnce(ws3);
+      const handler = registerAndGetHandler();
+      await handler("");
+      expect(wsFactory).toHaveBeenCalledTimes(3); // immediate
+
+      // ws3 closes — should use attempt 0 delay (~500ms), not attempt 2 (2000ms)
+      const ws4 = new FakeWs();
+      wsFactory.mockReturnValueOnce(ws4);
+      ws3.emit("close", 1006, Buffer.from(""));
+      vi.advanceTimersByTime(499);
+      expect(wsFactory).toHaveBeenCalledTimes(3); // not yet at 499ms
+      vi.advanceTimersByTime(2);
+      expect(wsFactory).toHaveBeenCalledTimes(4); // fires at ~500ms, not 2000ms
+    } finally {
+      vi.restoreAllMocks();
+      vi.useRealTimers();
+    }
+  });
+
+  it("stale close from the old ws after forceReconnect does not schedule another reconnect", async () => {
+    vi.useFakeTimers();
+    try {
+      const newWs = new FakeWs();
+      wsFactory.mockReturnValueOnce(newWs);
+
+      const handler = registerAndGetHandler();
+      await handler("");
+
+      // newWs is the active connection now; advancing time should not trigger another connect
+      vi.advanceTimersByTime(10_000);
+      expect(wsFactory).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("prints a green Reconnecting message", async () => {
+    const handler = registerAndGetHandler();
+    wsFactory.mockReturnValueOnce(new FakeWs());
+    display.print.mockClear();
+    await handler("");
+    const printed = display.print.mock.calls.map(args => stripAnsi(String(args[0]))).join("\n");
+    expect(printed).toMatch(/[Rr]econnect/);
+  });
+});
+
 // ── Stale WebSocket handlers ──────────────────────────────────────────────────
 
 describe("stale WebSocket handlers", () => {


### PR DESCRIPTION
## Summary

- Adds `_reconnectTimer` field to track the pending backoff `setTimeout` handle so it can be cancelled
- Adds `forceReconnect()` private method that cancels any pending timer, marks the old socket as stale (by nullifying `this.ws` before terminating it), resets the backoff counter, and calls `connect()` immediately
- Registers `/worker:reconnect` command in `registerCommands()` that calls `forceReconnect()` when worker mode is active

## Test plan

- [ ] All 6 new unit tests pass (cancels timer, terminates existing ws, resets backoff counter, stale-close guard, amber message when inactive, green reconnecting message)
- [ ] All existing tests continue to pass (pre-existing failures are unrelated to this change)
- [ ] TypeScript typecheck passes with `npx tsc --noEmit`
- [ ] ESLint passes with `npm run lint` (no new warnings)

Closes #989

🤖 Generated with [Claude Code](https://claude.com/claude-code)