### PR TITLE
Fix: use installation.githubId (not DB primary key) when minting tokens

### DIFF
--- a/src/foreman/models/repo.ts
+++ b/src/foreman/models/repo.ts
@@ -22,6 +22,7 @@ export class Repo extends ActiveRecord {
   status: RepoStatus;
   readonly createdAt: string;
   installationId: number | null;
+  private _installation: Promise<Installation | null> | undefined;
 
   private constructor(row: DbRow) {
     super();
@@ -57,10 +58,14 @@ export class Repo extends ActiveRecord {
     return TaskManager.forRepo(this);
   }
 
-  /** Returns the GitHub App installation linked to this repo, or null if not set. */
+  /** Returns the GitHub App installation linked to this repo, or null if not set. Memoized. */
   get installation(): Promise<Installation | null> {
-    if (this.installationId === null) return Promise.resolve(null);
-    return Installation.get(this.installationId);
+    if (this._installation === undefined) {
+      this._installation = this.installationId === null
+        ? Promise.resolve(null)
+        : Installation.get(this.installationId);
+    }
+    return this._installation;
   }
 
   async getTaskByIssue(issueNumber: number): Promise<Task | null> {
@@ -89,6 +94,7 @@ export class Repo extends ActiveRecord {
   async linkInstallation(installationId: number): Promise<Repo> {
     const updated = await this.update({ installation_id: installationId });
     this.installationId = installationId;
+    this._installation = undefined;
     return updated;
   }
 
@@ -96,6 +102,7 @@ export class Repo extends ActiveRecord {
   async unlinkInstallation(): Promise<Repo> {
     const updated = await this.update({ installation_id: null });
     this.installationId = null;
+    this._installation = undefined;
     return updated;
   }
 

--- a/src/foreman/models/task-manager.ts
+++ b/src/foreman/models/task-manager.ts
@@ -3,7 +3,6 @@ import * as Wire from "../../../shared/wire.js";
 import { GithubClient } from "../clients/github.js";
 import { Task } from "./task.js";
 import { Worker } from "./worker.js";
-import { Installation } from "./installation.js";
 import { fmtError, log } from "../../utils.js";
 import type { Repo } from "./repo.js";
 
@@ -73,11 +72,8 @@ export class TaskManager extends EventEmitter {
   readonly repo: Repo;
 
   private async github(): Promise<GithubClient> {
-    if (this.repo.installationId !== null) {
-      const installation = await Installation.get(this.repo.installationId);
-      if (installation) return new GithubClient(this.repo.fullName, installation.githubId);
-    }
-    return new GithubClient(this.repo.fullName);
+    const installation = await this.repo.installation;
+    return new GithubClient(this.repo.fullName, installation?.githubId);
   }
 
   // ── Ephemeral in-memory state (no DB backing) ────────────────────────────

--- a/src/foreman/models/task-manager.ts
+++ b/src/foreman/models/task-manager.ts
@@ -301,9 +301,10 @@ export class TaskManager extends EventEmitter {
 
   /** Fetch all blockers for an issue from body text and GitHub native relationships. */
   async fetchBlockers(issueNumber: number, body: string): Promise<number[]> {
+    const github = await this.github();
     const [bodyBlockers, nativeBlockers] = await Promise.all([
       Task.parseBodyBlockers(body),
-      (await this.github()).fetchNativeBlockers(issueNumber),
+      github.fetchNativeBlockers(issueNumber),
     ]);
     return Array.from(new Set([...bodyBlockers, ...nativeBlockers]));
   }
@@ -317,7 +318,8 @@ export class TaskManager extends EventEmitter {
     const blockers = await this.fetchBlockers(issueNumber, body);
     this.setBlockers(issueNumber, blockers);
     if (blockers.length > 0) {
-      const states = await (await this.github()).fetchIssueStates(blockers);
+      const github = await this.github();
+      const states = await github.fetchIssueStates(blockers);
       for (const [num, state] of states) {
         this.setIssueOpenState(num, state === "open");
       }
@@ -443,7 +445,8 @@ export class TaskManager extends EventEmitter {
    *  Called at startup after loadActiveTasksFromDb, and on installation/activation events. */
   async loadIssuesFromGithub(): Promise<void> {
     const repo = this.repo.fullName;
-    const issues = await (await this.github()).fetchIssues();
+    const github = await this.github();
+    const issues = await github.fetchIssues();
 
     const allBlockerNumbers = new Set<number>();
     const loadedIssueNumbers: number[] = [];
@@ -467,7 +470,8 @@ export class TaskManager extends EventEmitter {
     }
 
     if (allBlockerNumbers.size > 0) {
-      const states = await (await this.github()).fetchIssueStates(Array.from(allBlockerNumbers));
+      const github = await this.github();
+      const states = await github.fetchIssueStates(Array.from(allBlockerNumbers));
       for (const [num, state] of states) {
         this.setIssueOpenState(num, state === "open");
       }

--- a/src/foreman/models/task-manager.ts
+++ b/src/foreman/models/task-manager.ts
@@ -3,6 +3,7 @@ import * as Wire from "../../../shared/wire.js";
 import { GithubClient } from "../clients/github.js";
 import { Task } from "./task.js";
 import { Worker } from "./worker.js";
+import { Installation } from "./installation.js";
 import { fmtError, log } from "../../utils.js";
 import type { Repo } from "./repo.js";
 
@@ -71,8 +72,12 @@ export class TaskManager extends EventEmitter {
   // ── Instance state ───────────────────────────────────────────────────────
   readonly repo: Repo;
 
-  private get github(): GithubClient {
-    return new GithubClient(this.repo.fullName, this.repo.installationId ?? undefined);
+  private async github(): Promise<GithubClient> {
+    if (this.repo.installationId !== null) {
+      const installation = await Installation.get(this.repo.installationId);
+      if (installation) return new GithubClient(this.repo.fullName, installation.githubId);
+    }
+    return new GithubClient(this.repo.fullName);
   }
 
   // ── Ephemeral in-memory state (no DB backing) ────────────────────────────
@@ -302,7 +307,7 @@ export class TaskManager extends EventEmitter {
   async fetchBlockers(issueNumber: number, body: string): Promise<number[]> {
     const [bodyBlockers, nativeBlockers] = await Promise.all([
       Task.parseBodyBlockers(body),
-      this.github.fetchNativeBlockers(issueNumber),
+      (await this.github()).fetchNativeBlockers(issueNumber),
     ]);
     return Array.from(new Set([...bodyBlockers, ...nativeBlockers]));
   }
@@ -316,7 +321,7 @@ export class TaskManager extends EventEmitter {
     const blockers = await this.fetchBlockers(issueNumber, body);
     this.setBlockers(issueNumber, blockers);
     if (blockers.length > 0) {
-      const states = await this.github.fetchIssueStates(blockers);
+      const states = await (await this.github()).fetchIssueStates(blockers);
       for (const [num, state] of states) {
         this.setIssueOpenState(num, state === "open");
       }
@@ -442,7 +447,7 @@ export class TaskManager extends EventEmitter {
    *  Called at startup after loadActiveTasksFromDb, and on installation/activation events. */
   async loadIssuesFromGithub(): Promise<void> {
     const repo = this.repo.fullName;
-    const issues = await this.github.fetchIssues();
+    const issues = await (await this.github()).fetchIssues();
 
     const allBlockerNumbers = new Set<number>();
     const loadedIssueNumbers: number[] = [];
@@ -466,7 +471,7 @@ export class TaskManager extends EventEmitter {
     }
 
     if (allBlockerNumbers.size > 0) {
-      const states = await this.github.fetchIssueStates(Array.from(allBlockerNumbers));
+      const states = await (await this.github()).fetchIssueStates(Array.from(allBlockerNumbers));
       for (const [num, state] of states) {
         this.setIssueOpenState(num, state === "open");
       }


### PR DESCRIPTION
## Summary

- `TaskManager.github()` was passing `repo.installationId` (the internal DB FK to `installations.id`) to `GithubClient` as the GitHub installation ID
- GitHub expects its own external installation ID, so `POST /app/installations/{id}/access_tokens` returned 404 on every startup — the foreman crashed before accepting any connections
- Fixed by resolving the `Installation` record and using `installation.githubId`
- `worker-controller.ts` was already doing this correctly (line 137); this aligns `task-manager.ts` with the same pattern

## Test plan

- [ ] Deploy — verify no 404 errors at startup in Railway logs
- [ ] Verify issues are seeded from GitHub on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)