### PR TITLE
docs: Phase 2 plan — GitHub App, open to all users

### DIFF
--- a/docs/2026-04-21-multi-repo-support.md
+++ b/docs/2026-04-21-multi-repo-support.md
@@ -1,6 +1,10 @@
-# Multi-repo support
+# Phase 1: Multi-repo support
+
+**Status: Complete** (May 2026)
 
 **Milestone:** [Multi-repo support](https://github.com/jasoncrawford/brunel/milestone/6)
+
+**Next:** See [`docs/2026-05-04-github-app-phase2.md`](./2026-05-04-github-app-phase2.md) for Phase 2.
 
 ## Goal
 
@@ -84,9 +88,9 @@ The current singleton TaskManager created in `src/foreman/index.ts` goes away. C
 
 ## Out of scope (Phase 1)
 
-- Other users' repos (Phase 2)
-- Easy first-time setup / `brunel init` (Phase 3)
-- GitHub App (per-repo webhooks configured manually for now)
+- Other users' repos → Phase 2
+- Easy first-time setup / zero-config worker → Phase 2 (merged with "other users")
+- GitHub App → Phase 2 (chosen as the foundation; see Phase 2 doc)
 - User accounts or credentials on the foreman
 - Private repo support (public repos only for now)
 

--- a/docs/2026-05-04-github-app-phase2.md
+++ b/docs/2026-05-04-github-app-phase2.md
@@ -99,7 +99,9 @@ Developers running their own foreman (local dev, private deployment) continue to
 
 ### Public foreman URL as default
 
-The worker's `foremanUrl` config defaults to the production Railway deployment URL. A developer with no config file connects to the public foreman automatically.
+`brunel.dev` is the production domain. It serves the foreman dashboard (same as today) and handles GitHub App webhooks at `https://brunel.dev/webhook`. The worker WebSocket connects to `wss://brunel.dev`.
+
+The worker's `foremanUrl` config defaults to `wss://brunel.dev`. A developer with no config file connects to the public foreman automatically.
 
 ---
 

--- a/docs/2026-05-04-github-app-phase2.md
+++ b/docs/2026-05-04-github-app-phase2.md
@@ -119,16 +119,17 @@ One new table and one new column:
 
 ```sql
 CREATE TABLE installations (
-  id         bigint PRIMARY KEY,   -- GitHub's installation_id
-  account_login text NOT NULL,     -- org or user login
+  id            bigserial PRIMARY KEY,
+  github_id     bigint NOT NULL UNIQUE,  -- GitHub's installation_id
+  account_login text NOT NULL,           -- org or user login
   account_type  text NOT NULL CHECK (account_type IN ('User', 'Organization')),
-  created_at timestamptz DEFAULT now()
+  created_at    timestamptz DEFAULT now()
 );
 
 ALTER TABLE repos ADD COLUMN installation_id bigint REFERENCES installations(id);
 ```
 
-`installations` tracks GitHub App installations as first-class records. A row is created when the `installation` webhook arrives and deleted on uninstall.
+`installations` tracks GitHub App installations as first-class records. A row is created when the `installation` webhook arrives and deleted on uninstall. `github_id` is the value passed to all GitHub API calls (token minting, etc.).
 
 `repos.installation_id` is a nullable FK to `installations.id`. `NULL` means the App is not in use for that repo (self-hosted / legacy). For direct-repo installs the FK is set immediately when the webhook arrives; for org-level installs it is set on first worker connection.
 
@@ -159,7 +160,7 @@ Each issue must leave the app fully functional for existing users. New App-based
 | # | Title | Depends on |
 |---|-------|------------|
 | — | Register brunel GitHub App (operator task) | — |
-| TBD | Add `installations` table (`id`, `account_login`, `account_type`) and nullable `installation_id` FK on `repos` | — |
+| TBD | Add `installations` table (`github_id`, `account_login`, `account_type`) and nullable `installation_id` FK on `repos` | — |
 | TBD | Foreman: add App credentials to config (`appId`, `appPrivateKey`, `appWebhookSecret` — all optional); `GithubClient` gains installation-token minting; falls back to personal `githubToken` when App not configured | `installation_id` column |
 | TBD | Foreman: handle `installation` / `installation_repositories` webhooks → create/delete `Installation` records; auto-activate direct-repo installs (link repos, seed tasks); for org installs store the installation only — repos linked on first worker connect; deactivate on uninstall; uses installation token for seeding | App credentials in config |
 | TBD | Foreman: worker auth via GitHub token (additive) — `worker_hello` gains optional `githubToken`; when App is configured and repo has `installation_id`, verify push access via installation token; existing `workerSecret` path unchanged | App credentials in config |

--- a/docs/2026-05-04-github-app-phase2.md
+++ b/docs/2026-05-04-github-app-phase2.md
@@ -79,7 +79,15 @@ The token only needs standard repo-collaborator scopes — no `admin:repo_hook` 
 
 Workers no longer configure their own GitHub credentials for git/API operations. Instead, the foreman generates an installation token when assigning a task and includes it in `task_assigned` (new `githubToken` field). The worker uses this token for cloning the workspace, pushing branches, and any GitHub API calls during task execution.
 
-Installation tokens expire after one hour. If a long-running task needs a fresh token, the worker can request one via a new `request_token` message (foreman responds with `token_issued`). This is a separate issue; for Phase 2 a token-in-task-assigned is sufficient.
+**Git authentication uses `http.extraHeader`, not a token-in-URL.** After cloning, the workspace sets:
+
+```bash
+git config --local http.https://github.com/.extraheader "Authorization: Bearer {token}"
+```
+
+The remote URL stays clean (`https://github.com/owner/repo.git`). This is how GitHub Actions handles `GITHUB_TOKEN` internally — the token doesn't appear in `git remote -v` or process listings.
+
+**Token refresh.** Installation tokens expire after one hour. The worker refreshes proactively on a 45-minute timer: request a new installation token from the foreman (`request_token` message; foreman responds with `token_issued`), then update the `extraHeader` config in the workspace. No error handling or retry logic needed — the refresh happens before expiry. The existing clone-URL approach in `Workspace` is replaced with the `extraHeader` pattern as part of this work.
 
 ### App not installed: clear error
 
@@ -130,10 +138,8 @@ ALTER TABLE repos ADD COLUMN installation_id bigint;
 
 ### New messages
 
-- `request_token` (worker → foreman) — request a fresh installation token (for long-running tasks)
+- `request_token` (worker → foreman) — request a fresh installation token
 - `token_issued` (foreman → worker) — response with a new installation token
-
-*(These are out of scope for the initial Phase 2 cut; document here for awareness.)*
 
 ---
 
@@ -146,7 +152,8 @@ ALTER TABLE repos ADD COLUMN installation_id bigint;
 | TBD | Handle `installation` webhooks → auto-activate repos | `installation_id` column |
 | TBD | Refactor `GithubClient` to use App installation tokens | `installation_id` column |
 | TBD | Worker auth: verify GitHub token push access via installation token | `GithubClient` refactor |
-| TBD | Provide installation token to workers in `task_assigned` | `GithubClient` refactor |
+| TBD | Provide installation token to workers in `task_assigned`; use `extraHeader` for git auth | `GithubClient` refactor |
+| TBD | Proactive token refresh: `request_token` / `token_issued`; 45-min timer in worker | token in `task_assigned` |
 | TBD | Worker: source GitHub token from `gh` / env / prompt | — |
 | TBD | Worker: handle App-not-installed error with install link | Worker auth |
 | TBD | Default public foreman URL in worker config | — |
@@ -158,7 +165,6 @@ Ready to start immediately: **`installation_id` column** and **`gh`-based token 
 
 ## Out of scope
 
-- Long-running task token refresh (`request_token` / `token_issued`)
 - Organizational App installs (install once, covers all repos in an org) — works today but not explicitly tested
 - Multiple workers per repo
 - User-facing dashboard (separate milestone)

--- a/docs/2026-05-04-github-app-phase2.md
+++ b/docs/2026-05-04-github-app-phase2.md
@@ -157,6 +157,7 @@ ALTER TABLE repos ADD COLUMN installation_id bigint;
 | TBD | Worker: source GitHub token from `gh` / env / prompt | — |
 | TBD | Worker: handle App-not-installed error with install link | Worker auth |
 | TBD | Default public foreman URL in worker config | — |
+| TBD | Dashboard basic auth (operator password) — dashboard is currently open with no auth | — |
 | TBD | Versioning + npm publish (see #892) | All of the above |
 
 Ready to start immediately: **`installation_id` column** and **`gh`-based token sourcing** (independent of each other and of everything else).
@@ -165,5 +166,5 @@ Ready to start immediately: **`installation_id` column** and **`gh`-based token 
 
 ## Out of scope
 
-- User-facing dashboard (separate milestone)
+- Per-user dashboard views (users log in with GitHub and see only their own repos/tasks — separate milestone)
 - Private repo support beyond what GitHub App permissions already provide

--- a/docs/2026-05-04-github-app-phase2.md
+++ b/docs/2026-05-04-github-app-phase2.md
@@ -1,0 +1,157 @@
+# Phase 2: GitHub App — Open to All Users
+
+**Milestone:** (to be created)
+
+## Goal
+
+Any developer can use brunel on their GitHub repos by installing the brunel GitHub App and running the CLI. No per-repo configuration, no webhook secrets to copy, no admin-scoped tokens.
+
+This milestone merges the original Phase 2 ("other users' repos") and Phase 3 ("easy first-time setup") goals. The GitHub App makes zero-config setup achievable in one milestone rather than two.
+
+**Target user flow:**
+
+```
+# One-time: install the brunel GitHub App on your repo(s) at github.com/apps/brunel
+
+npm install -g brunel
+export ANTHROPIC_API_KEY=sk-ant-...
+cd my-repo
+brunel
+```
+
+That's the complete setup. No webhook URL, no secrets, no config file.
+
+**Done when** a developer who has never used brunel can go from zero to processing issues in under five minutes, using only the steps above.
+
+---
+
+## Key decisions
+
+### GitHub App as the foundation
+
+A GitHub App replaces the current `workerSecret` + `webhookSecret` + per-operator-token architecture. The App is registered once (by the brunel operator) and gives the foreman a credential that works for any repo where a user installs it.
+
+The App declares exactly the permissions it needs (Issues, Pull Requests, Contents, Metadata — all read/write). Users see what they're granting before they install.
+
+### App installation = immediate activation
+
+When a user installs the brunel GitHub App on a repo, the foreman receives an `installation` webhook and activates the repo automatically — seeding tasks from open `brunel:ready` issues. No worker needs to be running for this to happen.
+
+This is intentional: installing the App is a clear expression of intent to use brunel on that repo. The existing worker-driven activation prompt (`activate_repo` / `repo_activated`) is preserved for self-hosted setups (local dev, private foreman) where the App is not in use.
+
+When the App is later uninstalled, the repo is deactivated. Existing task records are preserved; new tasks stop being created and workers stop being assigned.
+
+### Installation tokens replace all personal tokens
+
+The foreman uses the App's private key to mint short-lived installation access tokens (1 hour TTL) scoped to individual repos. These replace the operator's personal `githubToken` for all foreman-side GitHub API calls:
+
+- Fetching open issues on activation
+- Checking blocker issue states
+- Verifying worker push access
+
+Workers receive an installation token in `task_assigned` and use it for git operations and any GitHub API calls they need to make during task execution. Workers no longer need a personal GitHub token in their config for anything repo-specific.
+
+The `githubToken` field in foreman config is replaced by `appPrivateKey` + `appId`. The foreman never touches a personal token.
+
+### Worker identity: GitHub token verification
+
+Any worker can claim to work on any repo — the foreman needs to verify the worker actually has push access. The mechanism: the worker sends its GitHub token in `worker_hello`; the foreman calls `GET /repos/{owner}/{repo}/collaborators/{username}/permission` using the installation token and confirms the user has at least `push` access.
+
+The `workerSecret` shared secret is removed. GitHub token verification is naturally repo-scoped and doesn't require a secret to be distributed to users.
+
+### Worker GitHub token sourcing
+
+Workers obtain their GitHub token silently in this order:
+
+1. `gh auth token` — zero config if the GitHub CLI is installed and authenticated (covers most developers)
+2. `GITHUB_TOKEN` or `GH_TOKEN` environment variable
+3. Prompt the user, with a link to create a fine-grained PAT with the required scopes (`contents: read/write`, `pull_requests: read/write`, `issues: read/write`, `metadata: read`)
+
+The token only needs standard repo-collaborator scopes — no `admin:repo_hook` or elevated permissions, since the App handles webhooks.
+
+### Foreman provides tokens to workers
+
+Workers no longer configure their own GitHub credentials for git/API operations. Instead, the foreman generates an installation token when assigning a task and includes it in `task_assigned` (new `githubToken` field). The worker uses this token for cloning the workspace, pushing branches, and any GitHub API calls during task execution.
+
+Installation tokens expire after one hour. If a long-running task needs a fresh token, the worker can request one via a new `request_token` message (foreman responds with `token_issued`). This is a separate issue; for Phase 2 a token-in-task-assigned is sufficient.
+
+### App not installed: clear error
+
+When a worker connects claiming a repo where the App is not installed, the foreman sends a non-fatal `foreman_error` with a message and install URL. The worker displays it clearly:
+
+```
+Brunel is not installed on owner/my-repo.
+Install it at: https://github.com/apps/brunel
+Then run brunel again.
+```
+
+The worker exits worker mode and returns to the REPL.
+
+### Self-hosted / local dev
+
+Developers running their own foreman (local dev, private deployment) continue to use the existing flow: `workerSecret` for auth, manual webhook setup via smee, and the worker-driven activation prompt. Nothing in this milestone breaks the existing single-user self-hosted setup.
+
+### Public foreman URL as default
+
+The worker's `foremanUrl` config defaults to the production Railway deployment URL. A developer with no config file connects to the public foreman automatically.
+
+---
+
+## DB changes
+
+One new column on `repos`:
+
+```sql
+ALTER TABLE repos ADD COLUMN installation_id bigint;
+```
+
+`installation_id` is the GitHub App installation ID for this repo. `NULL` means the App is not installed (self-hosted / legacy repos).
+
+---
+
+## Wire protocol changes
+
+### `worker_hello` (worker → foreman)
+
+- Add `githubToken: string` — the worker's personal GitHub token for identity verification
+- Remove `workerSecret?: string`
+
+### `task_assigned` (foreman → worker)
+
+- Add `githubToken: string` — an installation access token for the assigned repo, for use in git and API calls
+
+### New messages
+
+- `request_token` (worker → foreman) — request a fresh installation token (for long-running tasks)
+- `token_issued` (foreman → worker) — response with a new installation token
+
+*(These are out of scope for the initial Phase 2 cut; document here for awareness.)*
+
+---
+
+## Issue breakdown
+
+| # | Title | Depends on |
+|---|-------|------------|
+| — | Register brunel GitHub App (operator task) | — |
+| TBD | Add `installation_id` to `repos` table | — |
+| TBD | Handle `installation` webhooks → auto-activate repos | `installation_id` column |
+| TBD | Refactor `GithubClient` to use App installation tokens | `installation_id` column |
+| TBD | Worker auth: verify GitHub token push access via installation token | `GithubClient` refactor |
+| TBD | Provide installation token to workers in `task_assigned` | `GithubClient` refactor |
+| TBD | Worker: source GitHub token from `gh` / env / prompt | — |
+| TBD | Worker: handle App-not-installed error with install link | Worker auth |
+| TBD | Default public foreman URL in worker config | — |
+| TBD | Versioning + npm publish (see #892) | All of the above |
+
+Ready to start immediately: **`installation_id` column** and **`gh`-based token sourcing** (independent of each other and of everything else).
+
+---
+
+## Out of scope
+
+- Long-running task token refresh (`request_token` / `token_issued`)
+- Organizational App installs (install once, covers all repos in an org) — works today but not explicitly tested
+- Multiple workers per repo
+- User-facing dashboard (separate milestone)
+- Private repo support beyond what GitHub App permissions already provide

--- a/docs/2026-05-04-github-app-phase2.md
+++ b/docs/2026-05-04-github-app-phase2.md
@@ -165,7 +165,6 @@ Ready to start immediately: **`installation_id` column** and **`gh`-based token 
 
 ## Out of scope
 
-- Organizational App installs (install once, covers all repos in an org) — works today but not explicitly tested
 - Multiple workers per repo
 - User-facing dashboard (separate milestone)
 - Private repo support beyond what GitHub App permissions already provide

--- a/docs/2026-05-04-github-app-phase2.md
+++ b/docs/2026-05-04-github-app-phase2.md
@@ -39,9 +39,9 @@ Activation is triggered differently depending on how the App was installed:
 
 **Direct repo install** (user selects specific repos during App installation): the foreman receives an `installation` webhook listing exactly which repos were added and activates them immediately — seeding tasks from open `brunel:ready` issues. No worker needs to be running. This is a clear expression of intent to use brunel on those repos.
 
-**Org-level install** ("All repositories" or selected org repos): the foreman records the installation but does not activate any repos eagerly. An org "all repositories" install could cover hundreds of repos the user has no intention of running brunel on. Instead, activation is deferred: the first time a worker connects claiming a repo under that org, the foreman calls `GET /repos/{owner}/{repo}/installation` to confirm the App is installed, then activates that repo and seeds its tasks at that point.
+**Org-level install** ("All repositories" or selected org repos): the foreman records the installation in the `installations` table but does not activate any repos eagerly. An org "all repositories" install could cover hundreds of repos the user has no intention of running brunel on. Instead, activation is deferred: the first time a worker connects claiming a repo under that org, the foreman looks up the installation by `account_login`, links the repo (`repos.installation_id`), activates it, and seeds its tasks — no GitHub API call needed.
 
-In both cases, `installation_id` is stored on the `Repo` row when the repo is first seen — either from the `installation` webhook (direct install) or from the API response on first worker connection (org install).
+In both cases, the `Installation` record is created when the `installation` webhook arrives. The `Repo` row is linked to it (via `installation_id` FK) either immediately on the webhook (direct install) or on first worker connection (org install).
 
 When the App is later uninstalled, the repo is deactivated. Existing task records are preserved; new tasks stop being created and workers stop being assigned.
 
@@ -115,13 +115,22 @@ The worker's `foremanUrl` config defaults to `wss://brunel.dev`. A developer wit
 
 ## DB changes
 
-One new column on `repos`:
+One new table and one new column:
 
 ```sql
-ALTER TABLE repos ADD COLUMN installation_id bigint;
+CREATE TABLE installations (
+  id         bigint PRIMARY KEY,   -- GitHub's installation_id
+  account_login text NOT NULL,     -- org or user login
+  account_type  text NOT NULL CHECK (account_type IN ('User', 'Organization')),
+  created_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE repos ADD COLUMN installation_id bigint REFERENCES installations(id);
 ```
 
-`installation_id` is the GitHub App installation ID for this repo. `NULL` means the App is not installed (self-hosted / legacy repos).
+`installations` tracks GitHub App installations as first-class records. A row is created when the `installation` webhook arrives and deleted on uninstall.
+
+`repos.installation_id` is a nullable FK to `installations.id`. `NULL` means the App is not in use for that repo (self-hosted / legacy). For direct-repo installs the FK is set immediately when the webhook arrives; for org-level installs it is set on first worker connection.
 
 ---
 
@@ -150,9 +159,9 @@ Each issue must leave the app fully functional for existing users. New App-based
 | # | Title | Depends on |
 |---|-------|------------|
 | — | Register brunel GitHub App (operator task) | — |
-| TBD | Add `installation_id` to `repos` table (nullable — NULL means App not in use) | — |
+| TBD | Add `installations` table (`id`, `account_login`, `account_type`) and nullable `installation_id` FK on `repos` | — |
 | TBD | Foreman: add App credentials to config (`appId`, `appPrivateKey`, `appWebhookSecret` — all optional); `GithubClient` gains installation-token minting; falls back to personal `githubToken` when App not configured | `installation_id` column |
-| TBD | Foreman: handle `installation` / `installation_repositories` webhooks → store `installation_id`, auto-activate direct-repo installs, deactivate on uninstall; uses installation token for seeding (personal token fallback for self-hosted) | App credentials in config |
+| TBD | Foreman: handle `installation` / `installation_repositories` webhooks → create/delete `Installation` records; auto-activate direct-repo installs (link repos, seed tasks); for org installs store the installation only — repos linked on first worker connect; deactivate on uninstall; uses installation token for seeding | App credentials in config |
 | TBD | Foreman: worker auth via GitHub token (additive) — `worker_hello` gains optional `githubToken`; when App is configured and repo has `installation_id`, verify push access via installation token; existing `workerSecret` path unchanged | App credentials in config |
 | TBD | Foreman: provide installation token to workers — add `githubToken` to `task_assigned` when App is configured; worker switches git auth from token-in-URL to `extraHeader` (works for both personal token and installation token); older workers that ignore the new field continue working | Worker auth |
 | TBD | Worker: proactive token refresh — `request_token` / `token_issued` wire messages; worker starts 45-min timer when `task_assigned.githubToken` is present; no-op for self-hosted workers that don't receive one | token in `task_assigned` |

--- a/docs/2026-05-04-github-app-phase2.md
+++ b/docs/2026-05-04-github-app-phase2.md
@@ -157,7 +157,6 @@ ALTER TABLE repos ADD COLUMN installation_id bigint;
 | TBD | Worker: source GitHub token from `gh` / env / prompt | — |
 | TBD | Worker: handle App-not-installed error with install link | Worker auth |
 | TBD | Default public foreman URL in worker config | — |
-| TBD | Dashboard basic auth (operator password) — dashboard is currently open with no auth | — |
 | TBD | Versioning + npm publish (see #892) | All of the above |
 
 Ready to start immediately: **`installation_id` column** and **`gh`-based token sourcing** (independent of each other and of everything else).
@@ -168,3 +167,5 @@ Ready to start immediately: **`installation_id` column** and **`gh`-based token 
 
 - Per-user dashboard views (users log in with GitHub and see only their own repos/tasks — separate milestone)
 - Private repo support beyond what GitHub App permissions already provide
+
+The dashboard at brunel.dev is intentionally public and read-only. Users who need privacy can self-host.

--- a/docs/2026-05-04-github-app-phase2.md
+++ b/docs/2026-05-04-github-app-phase2.md
@@ -165,6 +165,5 @@ Ready to start immediately: **`installation_id` column** and **`gh`-based token 
 
 ## Out of scope
 
-- Multiple workers per repo
 - User-facing dashboard (separate milestone)
 - Private repo support beyond what GitHub App permissions already provide

--- a/docs/2026-05-04-github-app-phase2.md
+++ b/docs/2026-05-04-github-app-phase2.md
@@ -77,7 +77,7 @@ The token only needs standard repo-collaborator scopes — no `admin:repo_hook` 
 
 ### Foreman provides tokens to workers
 
-Workers no longer configure their own GitHub credentials for git/API operations. Instead, the foreman generates an installation token when assigning a task and includes it in `task_assigned` (new `githubToken` field). The worker uses this token for cloning the workspace, pushing branches, and any GitHub API calls during task execution.
+Workers no longer configure their own GitHub credentials for git/API operations. Instead, the foreman generates an installation token when sending `hello_ack` (new `githubToken` field) and the worker holds it for the duration of the connection. The worker uses this token for cloning the workspace, pushing branches, and any GitHub API calls during task execution.
 
 **Git authentication uses `http.extraHeader`, not a token-in-URL.** After cloning, the workspace sets:
 
@@ -87,7 +87,7 @@ git config --local http.https://github.com/.extraheader "Authorization: Bearer {
 
 The remote URL stays clean (`https://github.com/owner/repo.git`). This is how GitHub Actions handles `GITHUB_TOKEN` internally — the token doesn't appear in `git remote -v` or process listings.
 
-**Token refresh.** Installation tokens expire after one hour. The worker refreshes proactively on a 45-minute timer: request a new installation token from the foreman (`request_token` message; foreman responds with `token_issued`), then update the `extraHeader` config in the workspace. No error handling or retry logic needed — the refresh happens before expiry. The existing clone-URL approach in `Workspace` is replaced with the `extraHeader` pattern as part of this work.
+**Token refresh.** Installation tokens expire after one hour. The worker refreshes proactively on a 45-minute timer: request a new installation token from the foreman (`request_token` message; foreman responds with `token_issued`), then update the `extraHeader` config in the workspace. No error handling or retry logic needed — the refresh happens before expiry. This means the token is always valid when a new task arrives, even if the worker waited hours between tasks. The existing clone-URL approach in `Workspace` is replaced with the `extraHeader` pattern as part of this work.
 
 ### App not installed: clear error
 
@@ -142,9 +142,9 @@ ALTER TABLE repos ADD COLUMN installation_id bigint REFERENCES installations(id)
 - Add `githubToken: string` — the worker's personal GitHub token for identity verification
 - Remove `workerSecret?: string`
 
-### `task_assigned` (foreman → worker)
+### `hello_ack` (foreman → worker)
 
-- Add `githubToken: string` — an installation access token for the assigned repo, for use in git and API calls
+- Add `githubToken?: string` — an installation access token for the repo, for use in git and API calls; omitted when App is not configured (self-hosted)
 
 ### New messages
 
@@ -164,8 +164,8 @@ Each issue must leave the app fully functional for existing users. New App-based
 | TBD | Foreman: add App credentials to config (`appId`, `appPrivateKey`, `appWebhookSecret` — all optional); `GithubClient` gains installation-token minting; falls back to personal `githubToken` when App not configured | `installation_id` column |
 | TBD | Foreman: handle `installation` / `installation_repositories` webhooks → create/delete `Installation` records; auto-activate direct-repo installs (link repos, seed tasks); for org installs store the installation only — repos linked on first worker connect; deactivate on uninstall; uses installation token for seeding | App credentials in config |
 | TBD | Foreman: worker auth via GitHub token (additive) — `worker_hello` gains optional `githubToken`; when App is configured and repo has `installation_id`, verify push access via installation token; existing `workerSecret` path unchanged | App credentials in config |
-| TBD | Foreman: provide installation token to workers — add `githubToken` to `task_assigned` when App is configured; worker switches git auth from token-in-URL to `extraHeader` (works for both personal token and installation token); older workers that ignore the new field continue working | Worker auth |
-| TBD | Worker: proactive token refresh — `request_token` / `token_issued` wire messages; worker starts 45-min timer when `task_assigned.githubToken` is present; no-op for self-hosted workers that don't receive one | token in `task_assigned` |
+| TBD | Foreman: provide installation token to workers — add `githubToken` to `hello_ack` when App is configured; worker switches git auth from token-in-URL to `extraHeader` (works for both personal token and installation token); older workers that ignore the new field continue working | Worker auth |
+| TBD | Worker: proactive token refresh — `request_token` / `token_issued` wire messages; worker starts 45-min timer when `hello_ack.githubToken` is present; no-op for self-hosted workers that don't receive one | token in `hello_ack` |
 | TBD | Worker: source GitHub token from `gh auth token` → env var → prompt (additive — existing env var / config still works) | — |
 | TBD | Worker: handle App-not-installed `foreman_error` — display message and install link; older workers treat it as a generic error (acceptable) | Worker auth |
 | TBD | Worker: default `foremanUrl` to `wss://brunel.dev` (existing explicit config overrides it) | — |

--- a/docs/2026-05-04-github-app-phase2.md
+++ b/docs/2026-05-04-github-app-phase2.md
@@ -47,7 +47,7 @@ When the App is later uninstalled, the repo is deactivated. Existing task record
 
 The existing worker-driven activation prompt (`activate_repo` / `repo_activated`) is preserved for self-hosted setups (local dev, private foreman) where the App is not in use.
 
-### Installation tokens replace all personal tokens
+### Installation tokens for foreman API calls
 
 The foreman uses the App's private key to mint short-lived installation access tokens (1 hour TTL) scoped to individual repos. These replace the operator's personal `githubToken` for all foreman-side GitHub API calls:
 
@@ -55,9 +55,7 @@ The foreman uses the App's private key to mint short-lived installation access t
 - Checking blocker issue states
 - Verifying worker push access
 
-Workers receive an installation token in `task_assigned` and use it for git operations and any GitHub API calls they need to make during task execution. Workers no longer need a personal GitHub token in their config for anything repo-specific.
-
-The `githubToken` field in foreman config is replaced by `appPrivateKey` + `appId`. The foreman never touches a personal token.
+The `githubToken` field in foreman config is replaced by `appPrivateKey` + `appId`. Workers are not involved — they use their own personal GitHub token for git operations and any API calls they make during task execution.
 
 ### Worker identity: GitHub token verification
 
@@ -75,9 +73,9 @@ Workers obtain their GitHub token silently in this order:
 
 The token only needs standard repo-collaborator scopes — no `admin:repo_hook` or elevated permissions, since the App handles webhooks.
 
-### Foreman provides tokens to workers
+### Worker git authentication
 
-Workers no longer configure their own GitHub credentials for git/API operations. Instead, the foreman generates an installation token when sending `hello_ack` (new `githubToken` field) and the worker holds it for the duration of the connection. The worker uses this token for cloning the workspace, pushing branches, and any GitHub API calls during task execution.
+Workers use their own personal GitHub token (already obtained for identity verification) for git operations and any GitHub API calls they make during task execution.
 
 **Git authentication uses `http.extraHeader`, not a token-in-URL.** After cloning, the workspace sets:
 
@@ -85,9 +83,7 @@ Workers no longer configure their own GitHub credentials for git/API operations.
 git config --local http.https://github.com/.extraheader "Authorization: Bearer {token}"
 ```
 
-The remote URL stays clean (`https://github.com/owner/repo.git`). This is how GitHub Actions handles `GITHUB_TOKEN` internally — the token doesn't appear in `git remote -v` or process listings.
-
-**Token refresh.** Installation tokens expire after one hour. The worker refreshes proactively on a 45-minute timer: request a new installation token from the foreman (`request_token` message; foreman responds with `token_issued`), then update the `extraHeader` config in the workspace. No error handling or retry logic needed — the refresh happens before expiry. This means the token is always valid when a new task arrives, even if the worker waited hours between tasks. The existing clone-URL approach in `Workspace` is replaced with the `extraHeader` pattern as part of this work.
+The remote URL stays clean (`https://github.com/owner/repo.git`). This is how GitHub Actions handles `GITHUB_TOKEN` internally — the token doesn't appear in `git remote -v` or process listings. The existing clone-URL approach in `Workspace` is replaced with this pattern as part of this work.
 
 ### App not installed: clear error
 
@@ -142,15 +138,6 @@ ALTER TABLE repos ADD COLUMN installation_id bigint REFERENCES installations(id)
 - Add `githubToken: string` — the worker's personal GitHub token for identity verification
 - Remove `workerSecret?: string`
 
-### `hello_ack` (foreman → worker)
-
-- Add `githubToken?: string` — an installation access token for the repo, for use in git and API calls; omitted when App is not configured (self-hosted)
-
-### New messages
-
-- `request_token` (worker → foreman) — request a fresh installation token
-- `token_issued` (foreman → worker) — response with a new installation token
-
 ---
 
 ## Issue breakdown
@@ -164,9 +151,7 @@ Each issue must leave the app fully functional for existing users. New App-based
 | TBD | Foreman: add App credentials to config (`appId`, `appPrivateKey`, `appWebhookSecret` — all optional); `GithubClient` gains installation-token minting; falls back to personal `githubToken` when App not configured | `installation_id` column |
 | TBD | Foreman: handle `installation` / `installation_repositories` webhooks → create/delete `Installation` records; auto-activate direct-repo installs (link repos, seed tasks); for org installs store the installation only — repos linked on first worker connect; deactivate on uninstall; uses installation token for seeding | App credentials in config |
 | TBD | Foreman: worker auth via GitHub token (additive) — `worker_hello` gains optional `githubToken`; when App is configured and repo has `installation_id`, verify push access via installation token; existing `workerSecret` path unchanged | App credentials in config |
-| TBD | Foreman: provide installation token to workers — add `githubToken` to `hello_ack` when App is configured; worker switches git auth from token-in-URL to `extraHeader` (works for both personal token and installation token); older workers that ignore the new field continue working | Worker auth |
-| TBD | Worker: proactive token refresh — `request_token` / `token_issued` wire messages; worker starts 45-min timer when `hello_ack.githubToken` is present; no-op for self-hosted workers that don't receive one | token in `hello_ack` |
-| TBD | Worker: source GitHub token from `gh auth token` → env var → prompt (additive — existing env var / config still works) | — |
+| TBD | Worker: source GitHub token from `gh auth token` → env var → prompt; switch git auth from token-in-URL to `extraHeader` (additive — existing env var / config still works) | — |
 | TBD | Worker: handle App-not-installed `foreman_error` — display message and install link; older workers treat it as a generic error (acceptable) | Worker auth |
 | TBD | Worker: default `foremanUrl` to `wss://brunel.dev` (existing explicit config overrides it) | — |
 | TBD | Versioning + npm publish (see #892) | All of the above |

--- a/docs/2026-05-04-github-app-phase2.md
+++ b/docs/2026-05-04-github-app-phase2.md
@@ -33,13 +33,19 @@ A GitHub App replaces the current `workerSecret` + `webhookSecret` + per-operato
 
 The App declares exactly the permissions it needs (Issues, Pull Requests, Contents, Metadata — all read/write). Users see what they're granting before they install.
 
-### App installation = immediate activation
+### App installation and activation
 
-When a user installs the brunel GitHub App on a repo, the foreman receives an `installation` webhook and activates the repo automatically — seeding tasks from open `brunel:ready` issues. No worker needs to be running for this to happen.
+Activation is triggered differently depending on how the App was installed:
 
-This is intentional: installing the App is a clear expression of intent to use brunel on that repo. The existing worker-driven activation prompt (`activate_repo` / `repo_activated`) is preserved for self-hosted setups (local dev, private foreman) where the App is not in use.
+**Direct repo install** (user selects specific repos during App installation): the foreman receives an `installation` webhook listing exactly which repos were added and activates them immediately — seeding tasks from open `brunel:ready` issues. No worker needs to be running. This is a clear expression of intent to use brunel on those repos.
+
+**Org-level install** ("All repositories" or selected org repos): the foreman records the installation but does not activate any repos eagerly. An org "all repositories" install could cover hundreds of repos the user has no intention of running brunel on. Instead, activation is deferred: the first time a worker connects claiming a repo under that org, the foreman calls `GET /repos/{owner}/{repo}/installation` to confirm the App is installed, then activates that repo and seeds its tasks at that point.
+
+In both cases, `installation_id` is stored on the `Repo` row when the repo is first seen — either from the `installation` webhook (direct install) or from the API response on first worker connection (org install).
 
 When the App is later uninstalled, the repo is deactivated. Existing task records are preserved; new tasks stop being created and workers stop being assigned.
+
+The existing worker-driven activation prompt (`activate_repo` / `repo_activated`) is preserved for self-hosted setups (local dev, private foreman) where the App is not in use.
 
 ### Installation tokens replace all personal tokens
 

--- a/docs/2026-05-04-github-app-phase2.md
+++ b/docs/2026-05-04-github-app-phase2.md
@@ -145,21 +145,23 @@ ALTER TABLE repos ADD COLUMN installation_id bigint;
 
 ## Issue breakdown
 
+Each issue must leave the app fully functional for existing users. New App-based pathways are additive alongside the existing `workerSecret` / personal-token pathways; neither is removed during this milestone (cleanup is a separate decision).
+
 | # | Title | Depends on |
 |---|-------|------------|
 | — | Register brunel GitHub App (operator task) | — |
-| TBD | Add `installation_id` to `repos` table | — |
-| TBD | Handle `installation` webhooks → auto-activate repos | `installation_id` column |
-| TBD | Refactor `GithubClient` to use App installation tokens | `installation_id` column |
-| TBD | Worker auth: verify GitHub token push access via installation token | `GithubClient` refactor |
-| TBD | Provide installation token to workers in `task_assigned`; use `extraHeader` for git auth | `GithubClient` refactor |
-| TBD | Proactive token refresh: `request_token` / `token_issued`; 45-min timer in worker | token in `task_assigned` |
-| TBD | Worker: source GitHub token from `gh` / env / prompt | — |
-| TBD | Worker: handle App-not-installed error with install link | Worker auth |
-| TBD | Default public foreman URL in worker config | — |
+| TBD | Add `installation_id` to `repos` table (nullable — NULL means App not in use) | — |
+| TBD | Foreman: add App credentials to config (`appId`, `appPrivateKey`, `appWebhookSecret` — all optional); `GithubClient` gains installation-token minting; falls back to personal `githubToken` when App not configured | `installation_id` column |
+| TBD | Foreman: handle `installation` / `installation_repositories` webhooks → store `installation_id`, auto-activate direct-repo installs, deactivate on uninstall; uses installation token for seeding (personal token fallback for self-hosted) | App credentials in config |
+| TBD | Foreman: worker auth via GitHub token (additive) — `worker_hello` gains optional `githubToken`; when App is configured and repo has `installation_id`, verify push access via installation token; existing `workerSecret` path unchanged | App credentials in config |
+| TBD | Foreman: provide installation token to workers — add `githubToken` to `task_assigned` when App is configured; worker switches git auth from token-in-URL to `extraHeader` (works for both personal token and installation token); older workers that ignore the new field continue working | Worker auth |
+| TBD | Worker: proactive token refresh — `request_token` / `token_issued` wire messages; worker starts 45-min timer when `task_assigned.githubToken` is present; no-op for self-hosted workers that don't receive one | token in `task_assigned` |
+| TBD | Worker: source GitHub token from `gh auth token` → env var → prompt (additive — existing env var / config still works) | — |
+| TBD | Worker: handle App-not-installed `foreman_error` — display message and install link; older workers treat it as a generic error (acceptable) | Worker auth |
+| TBD | Worker: default `foremanUrl` to `wss://brunel.dev` (existing explicit config overrides it) | — |
 | TBD | Versioning + npm publish (see #892) | All of the above |
 
-Ready to start immediately: **`installation_id` column** and **`gh`-based token sourcing** (independent of each other and of everything else).
+Ready to start immediately: **`installation_id` column**, **`gh`-based token sourcing**, and **default foreman URL** (all independent of each other and of everything else).
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `docs/2026-05-04-github-app-phase2.md` — the Phase 2 planning document
- Marks Phase 1 complete in `docs/2026-04-21-multi-repo-support.md` and links forward

## What's in the Phase 2 plan

Phase 2 merges the original "other users' repos" and "easy first-time setup" goals into one milestone, with a GitHub App as the foundation.

Key decisions documented:
- App installation → immediate repo activation (no worker-driven confirmation prompt needed)
- Installation tokens replace all personal GitHub tokens on the foreman side
- Workers receive a token in `task_assigned` for git/API operations
- Worker identity verified via GitHub token + collaborator access check
- Worker token sourced from `gh auth token` → env vars → prompt
- Self-hosted / local dev flow preserved unchanged
- Public foreman URL baked into CLI as default

**Target UX:**
```
# Install brunel GitHub App at github.com/apps/brunel (one click)
npm install -g brunel
export ANTHROPIC_API_KEY=...
cd my-repo && brunel
```

Issue numbers are TBD — this PR is the planning doc; issues to be filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)