### PR TITLE
Fix: wire appWebhookSecret so GitHub App webhook signatures are verified

### DIFF
--- a/src/foreman/index.ts
+++ b/src/foreman/index.ts
@@ -26,7 +26,7 @@ if (isMain) {
   const supabase = createClient<Database>(config.supabaseUrl, config.supabaseSecretKey);
   initDb(supabase);
 
-  const httpServer = new HttpServer({ webhookSecret: config.webhookSecret });
+  const httpServer = new HttpServer({ webhookSecret: config.appWebhookSecret ?? config.webhookSecret });
   const { server } = httpServer;
 
   // Admin WebSocket broadcaster — owns snapshot lifecycle and event subscriptions

--- a/tests/foreman.http.test.ts
+++ b/tests/foreman.http.test.ts
@@ -10,6 +10,7 @@
  * - 404 fallback when no static dist/ exists
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import crypto from "crypto";
 import http from "http";
 import type { AddressInfo } from "net";
 import type { Webhooks } from "@octokit/webhooks";
@@ -139,6 +140,31 @@ describe("POST /webhook", () => {
       expect(res.status).toBe(401);
     } finally {
       await stopServer(s);
+    }
+  });
+
+  it("accepts a valid signature when webhookSecret is provided and dispatches the event", async () => {
+    const secret = "mysecret";
+    const body = JSON.stringify({ action: "labeled", issue: { number: 1 } });
+    const sig = "sha256=" + crypto.createHmac("sha256", secret).update(body).digest("hex");
+    const httpServer = new HttpServer({ webhookSecret: secret });
+    const dispatched = vi.fn();
+    httpServer.webhooks.onAny(({ name, payload }) => dispatched(name, payload));
+    const p = await startServer(httpServer.server);
+    try {
+      const res = await request(p, "POST", "/webhook", {
+        body,
+        headers: {
+          "content-type": "application/json",
+          "x-github-event": "issues",
+          "x-github-delivery": "sig-test-1",
+          "x-hub-signature-256": sig,
+        },
+      });
+      expect(res.status).toBe(200);
+      expect(dispatched).toHaveBeenCalledOnce();
+    } finally {
+      await stopServer(httpServer.server);
     }
   });
 });

--- a/tests/smoke.ts
+++ b/tests/smoke.ts
@@ -128,6 +128,8 @@ async function run(): Promise<void> {
 
   const spawnOpts = { cwd: REPO_ROOT, stdio: ["ignore", "pipe", "pipe"] as const };
 
+  const WEBHOOK_SECRET = "smoke-test-secret";
+
   const foreman = spawn("tsx", ["src/foreman/index.ts"], {
     ...spawnOpts,
     env: {
@@ -136,6 +138,7 @@ async function run(): Promise<void> {
       GITHUB_REPO: "test/test",
       GITHUB_TOKEN: "dummy",
       BRUNEL_GITHUB_API_URL: `http://localhost:${mockApiPort}`,
+      BRUNEL_APP_WEBHOOK_SECRET: WEBHOOK_SECRET,
     },
   });
 
@@ -281,6 +284,8 @@ async function run(): Promise<void> {
     },
   });
 
+  const webhookSig = "sha256=" + crypto.createHmac("sha256", WEBHOOK_SECRET).update(webhookPayload).digest("hex");
+
   await new Promise<void>((resolve, reject) => {
     const req = http.request(
       {
@@ -292,6 +297,7 @@ async function run(): Promise<void> {
           "Content-Type": "application/json",
           "x-github-event": "issues",
           "x-github-delivery": "smoke-test-delivery-1",
+          "x-hub-signature-256": webhookSig,
           "Content-Length": Buffer.byteLength(webhookPayload),
         },
       },


### PR DESCRIPTION
## Summary

- `appWebhookSecret` (`BRUNEL_APP_WEBHOOK_SECRET`) was defined in config but never passed to `HttpServer` — the `Webhooks` instance only ever saw `webhookSecret`
- This caused GitHub App webhook events (including `installation.created`) to be verified against the wrong secret and rejected, leaving the installations table empty
- Fix: pass `appWebhookSecret ?? webhookSecret` so the App secret takes precedence, with fallback for setups that only use `WEBHOOK_SECRET`

## Test plan

- [ ] Deploy to Railway with `BRUNEL_APP_WEBHOOK_SECRET` set — verify incoming App webhooks pass signature verification (no signature errors in logs)
- [ ] Confirm installation events are processed and written to DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)