### PR TITLE
docs: clarify why loadDefaultConfig() passes a placeholder githubToken

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -333,7 +333,9 @@ export async function loadConfig(
 
 /**
  * Returns a config object populated with schema defaults. Useful in tests
- * that need default values (e.g. taskLabel) without a real GitHub repo or token.
+ * that need default values (e.g. taskLabel) without a real GitHub repo or .env.
+ * Passes a placeholder githubToken so GithubClient.resolveToken() doesn't throw
+ * in tests that exercise code paths involving GithubClient (fetch is mocked separately).
  */
 export function loadDefaultConfig(): Promise<BrunelConfig> {
   return loadConfig([], { githubToken: "tok" });


### PR DESCRIPTION
## Summary

- Updates the JSDoc on `loadDefaultConfig()` to explain why `githubToken: "tok"` is passed
- `GithubClient.resolveToken()` throws synchronously before any `fetch()` call, so even a fully-mocked fetch doesn't bypass it — the placeholder is load-bearing test infrastructure, not a leftover

This was discovered while implementing #1055 (removing the foreman's githubToken startup requirement). Removing the placeholder broke 11 tests across `foreman.task-manager.test.ts`, `foreman.webhook-routing.test.ts`, and `pipeline.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)