### PR TITLE
fix: guard against empty issue_comment prompts and add diagnostics

### DIFF
--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -898,6 +898,7 @@ export class WorkerController extends EventEmitter {
    * resumeSessionId, if set, causes index.ts to resume an existing Claude session.
    */
   private enqueuePrompt(prompt: string, fresh: boolean, resumeSessionId?: string): void {
+    if (!prompt) return;
     this.pendingPrompts.push({ prompt, fresh, resumeSessionId });
     this.emit("prompts_ready");
   }
@@ -1253,6 +1254,17 @@ export class WorkerController extends EventEmitter {
         return;
       }
 
+      // Diagnostic: log payload structure when issue_comment arrives without a body
+      // so we can identify the "right place" to read it from (issue #1087).
+      if (event.name === "issue_comment") {
+        const comment = event.payload.comment as Record<string, unknown> | undefined;
+        if (!comment?.body) {
+          this.display.print(c.amber(
+            `[diag] issue_comment has no comment.body — payload keys: ${Object.keys(event.payload).join(", ")}; comment: ${JSON.stringify(comment)}`
+          ));
+        }
+      }
+
       const classification = classifyEvent(event);
       if (classification === "log_only") {
         // Already logged via printForemanMessage above; no further action.
@@ -1292,7 +1304,7 @@ export class WorkerController extends EventEmitter {
 
   private buildAndLogEventPrompt(events: Wire.WebhookEvent[]): string {
     const prompt = buildEventPrompt(events);
-    this.display.print(c.sageGreen(prompt));
+    if (prompt) this.display.print(c.sageGreen(prompt));
     return prompt;
   }
 }

--- a/tests/worker-prompts.test.ts
+++ b/tests/worker-prompts.test.ts
@@ -395,6 +395,26 @@ describe("buildEventPrompt", () => {
     expect(p).toContain("Can you also handle edge case Y?");
   });
 
+  it("issue_comment with missing comment — contains issue number", () => {
+    const evt: Wire.WebhookEvent = {
+      id: "e1",
+      name: "issue_comment",
+      payload: { issue: { number: 53 } },
+    };
+    const p = buildEventPrompt([evt]);
+    expect(p).toContain("issue #53");
+  });
+
+  it("issue_comment with empty body — contains issue number", () => {
+    const evt: Wire.WebhookEvent = {
+      id: "e1",
+      name: "issue_comment",
+      payload: { issue: { number: 53 }, comment: { body: "" } },
+    };
+    const p = buildEventPrompt([evt]);
+    expect(p).toContain("issue #53");
+  });
+
   it("issue_comment — preserves full multi-paragraph body including third paragraph", () => {
     // Real GitHub webhooks deliver comment.body with CRLF (\r\n) line endings.
     const body = [

--- a/tests/worker.classify-event.test.ts
+++ b/tests/worker.classify-event.test.ts
@@ -108,6 +108,13 @@ describe("classifyEvent", () => {
     it("is actionable when comment field is missing", () => {
       expect(classifyEvent(makeEvent("issue_comment", { action: "created" }))).toBe("actionable");
     });
+
+    it("is actionable when comment body is empty string", () => {
+      expect(classifyEvent(makeEvent("issue_comment", {
+        action: "created",
+        comment: { body: "" },
+      }))).toBe("actionable");
+    });
   });
 
   describe("unknown event names", () => {


### PR DESCRIPTION
## Summary

- When an `issue_comment` event arrives where `comment.body` is missing or empty, the previous code passed an empty string all the way to Claude as a prompt, and also printed an empty string to the terminal.
- `enqueuePrompt` now skips empty prompt strings so Claude is not interrupted with an empty message.
- `buildAndLogEventPrompt` guards the print call so empty strings are silent.
- Diagnostic logging is added: when an `issue_comment` arrives without `comment.body`, the payload keys and `comment` field are printed in amber — this will help identify the "right place" to read the body from if the root cause is not at `comment.body` (per owner's feedback in the PR discussion).

**Context:** the webhook payload confirmed the body IS at `comment.body`, so `normalizeLineEndings(p.comment?.body)` is already the correct read path. The diagnostics remain to confirm this on the next occurrence.

## Test plan

- [x] `tests/worker.classify-event.test.ts` — new test confirms empty-body `issue_comment` is still classified as `actionable`
- [x] `tests/worker-prompts.test.ts` — new tests confirm `buildEventPrompt` includes the issue number even when `comment` or `comment.body` is absent
- [x] `npm test` — all non-DB tests pass

Closes #1087