### PR TITLE
Cache installation tokens on GithubClient to avoid redundant minting

### DIFF
--- a/src/foreman/clients/github.ts
+++ b/src/foreman/clients/github.ts
@@ -36,10 +36,19 @@ export interface GithubIssue {
 
 // ── GitHub client ─────────────────────────────────────────────────────────────
 
+const TOKEN_TTL_MS = 55 * 60 * 1000;
+const TOKEN_BUFFER_MS = 5 * 60 * 1000;
+
 export class GithubClient {
   private readonly owner: string;
   private readonly repoName: string;
   private readonly installationGithubId?: number;
+
+  private static tokenCache = new Map<number, { token: string; expiresAt: number }>();
+
+  static _resetTokenCache(): void {
+    GithubClient.tokenCache.clear();
+  }
 
   constructor(repo: string, installationGithubId?: number) {
     const [owner, repoName] = repo.split("/");
@@ -67,9 +76,21 @@ export class GithubClient {
     return body.token;
   }
 
+  private async cachedInstallationToken(): Promise<string> {
+    const id = this.installationGithubId!;
+    const now = Date.now();
+    const entry = GithubClient.tokenCache.get(id);
+    if (entry && entry.expiresAt - now > TOKEN_BUFFER_MS) {
+      return entry.token;
+    }
+    const token = await this.mintInstallationToken();
+    GithubClient.tokenCache.set(id, { token, expiresAt: now + TOKEN_TTL_MS });
+    return token;
+  }
+
   private async resolveToken(): Promise<string> {
     if (this.installationGithubId !== undefined) {
-      return this.mintInstallationToken();
+      return this.cachedInstallationToken();
     }
     const token = getConfig().githubToken;
     if (!token) throw new Error("GitHub token not configured");
@@ -116,7 +137,7 @@ export class GithubClient {
    * Uses an installation token minted for this client's installationGithubId.
    */
   async verifyPushAccess(username: string): Promise<boolean> {
-    const token = await this.mintInstallationToken();
+    const token = await this.cachedInstallationToken();
     const { githubApiUrl: apiUrl = "https://api.github.com" } = getConfig();
     const res = await fetch(
       `${apiUrl}/repos/${this.owner}/${this.repoName}/collaborators/${username}/permission`,

--- a/tests/foreman.github.test.ts
+++ b/tests/foreman.github.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach, afterAll, beforeAll } from "vitest";
 import { generateKeyPairSync } from "node:crypto";
 import { GithubClient } from "../src/foreman/clients/github.js";
 import { Worker } from "../src/foreman/models/worker.js";
@@ -6,6 +6,7 @@ import { getConfig } from "../src/config.js";
 
 beforeEach(() => {
   Worker._reset();
+  GithubClient._resetTokenCache();
   vi.stubGlobal("fetch", vi.fn());
   getConfig().githubToken = "token123";
   getConfig().taskLabel = "brunel:ready";
@@ -397,5 +398,95 @@ describe("GithubClient without auth", () => {
   it("throws 'GitHub token not configured' for fetchIssueStates without auth", async () => {
     getConfig().githubToken = undefined as unknown as string;
     await expect(new GithubClient("owner/repo").fetchIssueStates([1])).rejects.toThrow("GitHub token not configured");
+  });
+});
+
+// ── Installation token caching ────────────────────────────────────────────────
+
+describe("installation token cache", () => {
+  // Generate one key pair for the whole block to avoid repeated expensive RSA generation.
+  let sharedPrivateKey: string;
+  beforeAll(() => {
+    sharedPrivateKey = makeTestKeyPair().privateKey;
+  });
+
+  beforeEach(() => {
+    getConfig().appId = "123";
+    getConfig().appPrivateKey = sharedPrivateKey;
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  it("reuses the cached token on a second resolveToken call without re-minting", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ token: "ghs_cached" }) } as any)
+      .mockResolvedValueOnce({ ok: true, json: async () => [] } as any)
+      .mockResolvedValueOnce({ ok: true, json: async () => [] } as any);
+
+    const client = new GithubClient("owner/repo", 789);
+    await client.fetchIssues();
+    await client.fetchIssues();
+
+    const mintCalls = vi.mocked(fetch).mock.calls.filter((c) =>
+      (c[0] as string).includes("/access_tokens"),
+    );
+    expect(mintCalls).toHaveLength(1);
+  });
+
+  it("different installationGithubIds use separate cache entries", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ token: "ghs_a" }) } as any)
+      .mockResolvedValueOnce({ ok: true, json: async () => [] } as any)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ token: "ghs_b" }) } as any)
+      .mockResolvedValueOnce({ ok: true, json: async () => [] } as any);
+
+    await new GithubClient("owner/repo", 111).fetchIssues();
+    await new GithubClient("owner/repo", 222).fetchIssues();
+
+    const mintCalls = vi.mocked(fetch).mock.calls.filter((c) =>
+      (c[0] as string).includes("/access_tokens"),
+    );
+    expect(mintCalls).toHaveLength(2);
+  });
+
+  it("re-mints when the cached token is within the expiry buffer", async () => {
+    vi.useFakeTimers();
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ token: "ghs_old" }) } as any)
+      .mockResolvedValueOnce({ ok: true, json: async () => [] } as any)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ token: "ghs_new" }) } as any)
+      .mockResolvedValueOnce({ ok: true, json: async () => [] } as any);
+
+    const client = new GithubClient("owner/repo", 789);
+    await client.fetchIssues();
+
+    // Advance time so the token is within 5 minutes of expiry (55 min TTL, advance 51 min)
+    vi.advanceTimersByTime(51 * 60 * 1000);
+    await client.fetchIssues();
+
+    const mintCalls = vi.mocked(fetch).mock.calls.filter((c) =>
+      (c[0] as string).includes("/access_tokens"),
+    );
+    expect(mintCalls).toHaveLength(2);
+
+    vi.useRealTimers();
+  });
+
+  it("verifyPushAccess uses the cached token from a prior resolveToken call", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ token: "ghs_shared" }) } as any)
+      .mockResolvedValueOnce({ ok: true, json: async () => [] } as any)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ permission: "push" }) } as any);
+
+    const client = new GithubClient("owner/repo", 789);
+    await client.fetchIssues();
+    await client.verifyPushAccess("someuser");
+
+    const mintCalls = vi.mocked(fetch).mock.calls.filter((c) =>
+      (c[0] as string).includes("/access_tokens"),
+    );
+    expect(mintCalls).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

- Adds a `static tokenCache` on `GithubClient` keyed by `installationGithubId`, with a 55-minute TTL and a 5-minute pre-expiry buffer.
- Introduces a private `cachedInstallationToken()` method; `resolveToken()` and `verifyPushAccess()` both use it instead of calling `mintInstallationToken()` directly.
- Adds `GithubClient._resetTokenCache()` (test-only helper, matches the `Worker._reset()` pattern) and calls it in `beforeEach` to keep tests isolated.
- Cache tests share a single RSA key pair via `beforeAll` to avoid the CPU-saturation timeouts that plagued earlier runs.

## Test plan

- [ ] `npx vitest run tests/foreman.github.test.ts` — all 35 tests pass, including 4 new cache-specific tests
- [ ] `npx tsc --noEmit` — clean
- [ ] `npm run lint` — clean

Closes #1057