### PR TITLE
Remove dead upsert() from repos table in memory-db mock

### DIFF
--- a/tests/helpers/memory-db.ts
+++ b/tests/helpers/memory-db.ts
@@ -277,23 +277,6 @@ export function createMemoryTaskDb(): SupabaseClient<Database> {
         };
         return sb;
       },
-      upsert(rowData: { full_name: string; status?: string }, _opts?: unknown) {
-        if (!reposStore.has(rowData.full_name)) {
-          reposStore.set(rowData.full_name, {
-            id: nextRepoId++,
-            full_name: rowData.full_name,
-            status: rowData.status ?? "new",
-            created_at: new Date().toISOString(),
-          });
-        }
-        const result = reposStore.get(rowData.full_name)!;
-        const sb = {
-          select() { return sb; },
-          single() { return ok(result); },
-          maybeSingle() { return ok(result); },
-        };
-        return sb;
-      },
       update(changes: Partial<RepoRow>) {
         let matchId: number | null = null;
         const thenable = {


### PR DESCRIPTION
## Summary

- Removes the `upsert` method from `buildReposTable()` in `tests/helpers/memory-db.ts`
- `db.from("repos").upsert(...)` is no longer called anywhere in production code since PR #1023 switched `Repo.findOrCreate` to SELECT-first + INSERT
- Dead code removal only — no behavior change

Closes #1025