### PR TITLE
Remove duplicate Repo.getByFullName (use findByFullName instead)

### DIFF
--- a/src/foreman/controllers/http-server.ts
+++ b/src/foreman/controllers/http-server.ts
@@ -147,7 +147,7 @@ export class HttpServer {
   app.get("/api/repos/:owner/:repo", async (c) => {
     try {
       const fullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
-      const repo = await Repo.getByFullName(fullName);
+      const repo = await Repo.findByFullName(fullName);
       if (!repo) return c.json({ error: "not found" }, 404);
       return c.json(repo.toWire());
     } catch (err) {

--- a/src/foreman/models/repo.ts
+++ b/src/foreman/models/repo.ts
@@ -44,10 +44,6 @@ export class Repo extends ActiveRecord {
     return super.get(id) as Promise<Repo | null>;
   }
 
-  static async getByFullName(fullName: string): Promise<Repo | null> {
-    return super.getBy("full_name", fullName) as Promise<Repo | null>;
-  }
-
   static async list(): Promise<Repo[]> {
     return super.list() as Promise<Repo[]>;
   }


### PR DESCRIPTION
## Summary

- Updated `http-server.ts` to call `Repo.findByFullName` instead of `Repo.getByFullName`
- Removed `Repo.getByFullName` from the model — it was identical to the pre-existing `findByFullName`

`findByFullName` matches the project naming convention (`findOrCreate`, `findByFullName`).

Closes #1067