### PR TITLE
fix: restore disconnected status and REPL prompt after fatal foreman_error

### DIFF
--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -915,7 +915,11 @@ export class WorkerController extends EventEmitter {
     ws.on("close", (code: number, _reason: Buffer) => {
       clearPingTimer(); // always clean up the ping timer when this socket closes
       if (ws !== this.ws) return; // stale close from a previous connection
-      if (this._stopped) return; // fatal error received; don't reconnect
+      if (this._stopped) {
+        // Fatal error path: update status but skip reconnect scheduling.
+        this.agentStatus.update({ connectionStatus: "disconnected", disconnectCode: code });
+        return;
+      }
       // Full Jitter (Brooker 2015): spread = entire [0, cap] window at high attempt counts.
       const delay = Math.random() * Math.min(this._activeMaxReconnectDelayMs, 1000 * Math.pow(2, this.reconnectAttempts));
       this.reconnectAttempts++;
@@ -961,6 +965,8 @@ export class WorkerController extends EventEmitter {
     if (msg.type === "foreman_error") {
       if (msg.fatal) {
         this._stopped = true;
+        this._isActive = false;
+        this.agentStatus.setWorkerModeActive(false);
         this.currentAc?.abort(); // abort any running query immediately
         this.ws?.close();
         this.emit("fatal");

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1657,6 +1657,17 @@ describe("foreman_error", () => {
     sendMsg(fakeWs, { type: "foreman_error", message: "Transient", fatal: false });
     expect(onFatal).not.toHaveBeenCalled();
   });
+
+  it("fatal: sets connectionStatus to 'disconnected' after ws closes", () => {
+    sendMsg(fakeWs, { type: "foreman_error", message: "Fatal error", fatal: true });
+    // FakeWs.close() fires the close event synchronously; connectionStatus must be updated
+    expect(sb.connectionStatus).toBe("disconnected");
+  });
+
+  it("fatal: sets isActive to false so the routing loop shows the REPL prompt", () => {
+    sendMsg(fakeWs, { type: "foreman_error", message: "Fatal error", fatal: true });
+    expect(session.isActive).toBe(false);
+  });
 });
 
 // ── workspace slash commands via WorkerController ─────────────────────────────


### PR DESCRIPTION
## Summary

- In the close handler, update `connectionStatus` to `"disconnected"` even when `_stopped` is true (just skip scheduling the reconnect timer), so the status bar doesn't stay stuck at the pre-error state (e.g. "handshaking")
- In the fatal error handler, set `_isActive = false` and call `agentStatus.setWorkerModeActive(false)` before emitting `"fatal"`, so the routing loop's `listenForInput()` sees `workerController.isActive === false` and shows `"\n> "` instead of the empty worker-waiting prompt

## Test plan

- [x] Added `fatal: sets connectionStatus to 'disconnected' after ws closes` — verifies Bug #1 fix
- [x] Added `fatal: sets isActive to false so the routing loop shows the REPL prompt` — verifies Bug #2 fix
- [x] All 211 worker tests pass; full suite (1866 non-DB tests) clean

Closes #1065

🤖 Generated with [Claude Code](https://claude.com/claude-code)