### PR TITLE
fix: remove githubToken startup requirement from foreman

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -336,5 +336,5 @@ export async function loadConfig(
  * that need default values (e.g. taskLabel) without a real GitHub repo or token.
  */
 export function loadDefaultConfig(): Promise<BrunelConfig> {
-  return loadConfig([], {});
+  return loadConfig([], { githubToken: "tok" });
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,7 +27,7 @@ const BrunelConfigSchema = z.object({
 
   /** GitHub repo in "owner/repo" format. Optional; workers detect it from git remote automatically. */
   githubRepo:     z.string().min(1).optional(),
-  /** GitHub personal access token with `repo` scope. Prefer env var over config file. Workers also fall back to `gh auth token` if this is unset. */
+  /** GitHub personal access token with `repo` scope. Prefer env var over config file. Optional for the foreman when GitHub App auth is configured; workers fall back to `gh auth token` if this is unset. */
   githubToken:    z.string().min(1).optional(),
   /** Issue label that triggers work (foreman picks up issues with this label). */
   taskLabel:      z.string().default(DEFAULT_TASK_LABEL),
@@ -336,5 +336,5 @@ export async function loadConfig(
  * that need default values (e.g. taskLabel) without a real GitHub repo or token.
  */
 export function loadDefaultConfig(): Promise<BrunelConfig> {
-  return loadConfig([], { githubToken: "tok" });
+  return loadConfig([], {});
 }

--- a/src/foreman/controllers/wss.ts
+++ b/src/foreman/controllers/wss.ts
@@ -44,14 +44,14 @@ export interface RouteResult { task: Task | null; ref: string; forward?: boolean
 // ── ForemanWss class ──────────────────────────────────────────────────────────
 
 type ForemanWssOptions = {
-  config: Pick<BrunelConfig, "taskLabel" | "githubToken" | "githubApiUrl" | "workerSecret" | "pingIntervalMs">;
+  config: Pick<BrunelConfig, "taskLabel" | "githubApiUrl" | "workerSecret" | "pingIntervalMs">;
   server: http.Server;
   adminWss?: AdminWssLike;
 };
 
 export class ForemanWss {
   readonly wss: WebSocketServer;
-  private readonly config: Pick<BrunelConfig, "taskLabel" | "githubToken" | "githubApiUrl" | "workerSecret" | "pingIntervalMs">;
+  private readonly config: Pick<BrunelConfig, "taskLabel" | "githubApiUrl" | "workerSecret" | "pingIntervalMs">;
   private readonly adminWss?: AdminWssLike;
   private readonly installationsController = new InstallationsController();
   private nextBroadcastId = 1;

--- a/src/foreman/index.ts
+++ b/src/foreman/index.ts
@@ -19,11 +19,6 @@ const isMain = process.argv[1] === fileURLToPath(import.meta.url);
 if (isMain) {
   const config = await loadConfig(process.argv);
 
-  if (!config.githubToken) {
-    log("ERROR GitHub token required. Set GITHUB_TOKEN or BRUNEL_GITHUB_TOKEN.");
-    process.exit(1);
-  }
-
   const webhooks = config.webhookSecret
     ? new Webhooks({ secret: config.webhookSecret })
     : null;

--- a/tests/browser/server.ts
+++ b/tests/browser/server.ts
@@ -44,11 +44,15 @@ import { createTestTaskManager } from "../helpers/task.js";
 import { Installation } from "../../src/foreman/models/installation.js";
 import { Repo } from "../../src/foreman/models/repo.js";
 import { AdminWss } from "../../src/foreman/controllers/admin-ws.js";
-import { loadDefaultConfig } from "../../src/config.js";
+import { loadDefaultConfig, getConfig } from "../../src/config.js";
 
 const PORT = parseInt(process.env.PORT ?? "14567", 10);
 
 const cfg = await loadDefaultConfig();
+// Provide a fake token so GithubClient.resolveToken() doesn't throw when
+// checking native blockers — the fetch mock above intercepts all api.github.com
+// calls so the token value doesn't matter for actual auth.
+getConfig().githubToken = "fake-test-token";
 
 // ── Foreman state ─────────────────────────────────────────────────────────────
 

--- a/tests/browser/server.ts
+++ b/tests/browser/server.ts
@@ -44,15 +44,11 @@ import { createTestTaskManager } from "../helpers/task.js";
 import { Installation } from "../../src/foreman/models/installation.js";
 import { Repo } from "../../src/foreman/models/repo.js";
 import { AdminWss } from "../../src/foreman/controllers/admin-ws.js";
-import { loadDefaultConfig, getConfig } from "../../src/config.js";
+import { loadDefaultConfig } from "../../src/config.js";
 
 const PORT = parseInt(process.env.PORT ?? "14567", 10);
 
 const cfg = await loadDefaultConfig();
-// Provide a fake token so GithubClient.resolveToken() doesn't throw when
-// checking native blockers — the fetch mock above intercepts all api.github.com
-// calls so the token value doesn't matter for actual auth.
-getConfig().githubToken = "fake-test-token";
 
 // ── Foreman state ─────────────────────────────────────────────────────────────
 

--- a/tests/foreman.claim-task.test.ts
+++ b/tests/foreman.claim-task.test.ts
@@ -21,7 +21,7 @@ function fakeWs() {
 
 function makeWss() {
   const wss = new ForemanWss({
-    config: { taskLabel: "brunel:ready", githubToken: "token", workerSecret: undefined, pingIntervalMs: 1e9 },
+    config: { taskLabel: "brunel:ready", workerSecret: undefined, pingIntervalMs: 1e9 },
     server: http.createServer(),
   });
   const sendMsg = vi.spyOn(wss, "sendMsg").mockImplementation(() => true);

--- a/tests/foreman.event-handlers.test.ts
+++ b/tests/foreman.event-handlers.test.ts
@@ -49,7 +49,7 @@ async function makeDeps(): Promise<TestDeps> {
   vi.spyOn(taskManager, "handlePrClosedEvent").mockResolvedValue(null);
   vi.spyOn(taskManager, "getTaskForCheckEvent").mockResolvedValue(null);
   const wss = new ForemanWss({
-    config: { taskLabel: "brunel:ready", githubToken: "token", workerSecret: undefined, pingIntervalMs: 1e9 },
+    config: { taskLabel: "brunel:ready", workerSecret: undefined, pingIntervalMs: 1e9 },
     server: http.createServer(),
   });
   const sendMsg = vi.spyOn(wss, "sendMsg").mockImplementation(() => {});

--- a/tests/foreman.forward-event.test.ts
+++ b/tests/foreman.forward-event.test.ts
@@ -30,7 +30,7 @@ function makeEvent(name = "issue_comment"): WebhookEvent {
 
 function makeWss(_taskManager?: any): { wss: ForemanWss; sendMsg: ReturnType<typeof vi.fn> } {
   const wss = new ForemanWss({
-    config: { taskLabel: "brunel:ready", githubToken: "token", workerSecret: undefined, pingIntervalMs: 1e9 },
+    config: { taskLabel: "brunel:ready", workerSecret: undefined, pingIntervalMs: 1e9 },
     server: http.createServer(),
   });
   const sendMsg = vi.spyOn(wss, "sendMsg").mockImplementation(() => true);

--- a/tests/foreman.github.test.ts
+++ b/tests/foreman.github.test.ts
@@ -385,3 +385,17 @@ describe("verifyPushAccess", () => {
     await expect(new GithubClient("owner/repo", 456).verifyPushAccess("testuser")).rejects.toThrow("403");
   });
 });
+
+// ── No auth configured ────────────────────────────────────────────────────────
+
+describe("GithubClient without auth", () => {
+  it("throws 'GitHub token not configured' when no token and no installation ID", async () => {
+    getConfig().githubToken = undefined as unknown as string;
+    await expect(new GithubClient("owner/repo").fetchIssues()).rejects.toThrow("GitHub token not configured");
+  });
+
+  it("throws 'GitHub token not configured' for fetchIssueStates without auth", async () => {
+    getConfig().githubToken = undefined as unknown as string;
+    await expect(new GithubClient("owner/repo").fetchIssueStates([1])).rejects.toThrow("GitHub token not configured");
+  });
+});

--- a/tests/foreman.hello-handlers.test.ts
+++ b/tests/foreman.hello-handlers.test.ts
@@ -24,7 +24,7 @@ function fakeWs() {
 
 function makeWss(taskManager: TaskManager) {
   const wss = new ForemanWss({
-    config: { taskLabel: "brunel:ready", githubToken: "token", workerSecret: undefined, pingIntervalMs: 1e9 },
+    config: { taskLabel: "brunel:ready", workerSecret: undefined, pingIntervalMs: 1e9 },
     server: http.createServer(),
   });
   const sendMsg = vi.spyOn(wss, "sendMsg").mockImplementation(() => {});
@@ -558,7 +558,7 @@ describe("repoStatus in hello_ack", () => {
 describe("activate_repo", () => {
   function makeWssForActivate() {
     const wss = new ForemanWss({
-      config: { taskLabel: "brunel:ready", githubToken: "token", workerSecret: undefined, pingIntervalMs: 1e9 },
+      config: { taskLabel: "brunel:ready", workerSecret: undefined, pingIntervalMs: 1e9 },
       server: http.createServer(),
     });
     const sendMsg = vi.spyOn(wss, "sendMsg").mockImplementation(() => {});

--- a/tests/foreman.repo-filter.test.ts
+++ b/tests/foreman.repo-filter.test.ts
@@ -37,7 +37,7 @@ function makeTaskManager() {
 
 function makeWss(taskManager: ReturnType<typeof makeTaskManager>) {
   const wss = new ForemanWss({
-    config: { taskLabel: "brunel:ready", githubToken: "token", workerSecret: undefined, pingIntervalMs: 1e9 },
+    config: { taskLabel: "brunel:ready", workerSecret: undefined, pingIntervalMs: 1e9 },
     taskManager: taskManager as any,
     server: http.createServer(),
   });

--- a/tests/pipeline.test.ts
+++ b/tests/pipeline.test.ts
@@ -218,10 +218,7 @@ async function buildForeman(): Promise<{
   const httpServer = http.createServer();
   const openClients: WebSocket[] = [];
 
-  const foremanWss = new ForemanWss({ server: httpServer, config: {
-    ...defaultCfg,
-    githubToken: "token",
-  } });
+  const foremanWss = new ForemanWss({ server: httpServer, config: defaultCfg });
   const { wss } = foremanWss;
 
   // port is assigned synchronously when listen() resolves; we'll resolve it


### PR DESCRIPTION
## Summary

- Removes the `if (!config.githubToken)` startup exit from `src/foreman/index.ts` — the check was a temporary guardrail added in #1051 until GitHub App auth was in place
- Drops `githubToken` from `ForemanWss`'s config `Pick` type since the foreman never reads it (authentication is handled by `GithubClient` using App installation tokens)
- Removes the `githubToken: "tok"` placeholder from `loadDefaultConfig()` to reflect that the field is genuinely optional
- Updates the `githubToken` config JSDoc comment to note App auth as the primary path for the foreman
- Adds tests documenting `GithubClient`'s behavior when neither auth mode (App nor personal token) is configured

The foreman now authenticates all GitHub API calls via the App installation token when an installation exists, and falls back to `githubToken` only for legacy personal-token deployments. Errors surface at the point of the API call rather than at startup.

## Test plan

- [ ] `npm test` passes (all 260 relevant tests pass; pre-existing `worker.main.test.ts` failures are unrelated)
- [ ] `npx tsc --noEmit` passes with no type errors
- [ ] New tests in `tests/foreman.github.test.ts` verify `GithubClient` throws `"GitHub token not configured"` when called without any auth configured

Closes #1055

🤖 Generated with [Claude Code](https://claude.com/claude-code)