### PR TITLE
fix: use SELECT-first in Repo.findOrCreate to avoid burning sequence values

### DIFF
--- a/src/foreman/models/repo.ts
+++ b/src/foreman/models/repo.ts
@@ -71,16 +71,22 @@ export class Repo extends ActiveRecord {
 
   /**
    * Find or create a repo by full_name (e.g. "owner/repo").
-   * Upserts on full_name so it's safe to call on every webhook.
+   * Uses SELECT-first to avoid burning sequence values on the hot path (every webhook).
    * Returns the persisted Repo instance.
    */
   static async findOrCreate(fullName: string): Promise<Repo> {
-    const { data, error } = await db.from("repos")
-      .upsert({ full_name: fullName }, { onConflict: "full_name" })
+    const existing = await Repo.getBy("full_name", fullName) as Repo | null;
+    if (existing) return existing;
+    // Attempt INSERT; a concurrent insert may win the race.
+    const { data } = await db.from("repos")
+      .insert({ full_name: fullName })
       .select()
       .single();
-    if (error) throw error;
-    Repo.events.emit("changed");
-    return new Repo(data);
+    if (data) {
+      Repo.events.emit("changed");
+      return new Repo(data);
+    }
+    // Concurrent insert won — fetch the winner.
+    return (await Repo.getBy("full_name", fullName) as Repo)!;
   }
 }

--- a/tests/db.repos.test.ts
+++ b/tests/db.repos.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { Repo } from "../src/foreman/models/repo.js";
 import { initDb } from "../src/foreman/clients/db-client.js";
 import { createTestSupabase } from "./helpers/db.js";
@@ -33,6 +33,29 @@ describe("Repo.findOrCreate", () => {
     const a = await Repo.findOrCreate("dbr-owner/repo-a");
     const b = await Repo.findOrCreate("dbr-owner/repo-b");
     expect(a.id).not.toBe(b.id);
+  });
+
+  it("does not emit 'changed' when the repo already exists", async () => {
+    await Repo.findOrCreate("dbr-owner/repo-a");
+    const listener = vi.fn();
+    Repo.events.on("changed", listener);
+    try {
+      await Repo.findOrCreate("dbr-owner/repo-a");
+      expect(listener).not.toHaveBeenCalled();
+    } finally {
+      Repo.events.off("changed", listener);
+    }
+  });
+
+  it("emits 'changed' when a new repo is created", async () => {
+    const listener = vi.fn();
+    Repo.events.on("changed", listener);
+    try {
+      await Repo.findOrCreate("dbr-owner/repo-a");
+      expect(listener).toHaveBeenCalledOnce();
+    } finally {
+      Repo.events.off("changed", listener);
+    }
   });
 });
 

--- a/tests/helpers/memory-db.ts
+++ b/tests/helpers/memory-db.ts
@@ -139,6 +139,30 @@ export function createMemoryTaskDb(): SupabaseClient<Database> {
 
   function buildReposTable() {
     return {
+      insert(rowData: { full_name: string }) {
+        if (reposStore.has(rowData.full_name)) {
+          // Simulate a unique constraint violation — caller falls back to SELECT.
+          const sb = {
+            select() { return sb; },
+            single(): Promise<{ data: null; error: Error }> {
+              return Promise.resolve({ data: null, error: new Error("duplicate key value violates unique constraint") });
+            },
+          };
+          return sb;
+        }
+        const newRow: RepoRow = {
+          id: nextRepoId++,
+          full_name: rowData.full_name,
+          status: "new",
+          created_at: new Date().toISOString(),
+        };
+        reposStore.set(rowData.full_name, newRow);
+        const sb = {
+          select() { return sb; },
+          single() { return ok(newRow); },
+        };
+        return sb;
+      },
       upsert(rowData: { full_name: string; status?: string }, _opts?: unknown) {
         if (!reposStore.has(rowData.full_name)) {
           reposStore.set(rowData.full_name, {


### PR DESCRIPTION
## Summary

- `Repo.findOrCreate` was implemented as a Supabase `upsert` (INSERT … ON CONFLICT DO NOTHING). PostgreSQL advances the identity sequence on every INSERT attempt, even when the conflict causes the insert to be skipped — so every webhook event for an already-known repo burned a sequence value, producing large gaps in `repos.id`.
- Replace with SELECT-first: fetch the existing row with `getBy("full_name", …)` before attempting an INSERT, falling back to another SELECT if a concurrent INSERT wins the race.
- The `Repo.events.emit("changed")` call now fires only when a new repo is actually created, not on every webhook hit.

## Changes

- `src/foreman/models/repo.ts` — replace `upsert` with SELECT → INSERT → fallback SELECT
- `tests/helpers/memory-db.ts` — add `insert()` support to the in-memory repos table mock
- `tests/db.repos.test.ts` — add two tests verifying the new `changed`-event semantics

## Test plan

- [ ] `npm test` — unit + integration tests pass (DB tests require `supabase start`)
- [ ] `npm run lint` — no new errors
- [ ] `npx tsc --noEmit` — no type errors

Closes #880