### PR TITLE
refactor: simplify routeIssueCommentEvent to delegate to routeIssuesEvent

### DIFF
--- a/src/foreman/controllers/webhook-controller.ts
+++ b/src/foreman/controllers/webhook-controller.ts
@@ -236,10 +236,7 @@ export class WebhookController {
   }
 
   async routeIssueCommentEvent(p: R, evt: WebhookEvent): Promise<RouteResult> {
-    const issue = p.issue as R | undefined;
-    const issueNumber = numProp(issue, "number");
-    if (issueNumber === null) return { task: null, ref: "" };
-    return { task: await this.applyIssueEffects(p, issue!, issueNumber), ref: `#${issueNumber}` };
+    return this.routeIssuesEvent(p, evt);
   }
 
   /**


### PR DESCRIPTION
## Summary

- `routeIssueCommentEvent` now delegates to `routeIssuesEvent` instead of duplicating its body
- Same pattern already used by `routePullRequestReviewCommentEvent` → `routePullRequestReviewEvent`