### PR TITLE
feat: invoke commands from command line args

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,11 +30,11 @@ Follows MVC with three subdirectories:
 
 - **Models** (`models/`) — `Workspace` (git/npm workspace management), `Settings` (runtime-settable preferences: model, effort, permissions), `QueryStats` (token usage/turn counts and API cost from SDK messages), `AgentStatus` (pure state model for worker status — emits `"change"` on updates, subscribed to by `Display` for reactive redraws; also owns static git/id utilities `getCurrentBranch`, `getRemoteRepo`, `generateAgentId`)
 - **Views** (`views/`) — `Display` (TUI terminal I/O — the single doorway to stdout), `Renderer` (pure string producers, no I/O), `Input` (readline-based REPL), `Picker` (arrow-key menus), `style.ts` (terminal color/style constants)
-- **Controllers** (`controllers/`) — `AgentController` (runs queries), `WorkerController` (consolidated worker mode lifecycle: WebSocket protocol, task state, reconnect/heartbeat, `/worker:*` commands; maintains an explicit three-state model: stopped / waiting / active — `transitionToIdle()` is the canonical entry point for the waiting state), `WorkspaceController` (workspace lifecycle + `/workspace:*` slash commands; event listeners are registered once in the constructor, not in `onCreate()` or other per-operation methods), `CommandRegistry`/`CommandController` (slash command registration and dispatch), `SettingsController` (model/effort/permissions selection)
+- **Controllers** (`controllers/`) — `AgentController` (runs queries), `WorkerController` (consolidated worker mode lifecycle: WebSocket protocol, task state, reconnect/heartbeat, `/worker:*` commands; maintains an explicit three-state model: stopped / waiting / active — `transitionToIdle()` is the canonical entry point for the waiting state), `WorkspaceController` (workspace lifecycle + `/workspace:*` slash commands; event listeners are registered once in the constructor, not in `onCreate()` or other per-operation methods), `CommandRegistry`/`CommandController` (slash command registration and dispatch; commands registered with `canRunFromArgs: true` can be invoked directly from CLI args, e.g. `brunel worker:start`; `exitAfterRunFromArgs: true` causes the process to exit after the command completes rather than entering the REPL), `SettingsController` (model/effort/permissions selection)
 
 ### Shared
 
-- `src/` root — `config.ts` (unified config loader with `getConfig()` singleton), `wire.ts` (re-exports from `shared/wire.ts`)
+- `src/` root — `config.ts` (unified config loader with `getConfig()` singleton; also exports `parseCommandFromArgs()` which extracts the first positional CLI arg as a command name for direct CLI invocation), `wire.ts` (re-exports from `shared/wire.ts`)
 - `shared/` — utilities needed by both Node backend and Vite frontend: `wire.ts` (wire protocol types), `formatters.ts` (pure data-to-string helpers)
 
 ## Task lifecycle
@@ -81,7 +81,7 @@ npm start
 npm run worker
 ```
 
-Config via `.env` or `brunel.config.ts` (CLI flags also accepted). See `src/config.ts` for all options.
+Config via `.env` or `brunel.config.ts` (CLI flags also accepted). See `src/config.ts` for all options. Positional args that aren't flag values are treated as command invocations (e.g. `brunel worker:start`, `brunel workspace:prune`, `brunel worker:claim 512`).
 
 ## Useful scripts
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "tsx src/foreman/index.ts",
     "dev": "tsx watch src/foreman/index.ts",
     "repl": "tsx src/agent/index.ts",
-    "worker": "tsx src/agent/index.ts --worker-mode",
+    "worker": "tsx src/agent/index.ts worker:start",
     "test": "vitest run",
     "test:watch": "vitest",
     "smoke": "tsx tests/smoke.ts",

--- a/src/agent/controllers/command-controller.ts
+++ b/src/agent/controllers/command-controller.ts
@@ -108,6 +108,10 @@ export interface CommandEntry {
   aliasFor?: string;
   /** Alias names registered for this canonical command. */
   aliases?: string[];
+  /** Whether this command can be invoked via CLI args (e.g. `brunel worker:start`). Defaults to false. */
+  canRunFromArgs?: boolean;
+  /** Whether to exit after running this command from CLI args. Defaults to false. */
+  exitAfterRunFromArgs?: boolean;
 }
 
 /** A command name paired with a display description for autocomplete. */
@@ -332,7 +336,7 @@ export class CommandRegistry {
   }
 
   /** Register a command. In a scoped registry the name is automatically prefixed. */
-  register(name: string, opts: { description: string; handler: CommandHandler; aliases?: string[] }): void {
+  register(name: string, opts: { description: string; handler: CommandHandler; aliases?: string[]; canRunFromArgs?: boolean; exitAfterRunFromArgs?: boolean }): void {
     const fullName = this._qualify(name);
     const aliasFullNames = (opts.aliases ?? []).map(a => this._qualify(a));
 
@@ -348,6 +352,8 @@ export class CommandRegistry {
       description,
       handler: opts.handler,
       ...(aliasFullNames.length > 0 ? { aliases: aliasFullNames } : {}),
+      ...(opts.canRunFromArgs ? { canRunFromArgs: true } : {}),
+      ...(opts.exitAfterRunFromArgs ? { exitAfterRunFromArgs: true } : {}),
     });
 
     for (const aliasName of aliasFullNames) {
@@ -356,6 +362,8 @@ export class CommandRegistry {
         description: `${opts.description} (alias for ${fullName})`,
         handler: opts.handler,
         aliasFor: fullName,
+        ...(opts.canRunFromArgs ? { canRunFromArgs: true } : {}),
+        ...(opts.exitAfterRunFromArgs ? { exitAfterRunFromArgs: true } : {}),
       });
     }
   }

--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -611,6 +611,7 @@ export class WorkerController extends EventEmitter {
     registry.register("start", {
       description: "Start accepting tasks from the foreman",
       aliases: ["ready"],
+      canRunFromArgs: true,
       handler: async () => {
         if (!this._isActive) {
           await this.start();
@@ -682,6 +683,7 @@ export class WorkerController extends EventEmitter {
     });
     registry.register("claim", {
       description: "Claim a specific task by ID",
+      canRunFromArgs: true,
       handler: async (args: string) => {
         const taskId = args.trim();
         if (!taskId) {

--- a/src/agent/controllers/workspace-controller.ts
+++ b/src/agent/controllers/workspace-controller.ts
@@ -113,6 +113,8 @@ export class WorkspaceController {
 
     registry.register("prune", {
       description: "Remove orphaned worker workspace directories",
+      canRunFromArgs: true,
+      exitAfterRunFromArgs: true,
       handler: async () => {
         if (!workspace) {
           display.print(c.boldRed("Cannot prune: no workspace directory configured."));

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -8,7 +8,7 @@ import { AgentStatus } from "./models/agent-status.js";
 import { Input } from "./views/input.js";
 import { Picker } from "./views/picker.js";
 import { WorkerController } from "./controllers/worker-controller.js";
-import { loadConfig, getConfig, type BrunelConfig } from "../config.js";
+import { loadConfig, getConfig, parseCommandFromArgs, type BrunelConfig } from "../config.js";
 import { Workspace } from "./models/workspace.js";
 import { fmtError } from "../utils.js";
 import { Settings } from "./models/settings.js";
@@ -62,11 +62,12 @@ export class BrunelAgent {
   /**
    * Complete setup and enter the routing loop.
    *
-   * If runWorkerMode is true, connects to the foreman immediately (equivalent
-   * to running /worker:start on startup). Worker mode can also be toggled at
-   * runtime via /worker:start and /worker:stop. The status bar is always shown.
+   * If cliCommand is provided, the named command is executed on startup (equivalent
+   * to the user typing that slash command). Commands with exitAfterRunFromArgs will
+   * exit after running instead of entering the REPL loop. Commands must have
+   * canRunFromArgs: true to be invocable this way.
    */
-  async start(runWorkerMode: boolean): Promise<void> {
+  async start(cliCommand: { command: string; args: string } | null): Promise<void> {
     // Always detect the repo so /worker:start can use it at runtime.
     const repo = await AgentStatus.getRemoteRepo();
     // Show current branch in the minimal status bar before worker mode activates.
@@ -157,12 +158,7 @@ export class BrunelAgent {
       process.exit(0);
     });
 
-    // Start worker mode immediately if requested via --worker-mode flag.
-    if (runWorkerMode) {
-      await workerController.start();
-    }
-
-    // Status bar is always shown regardless of worker mode.
+    // Status bar is always shown.
     this.display.startPersistentBar();
 
     // Print the startup banner.
@@ -229,6 +225,42 @@ export class BrunelAgent {
         );
       },
     });
+
+    // ── CLI command dispatch ──────────────────────────────────────────────────
+    //
+    // If a command was specified in CLI args (e.g. `brunel worker:start`), execute
+    // it now using the same resolution logic as the REPL (suffix matching, aliases).
+    // Commands must have canRunFromArgs: true; exitAfterRunFromArgs: true commands
+    // exit after running instead of entering the routing loop.
+
+    if (cliCommand) {
+      const slashResult = this.controller.parseSlashCommand(`/${cliCommand.command}`);
+      if (!slashResult || slashResult.type === "unknown_command") {
+        process.stderr.write(`Error: Unknown command: ${cliCommand.command}\n`);
+        await doExit();
+        process.exit(1);
+        return;
+      }
+      if (slashResult.type === "ambiguous_command") {
+        const options = slashResult.matches.map(m => `/${m}`).join(", ");
+        process.stderr.write(`Error: Ambiguous command: ${cliCommand.command} — did you mean one of: ${options}\n`);
+        await doExit();
+        process.exit(1);
+        return;
+      }
+      const entry = registry.lookup(slashResult.name);
+      if (!entry?.canRunFromArgs) {
+        process.stderr.write(`Error: Command cannot be invoked from command line args: /${slashResult.name}\n`);
+        await doExit();
+        process.exit(1);
+        return;
+      }
+      const result = await registry.execute(slashResult.name, cliCommand.args);
+      if (result === "exit" || entry.exitAfterRunFromArgs) {
+        await doExit();
+        return;
+      }
+    }
 
     /**
      * Run a single prompt through agentController.runQuery. Notifies the session
@@ -399,6 +431,6 @@ export class BrunelAgent {
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const config = await loadConfig(process.argv);
-  const runWorkerMode = process.argv.includes("--worker-mode");
-  await new BrunelAgent(config).start(runWorkerMode);
+  const cliCommand = parseCommandFromArgs(process.argv);
+  await new BrunelAgent(config).start(cliCommand);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -197,6 +197,39 @@ function parseCliFlags(argv: string[]): Record<string, unknown> {
   return flags;
 }
 
+/** CLI flags that are boolean (take no value argument). */
+const BOOLEAN_CLI_FLAGS = new Set(["--verbose", "--dangerously-skip-permissions"]);
+
+/**
+ * Parse a command invocation from CLI argv.
+ * Returns the first positional arg (not a flag or its value) as the command name,
+ * and any subsequent positional args joined with spaces as the args string.
+ * Returns null if no positional args are present.
+ *
+ * Example: ["node", "brunel.js", "--effort", "high", "worker:claim", "512"]
+ *   → { command: "worker:claim", args: "512" }
+ */
+export function parseCommandFromArgs(argv: string[]): { command: string; args: string } | null {
+  const args = argv.slice(2);
+  const consumed = new Set<number>();
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (!arg.startsWith("--")) continue;
+    consumed.add(i);
+    if (BOOLEAN_CLI_FLAGS.has(arg)) continue;
+    // All other --flags consume the next arg as their value.
+    if (i + 1 < args.length && !args[i + 1].startsWith("--")) {
+      consumed.add(i + 1);
+      i++;
+    }
+  }
+
+  const positional = args.filter((_, i) => !consumed.has(i));
+  if (positional.length === 0) return null;
+  return { command: positional[0], args: positional.slice(1).join(" ") };
+}
+
 function readBrunelEnvVars(env: NodeJS.ProcessEnv): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   for (const key of Object.keys(BrunelConfigSchema.shape)) {

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -108,6 +108,39 @@ describe("register", () => {
     const entry = registry.registry.lookup("test:overwrite")!;
     expect(entry.description).toBe("second");
   });
+
+  it("canRunFromArgs and exitAfterRunFromArgs are stored on canonical entry", () => {
+    registry.registry.register("test:runnable", {
+      description: "Runnable",
+      handler: async () => {},
+      canRunFromArgs: true,
+      exitAfterRunFromArgs: true,
+    });
+    const entry = registry.registry.lookup("test:runnable")!;
+    expect(entry.canRunFromArgs).toBe(true);
+    expect(entry.exitAfterRunFromArgs).toBe(true);
+  });
+
+  it("canRunFromArgs defaults to undefined when not set", () => {
+    registry.registry.register("test:plain", { description: "Plain", handler: async () => {} });
+    const entry = registry.registry.lookup("test:plain")!;
+    expect(entry.canRunFromArgs).toBeUndefined();
+    expect(entry.exitAfterRunFromArgs).toBeUndefined();
+  });
+
+  it("canRunFromArgs and exitAfterRunFromArgs are propagated to alias entries", () => {
+    registry.registry.register("test:cmd", {
+      description: "Cmd",
+      aliases: ["test:c"],
+      handler: async () => {},
+      canRunFromArgs: true,
+      exitAfterRunFromArgs: true,
+    });
+    const alias = registry.registry.lookup("test:c")!;
+    expect(alias.aliasFor).toBe("test:cmd");
+    expect(alias.canRunFromArgs).toBe(true);
+    expect(alias.exitAfterRunFromArgs).toBe(true);
+  });
 });
 
 // ── scoped ────────────────────────────────────────────────────────────────────

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,7 +1,7 @@
 // tests/config.test.ts
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-import { loadConfig, VALID_PERMISSION_MODES } from "../src/config.js";
+import { loadConfig, parseCommandFromArgs, VALID_PERMISSION_MODES } from "../src/config.js";
 
 // ── Test helpers ──────────────────────────────────────────────────────────────
 
@@ -572,5 +572,73 @@ describe("effort", () => {
       const cfg = await loadConfig(["node", "repl.js", "--effort", level]);
       expect(cfg.effort).toBe(level);
     }
+  });
+});
+
+// ── parseCommandFromArgs ─────────────────────────────────────────────────────
+
+describe("parseCommandFromArgs", () => {
+  it("returns null when no positional args", () => {
+    expect(parseCommandFromArgs(["node", "brunel.js"])).toBeNull();
+  });
+
+  it("returns null when only flags are present", () => {
+    expect(parseCommandFromArgs(["node", "brunel.js", "--verbose", "--effort", "high"])).toBeNull();
+  });
+
+  it("returns command with empty args when one positional arg", () => {
+    expect(parseCommandFromArgs(["node", "brunel.js", "worker:start"])).toEqual({
+      command: "worker:start",
+      args: "",
+    });
+  });
+
+  it("returns command and args when multiple positional args", () => {
+    expect(parseCommandFromArgs(["node", "brunel.js", "worker:claim", "512"])).toEqual({
+      command: "worker:claim",
+      args: "512",
+    });
+  });
+
+  it("multiple command args are joined with spaces", () => {
+    expect(parseCommandFromArgs(["node", "brunel.js", "cmd", "arg1", "arg2"])).toEqual({
+      command: "cmd",
+      args: "arg1 arg2",
+    });
+  });
+
+  it("config flags with values are not treated as commands", () => {
+    expect(parseCommandFromArgs(["node", "brunel.js", "--effort", "high", "worker:start"])).toEqual({
+      command: "worker:start",
+      args: "",
+    });
+  });
+
+  it("--verbose flag (no value) does not consume next arg", () => {
+    expect(parseCommandFromArgs(["node", "brunel.js", "--verbose", "worker:start"])).toEqual({
+      command: "worker:start",
+      args: "",
+    });
+  });
+
+  it("--dangerously-skip-permissions flag (no value) does not consume next arg", () => {
+    expect(parseCommandFromArgs(["node", "brunel.js", "--dangerously-skip-permissions", "prune"])).toEqual({
+      command: "prune",
+      args: "",
+    });
+  });
+
+  it("config flags can appear before and after command", () => {
+    expect(parseCommandFromArgs(["node", "brunel.js", "--model", "opus", "worker:claim", "42", "--verbose"])).toEqual({
+      command: "worker:claim",
+      args: "42",
+    });
+  });
+
+  it("works with alias short names", () => {
+    expect(parseCommandFromArgs(["node", "brunel.js", "prune"])).toEqual({
+      command: "prune",
+      args: "",
+    });
   });
 });

--- a/tests/smoke.ts
+++ b/tests/smoke.ts
@@ -154,7 +154,7 @@ async function run(): Promise<void> {
     }
 
     function spawnWorker() {
-      worker = spawn("tsx", ["src/agent/index.ts", "--worker-mode"], {
+      worker = spawn("tsx", ["src/agent/index.ts", "worker:start"], {
         ...spawnOpts,
         env: { ...process.env, BRUNEL_FOREMAN_URL: foremanUrl, GITHUB_REPO: "test/test", GITHUB_TOKEN: "dummy", BRUNEL_REPO_URL: SMOKE_REPO_URL },
       });

--- a/tests/worker.main.test.ts
+++ b/tests/worker.main.test.ts
@@ -28,6 +28,7 @@ const fakeWorkspace = vi.hoisted(() => {
     checkSafety: ReturnType<typeof vi.fn>;
     reset: ReturnType<typeof vi.fn>;
     create: ReturnType<typeof vi.fn>;
+    prune: ReturnType<typeof vi.fn>;
     on: ReturnType<typeof vi.fn>;
   } = {
     dir: "/fake/workers/test-worker",
@@ -44,6 +45,7 @@ const fakeWorkspace = vi.hoisted(() => {
     }),
     reset: vi.fn().mockResolvedValue(undefined),
     create: vi.fn().mockImplementation(async () => { ws.isCreated = true; }),
+    prune: vi.fn().mockResolvedValue([]),
     on: vi.fn(),
   };
   return ws;
@@ -139,7 +141,7 @@ async function runWorkerMain(runQueryFn = vi.fn().mockResolvedValue(undefined)):
   }) as unknown as ReturnType<typeof vi.spyOn>;
 
   try {
-    await new BrunelAgent(getConfig()).start(true);
+    await new BrunelAgent(getConfig()).start({ command: "worker:start", args: "" });
     return { exitCalled: false, exitCode: undefined };
   } catch (err) {
     if (err instanceof Error && err.message === "__process_exit__") {
@@ -179,7 +181,7 @@ describe("workerMain startup banner", () => {
     const agent = new BrunelAgent(getConfig());
     const printSpy = vi.spyOn(agent.display, "print").mockImplementation(() => {});
     try {
-      await agent.start(true);
+      await agent.start({ command: "worker:start", args: "" });
     } catch (err) {
       if (!(err instanceof Error && err.message === "__process_exit__")) throw err;
     } finally {
@@ -227,7 +229,7 @@ describe("workerMain query error display", () => {
     }) as unknown as ReturnType<typeof vi.spyOn>;
 
     try {
-      await agent.start(true);
+      await agent.start({ command: "worker:start", args: "" });
     } catch (err) {
       if (!(err instanceof Error && err.message === "__process_exit__")) throw err;
     } finally {
@@ -311,7 +313,7 @@ describe("workerMain exit behavior", () => {
     }) as unknown as ReturnType<typeof vi.spyOn>;
 
     let workerDone = false;
-    const workerPromise = new BrunelAgent(getConfig()).start(true).then(
+    const workerPromise = new BrunelAgent(getConfig()).start({ command: "worker:start", args: "" }).then(
       () => { workerDone = true; },
       () => { workerDone = true; },
     );
@@ -346,7 +348,7 @@ describe("workerMain exit behavior", () => {
 
     installMocks();
     try {
-      await new BrunelAgent(getConfig()).start(true);
+      await new BrunelAgent(getConfig()).start({ command: "worker:start", args: "" });
     } catch (err) {
       if (!(err instanceof Error && err.message === "__process_exit__")) throw err;
     } finally {
@@ -406,7 +408,7 @@ describe("workerMain prompt suppression while waiting for task", () => {
     }) as unknown as ReturnType<typeof vi.spyOn>;
 
     let agentError: unknown;
-    const agentDone = new BrunelAgent(getConfig()).start(true).then(
+    const agentDone = new BrunelAgent(getConfig()).start({ command: "worker:start", args: "" }).then(
       () => {},
       (err: unknown) => { if (!(err instanceof Error && err.message === "__process_exit__")) agentError = err; },
     );
@@ -521,7 +523,7 @@ describe("workerMain input cancel discipline", () => {
     }) as unknown as ReturnType<typeof vi.spyOn>;
 
     let agentError: unknown;
-    const agentDone = new BrunelAgent(getConfig()).start(true).then(
+    const agentDone = new BrunelAgent(getConfig()).start({ command: "worker:start", args: "" }).then(
       () => {},
       (err: unknown) => {
         if (!(err instanceof Error && err.message === "__process_exit__")) agentError = err;
@@ -601,7 +603,7 @@ describe("workerMain stall retry exhaustion", () => {
     }) as unknown as ReturnType<typeof vi.spyOn>;
 
     try {
-      await agent.start(true);
+      await agent.start({ command: "worker:start", args: "" });
     } catch (err) {
       if (!(err instanceof Error && err.message === "__process_exit__")) throw err;
     } finally {
@@ -612,5 +614,112 @@ describe("workerMain stall retry exhaustion", () => {
     expect(printed).toContain("Connection stalled");
     expect(printed).toContain("giving up");
     expect(printed).toContain("retries");
+  });
+});
+
+describe("CLI command dispatch", () => {
+  let chdirSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    makeMockInput();
+    chdirSpy = vi.spyOn(process, "chdir").mockImplementation(() => {});
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    fakeWorkspace.isCreated = false;
+    vi.mocked(fakeWorkspace.destroy).mockResolvedValue(undefined);
+    vi.mocked(fakeWorkspace.checkSafety).mockResolvedValue({ uncommittedFiles: [], unpushedCommits: [], noUpstream: false });
+    vi.mocked(fakeWorkspace.create).mockImplementation(async () => { fakeWorkspace.isCreated = true; });
+    vi.mocked(fakeWorkspace.prune).mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    chdirSpy.mockRestore();
+    stderrSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it("workspace:prune exits after running (exitAfterRunFromArgs)", async () => {
+    installMocks();
+    let exitCode: number | undefined;
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((code?: number | string) => {
+      exitCode = typeof code === "number" ? code : undefined;
+      throw new Error("__process_exit__");
+    }) as unknown as ReturnType<typeof vi.spyOn>;
+
+    let startCalled = false;
+    try {
+      await new BrunelAgent(getConfig()).start({ command: "workspace:prune", args: "" });
+      startCalled = true;
+    } catch (err) {
+      if (!(err instanceof Error && err.message === "__process_exit__")) throw err;
+    } finally {
+      exitSpy.mockRestore();
+    }
+
+    // start() should return normally (no process.exit) — doExit() + return exits cleanly
+    expect(startCalled).toBe(true);
+    // ask() should NOT have been called (routing loop skipped)
+    expect(mockInput.ask).not.toHaveBeenCalled();
+  });
+
+  it("unknown command writes to stderr and exits with code 1", async () => {
+    installMocks();
+    let exitCode: number | undefined;
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((code?: number | string) => {
+      exitCode = typeof code === "number" ? code : undefined;
+      throw new Error("__process_exit__");
+    }) as unknown as ReturnType<typeof vi.spyOn>;
+
+    try {
+      await new BrunelAgent(getConfig()).start({ command: "nonexistent-command", args: "" });
+    } catch (err) {
+      if (!(err instanceof Error && err.message === "__process_exit__")) throw err;
+    } finally {
+      exitSpy.mockRestore();
+    }
+
+    expect(exitCode).toBe(1);
+    const stderrOutput = stderrSpy.mock.calls.map(([s]: [unknown]) => String(s)).join("");
+    expect(stderrOutput).toContain("Unknown command: nonexistent-command");
+  });
+
+  it("command without canRunFromArgs writes to stderr and exits with code 1", async () => {
+    installMocks();
+    let exitCode: number | undefined;
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((code?: number | string) => {
+      exitCode = typeof code === "number" ? code : undefined;
+      throw new Error("__process_exit__");
+    }) as unknown as ReturnType<typeof vi.spyOn>;
+
+    // /clear is a real registered command but does not have canRunFromArgs
+    try {
+      await new BrunelAgent(getConfig()).start({ command: "clear", args: "" });
+    } catch (err) {
+      if (!(err instanceof Error && err.message === "__process_exit__")) throw err;
+    } finally {
+      exitSpy.mockRestore();
+    }
+
+    expect(exitCode).toBe(1);
+    const stderrOutput = stderrSpy.mock.calls.map(([s]: [unknown]) => String(s)).join("");
+    expect(stderrOutput).toContain("cannot be invoked from command line args");
+  });
+
+  it("worker:start does not exit after running (enters routing loop)", async () => {
+    installMocks();
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("__process_exit__");
+    }) as unknown as ReturnType<typeof vi.spyOn>;
+
+    try {
+      await new BrunelAgent(getConfig()).start({ command: "worker:start", args: "" });
+    } catch (err) {
+      if (!(err instanceof Error && err.message === "__process_exit__")) throw err;
+    } finally {
+      exitSpy.mockRestore();
+    }
+
+    // The routing loop ran — ask() was called (got __eof__ and exited)
+    expect(mockInput.ask).toHaveBeenCalled();
   });
 });

--- a/tests/worker.mode-switching.test.ts
+++ b/tests/worker.mode-switching.test.ts
@@ -90,18 +90,20 @@ function makeMocks() {
 }
 
 /**
- * Run BrunelAgent.start(runWorkerMode) and return the agent.
+ * Run BrunelAgent.start() and return the agent.
+ * Pass workerMode=true to start in worker mode (equivalent to `brunel worker:start`).
  * Mocks process.exit so it throws instead of exiting.
  * Cleans up the persistent bar to avoid resize-listener accumulation.
  */
-async function runAgent(runWorkerMode: boolean, agentOverride?: BrunelAgent): Promise<BrunelAgent> {
+async function runAgent(workerMode: boolean, agentOverride?: BrunelAgent): Promise<BrunelAgent> {
   const exitSpy = vi.spyOn(process, "exit").mockImplementation((code?: number | string) => {
     throw new Error("__process_exit__");
   }) as unknown as ReturnType<typeof vi.spyOn>;
   const chdirSpy = vi.spyOn(process, "chdir").mockImplementation(() => {});
   const agent = agentOverride ?? new BrunelAgent(getConfig());
+  const cliCommand = workerMode ? { command: "worker:start", args: "" } : null;
   try {
-    await agent.start(runWorkerMode);
+    await agent.start(cliCommand);
   } catch (err) {
     if (!(err instanceof Error && err.message === "__process_exit__")) throw err;
   } finally {
@@ -135,7 +137,7 @@ describe("worker mode switching", () => {
     expect(capturedStatus?.workerModeActive).toBe(false);
   });
 
-  it("workerModeActive is true when --worker-mode flag is used", async () => {
+  it("workerModeActive is true when started via `brunel worker:start`", async () => {
     // Verify that worker mode was started (controller captured in list).
     // After ^D exits, stop() is called first, so workerModeActive is false at that point.
     await runAgent(true);
@@ -259,7 +261,7 @@ describe("worker mode switching", () => {
 
     let agentError: unknown;
     const agent = new BrunelAgent(getConfig());
-    const agentDone = agent.start(true).then(
+    const agentDone = agent.start({ command: "worker:start", args: "" }).then(
       () => {},
       (err: unknown) => { if (!(err instanceof Error && err.message === "__process_exit__")) agentError = err; },
     );
@@ -378,7 +380,7 @@ describe("worker mode switching", () => {
     const chdirSpy = vi.spyOn(process, "chdir").mockImplementation(() => {});
     const agent = new BrunelAgent(getConfig());
     try {
-      await agent.start(false);
+      await agent.start(null);
     } catch (err) {
       if (!(err instanceof Error && err.message === "__process_exit__")) throw err;
     } finally {


### PR DESCRIPTION
## Summary

- Adds `canRunFromArgs` and `exitAfterRunFromArgs` options to `CommandRegistry.register()`, enabling commands to be invoked directly from CLI args
- Adds `parseCommandFromArgs(argv)` to `src/config.ts` — extracts the first positional (non-flag) arg as a command name, skipping known boolean and value-taking flags
- Changes `BrunelAgent.start()` from `start(runWorkerMode: boolean)` to `start(cliCommand: { command: string; args: string } | null)`, dispatching the CLI command (if any) before entering the routing loop
- Removes the `--worker-mode` flag; replace with `brunel worker:start`
- Registers `worker:start` and `worker:claim` with `canRunFromArgs: true`; registers `workspace:prune` with `canRunFromArgs: true, exitAfterRunFromArgs: true`
- Updates `package.json` `worker` script and smoke test accordingly

## Examples

```sh
brunel worker:start        # connects to foreman, enters REPL loop
brunel workspace:prune     # prunes workspaces and exits
brunel worker:claim 512    # claims task 512, enters REPL loop
```

## Test plan

- [x] 17 new tests: `parseCommandFromArgs` in `config.test.ts`, `canRunFromArgs`/`exitAfterRunFromArgs` in `commands.test.ts`, CLI dispatch scenarios in `worker.main.test.ts`
- [x] Existing `worker.mode-switching.test.ts` updated for new signature
- [x] All unit tests pass (`npm test`)
- [x] TypeScript type check passes (`npx tsc --noEmit`)

Closes #865

🤖 Generated with [Claude Code](https://claude.com/claude-code)