### PR TITLE
ci: fail loudly on missing Supabase key; eliminate double vitest run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,14 +34,14 @@ jobs:
           if [ -z "$KEY" ]; then
             KEY=$(echo "$STATUS" | grep 'service_role' | awk '{print $NF}')
           fi
+          if [ -z "$KEY" ]; then
+            echo "ERROR: Could not extract Supabase service role key from 'supabase status' output" >&2
+            exit 1
+          fi
           {
             echo "SUPABASE_URL=http://127.0.0.1:54321"
             echo "SUPABASE_SERVICE_ROLE_KEY=${KEY}"
           } >> "$GITHUB_ENV"
-
-      - run: npm test
-        env:
-          CI: true
 
       - name: Run frontend component tests
         run: cd frontend && npm ci && npm test
@@ -49,7 +49,6 @@ jobs:
           CI: true
 
       - run: npm run coverage
-        if: always()
 
       - uses: actions/upload-artifact@v7
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,13 +90,14 @@ Config via `.env` or `brunel.config.ts` (CLI flags also accepted). See `src/conf
 ## Useful scripts
 
 - `npm test` — unit tests (vitest); excludes `frontend/**`
+- `npm run coverage` — unit tests + coverage report; this is what CI runs (use `npm test` locally for a faster feedback loop)
 - `cd frontend && npm test` — frontend component tests (vitest + jsdom)
 - `npm run smoke` — end-to-end smoke test: spawns real foreman + worker and asserts they connect
 - `npm run test:browser` — Playwright browser tests for the admin dashboard (requires `npm run build` first)
 - `npm run lint` — ESLint
 - `npx tsc --noEmit` — type check
 
-All five run in CI on every PR.
+All five run in CI on every PR (coverage, frontend tests, browser tests, lint, type check).
 
 ## Database
 


### PR DESCRIPTION
## Summary

- Adds an explicit `exit 1` after both Supabase key extraction regexes fail, so CI fails immediately at the credential step with a clear error message rather than masking it as a cryptic test failure two steps later.
- Removes the redundant `npm test` step and drops `if: always()` from `npm run coverage`, so vitest runs only once (with coverage). This halves the Supabase container exposure window and eliminates the duplicate test run.

## Test plan

- [ ] Verify CI passes on this PR (tests run once via `npm run coverage`, coverage artifact still uploaded)
- [ ] Confirm the credential step would fail loudly if key extraction returned empty (logic inspection)

Closes #1081

🤖 Generated with [Claude Code](https://claude.com/claude-code)