### PR TITLE
refactor: consolidate worker deactivation into _deactivate(), remove _stopped

### DIFF
--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -148,8 +148,6 @@ export class WorkerController extends EventEmitter {
   private bufferedMessages: BufferableMessage[] = [];
   private reconnectAttempts = 0;
   private _reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-  private _stopped = false;
-
   // ── Reserved state ────────────────────────────────────────────────────────
   private _isReserved = false;
 
@@ -550,7 +548,6 @@ export class WorkerController extends EventEmitter {
     this._activePingIntervalMs = getConfig().pingIntervalMs ?? 25_000;
     this._activeMaxReconnectDelayMs = getConfig().maxReconnectDelayMs ?? 300_000;
 
-    this._stopped = false;
     this._isActive = true;
 
     this.agentStatus.update({ model: getConfig().model, effort: getConfig().effort });
@@ -580,16 +577,14 @@ export class WorkerController extends EventEmitter {
         }
       }
     }
-    this._stopped = true;
     this.sendGoodbye(goodbyeOpts);
+    this._deactivate();
     this.ws?.close();
     if (this.debounceTimer) {
       clearTimeout(this.debounceTimer);
       this.debounceTimer = null;
     }
     this.resetSessionState();
-    this._isActive = false;
-    this.agentStatus.setWorkerModeActive(false);
     this.display.print(c.sageGreen("Worker mode stopped."));
     await this.agentStatus.refreshBranch();
   }
@@ -749,6 +744,18 @@ export class WorkerController extends EventEmitter {
 
   // ── Private ───────────────────────────────────────────────────────────────
 
+  /**
+   * Own the full "worker mode is done" invariant. Sets all three fields
+   * atomically so every deactivation path (stop, fatal) stays in sync.
+   * Sets connectionStatus immediately — even if the socket is already closed
+   * and no close event will fire.
+   */
+  private _deactivate(): void {
+    this._isActive = false;
+    this.agentStatus.setWorkerModeActive(false);
+    this.agentStatus.update({ connectionStatus: "disconnected", reconnectAt: undefined });
+  }
+
   private buildWsFactory(): WsFactory {
     return () => new WebSocket(`${getConfig().foremanUrl}/worker`);
   }
@@ -843,6 +850,7 @@ export class WorkerController extends EventEmitter {
   }
 
   private connect(): void {
+    if (!this._isActive) return;
     // Clearing reconnectAt stops the countdown timer in the model.
     this.agentStatus.update({ connectionStatus: "reconnecting", reconnectAt: undefined });
     const ws = this._activeWsFactory!(this.agentStatus.agentId, this.currentTaskId);
@@ -915,11 +923,7 @@ export class WorkerController extends EventEmitter {
     ws.on("close", (code: number, _reason: Buffer) => {
       clearPingTimer(); // always clean up the ping timer when this socket closes
       if (ws !== this.ws) return; // stale close from a previous connection
-      if (this._stopped) {
-        // Fatal error path: update status but skip reconnect scheduling.
-        this.agentStatus.update({ connectionStatus: "disconnected", disconnectCode: code });
-        return;
-      }
+      if (!this._isActive) return; // already deactivated (stop or fatal) — skip reconnect
       // Full Jitter (Brooker 2015): spread = entire [0, cap] window at high attempt counts.
       const delay = Math.random() * Math.min(this._activeMaxReconnectDelayMs, 1000 * Math.pow(2, this.reconnectAttempts));
       this.reconnectAttempts++;
@@ -964,9 +968,7 @@ export class WorkerController extends EventEmitter {
 
     if (msg.type === "foreman_error") {
       if (msg.fatal) {
-        this._stopped = true;
-        this._isActive = false;
-        this.agentStatus.setWorkerModeActive(false);
+        this._deactivate();
         this.currentAc?.abort(); // abort any running query immediately
         this.ws?.close();
         this.emit("fatal");

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -3167,3 +3167,91 @@ describe("worker_hello githubToken", () => {
     expect(hellos[0].githubToken).toBeUndefined();
   });
 });
+
+// ── _deactivate() — unified teardown invariant ────────────────────────────────
+
+describe("_deactivate() — unified teardown invariant", () => {
+  it("stop() sets connectionStatus to 'disconnected' even when no socket exists (backoff case)", async () => {
+    vi.useFakeTimers();
+    try {
+      // Let the socket connect, then close it to enter reconnect backoff.
+      fakeWs.emit("close", 1006, Buffer.from(""));
+      // At this point we are in reconnect backoff — ws is pending a timer, no open socket.
+      // Call stop() before the backoff timer fires.
+      await session.stop();
+      // _deactivate() must have set connectionStatus directly without relying on a close event.
+      expect(sb.connectionStatus).toBe("disconnected");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stop() during reconnect backoff clears reconnectAt (countdown timer stopped)", async () => {
+    vi.useFakeTimers();
+    try {
+      fakeWs.emit("close", 1006, Buffer.from("")); // triggers backoff, sets reconnectAt
+      expect(sb.reconnectAt).toBeDefined(); // confirm it's set by the close handler
+
+      await session.stop();
+      // _deactivate() must clear reconnectAt — current code's _stopped path does not do this.
+      expect(sb.reconnectAt).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stop() sets workerModeActive to false synchronously before close event fires", async () => {
+    // Intercept the close handler to inspect state at the moment it fires.
+    let workerModeActiveAtClose: boolean | undefined;
+    const origClose = fakeWs.close.getMockImplementation();
+    fakeWs.close.mockImplementation(function(this: FakeWs) {
+      workerModeActiveAtClose = sb.workerModeActive;
+      origClose?.call(this);
+    });
+
+    await session.stop();
+
+    // workerModeActive must be false by the time close fires (set by _deactivate() before ws.close()).
+    expect(workerModeActiveAtClose).toBe(false);
+    expect(sb.workerModeActive).toBe(false);
+  });
+
+  it("stop() does not schedule a reconnect when the socket close event fires", async () => {
+    vi.useFakeTimers();
+    try {
+      await session.stop();
+      vi.advanceTimersByTime(10_000);
+      // wsFactory was called once on start(); stop() must not trigger a second call.
+      expect(wsFactory).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("fatal foreman_error sets connectionStatus to 'disconnected' synchronously", () => {
+    // _deactivate() must update status before ws.close() fires.
+    let statusAtClose: string | undefined;
+    const origClose = fakeWs.close.getMockImplementation();
+    fakeWs.close.mockImplementation(function(this: FakeWs) {
+      statusAtClose = sb.connectionStatus;
+      origClose?.call(this);
+    });
+
+    sendMsg(fakeWs, { type: "foreman_error", message: "Fatal error", fatal: true });
+    // Status should be "disconnected" both at close-event time and after.
+    expect(statusAtClose).toBe("disconnected");
+    expect(sb.connectionStatus).toBe("disconnected");
+  });
+
+  it("fatal foreman_error sets workerModeActive to false before close event fires", () => {
+    let workerModeActiveAtClose: boolean | undefined;
+    const origClose = fakeWs.close.getMockImplementation();
+    fakeWs.close.mockImplementation(function(this: FakeWs) {
+      workerModeActiveAtClose = sb.workerModeActive;
+      origClose?.call(this);
+    });
+
+    sendMsg(fakeWs, { type: "foreman_error", message: "Fatal error", fatal: true });
+    expect(workerModeActiveAtClose).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Introduces a private `_deactivate()` method in `WorkerController` that owns the full "worker mode is done" invariant: sets `_isActive = false`, `workerModeActive = false`, `connectionStatus = "disconnected"`, and `reconnectAt = undefined` atomically
- Both `stop()` and the fatal `foreman_error` handler call `_deactivate()` before `ws?.close()`, ensuring all fields are always updated together — even when the socket is already closed and no close event fires
- Eliminates `_stopped` flag — the close handler now checks `!this._isActive` instead, deriving reconnect-or-not from the single source of truth
- Adds a safety guard in `connect()` that early-returns when `!this._isActive`, preventing timer-deferred connections from racing with deactivation

## Test plan

- [x] New tests in `_deactivate() — unified teardown invariant` describe block covering:
  - `stop()` sets `connectionStatus` to `"disconnected"` during reconnect backoff (no live socket)
  - `stop()` during backoff clears `reconnectAt` (previously a bug — `_stopped` path did not clear it)
  - `stop()` sets `workerModeActive = false` before `ws.close()` fires (was set after, now set before)
  - `stop()` does not schedule a reconnect after deactivation
  - Fatal `foreman_error` sets `connectionStatus = "disconnected"` before close event fires (was set by the event handler, now by `_deactivate()`)
  - Fatal `foreman_error` sets `workerModeActive = false` before close event fires
- [x] All 217 existing worker tests still pass
- [x] Full test suite: 1912 tests pass
- [x] `tsc --noEmit`: clean

Closes #1073

🤖 Generated with [Claude Code](https://claude.com/claude-code)