### PR TITLE
fix: unpause events when waiting for next task after completion

### DIFF
--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -497,6 +497,8 @@ export class WorkerController extends EventEmitter {
         return "exit";
       default:
         await this.runAfterTaskReset();
+        this._eventsPaused = false;
+        this._syncPendingEventsStatus();
         this.sendWorkerReady();
         this.display.print(c.sageGreen("Waiting for next task..."));
         return "task-complete";

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1960,6 +1960,14 @@ describe("completeCurrentTask: post-completion prompt", () => {
     const msgs = ws.send.mock.calls.map(([s]: [string]) => JSON.parse(s));
     expect(msgs.some((m: { type: string }) => m.type === "worker_ready")).toBe(false);
   });
+
+  it("option 0 (wait for next task): clears eventsPaused so status bar does not show 'Events paused'", async () => {
+    const { sess } = await makeSession(async () => 0);
+    sess.pauseEvents();
+    expect(sess.eventsPaused).toBe(true);
+    await sess.completeCurrentTask();
+    expect(sess.eventsPaused).toBe(false);
+  });
 });
 
 // ── sendGoodbye ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- When a task is completed and the worker selects "Wait to be assigned the next task", `_eventsPaused` was not being reset
- This caused the status bar to show "Events paused" while the worker was in the idle waiting state
- Fixed by resetting `_eventsPaused = false` and syncing the status before entering the waiting state

## Test plan

- Added a test: `option 0 (wait for next task): clears eventsPaused so status bar does not show 'Events paused'`
- Verifies that `eventsPaused` is `false` after completing a task with events paused and choosing "Wait for next task"

Closes #1085

🤖 Generated with [Claude Code](https://claude.com/claude-code)