### PR TITLE
feat: add README.md and GitHub link in dashboard header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+**brunel** is a GitHub-driven autonomous coding agent. Label a GitHub issue `brunel:ready`, and brunel picks it up, spins up a Claude-powered worker in your repo, and reports back when done — all from your terminal, with you in the loop.
+
+## Quickstart
+
+```
+# Install the brunel GitHub App on your repo at github.com/apps/brunel-foreman
+npm install -g brunel-agent
+export ANTHROPIC_API_KEY=sk-ant-...
+cd my-repo
+brunel
+```
+
+For more detail, see the [GitHub repo](https://github.com/jasoncrawford/brunel).

--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
-**brunel** is a GitHub-driven autonomous coding agent. Label a GitHub issue `brunel:ready`, and brunel picks it up, spins up a Claude-powered worker in your repo, and reports back when done — all from your terminal, with you in the loop.
+**Brunel** orchestrates a team of Claude coding agents to work on GitHub issues and file pull requests:
+
+* Tag an issue `brunel:ready`, and it will be assigned to an agent
+* Agents automatically respond to test failures, code reviews, and any comments you leave on the PR
+* Agents run in your terminal, and use any skills you have installed
 
 ## Quickstart
 
-```
-# Install the brunel GitHub App on your repo at github.com/apps/brunel-foreman
-npm install -g brunel-agent
-export ANTHROPIC_API_KEY=sk-ant-...
-cd my-repo
-brunel
-```
+1. Install the Brunel GitHub App on your repo: [github.com/apps/brunel-foreman](https://github.com/apps/brunel-foreman)
+2. Install the Brunel client locally: `npm install -g brunel-agent`
+3. Strongly recommended: install the skills at [jasoncrawford/claude-skills](https://github.com/jasoncrawford/claude-skills) and also [obra/superpowers](https://github.com/obra/superpowers#claude-code)
+4. Put an Anthropic key/token in your env: `export ANTHROPIC_API_KEY=sk-ant-...` or `export CLAUDE_CODE_OAUTH_TOKEN=sk-ant-...`
+5. Run `brunel` in your repo
+6. Tag issues `brunel:ready` in GitHub
 
-For more detail, see the [GitHub repo](https://github.com/jasoncrawford/brunel).
+Go to [brunel.dev](https://brunel.dev) and find your repo in the dashboard to see the status of tasks and workers.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,8 @@ export default function App() {
         <NavLink to="/tasks">Tasks</NavLink>
         {" · "}
         <NavLink to="/log">Event Log</NavLink>
+        {" · "}
+        <a href="https://github.com/jasoncrawford/brunel" target="_blank" rel="noreferrer">GitHub</a>
       </header>
       <Routes>
         <Route path="/" element={<Dashboard />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,7 +18,7 @@ export default function App() {
         {" · "}
         <NavLink to="/log">Event Log</NavLink>
         {" · "}
-        <a href="https://github.com/jasoncrawford/brunel" target="_blank" rel="noreferrer">GitHub</a>
+        <a href="https://github.com/jasoncrawford/brunel#readme" target="_blank" rel="noreferrer">README</a>
       </header>
       <Routes>
         <Route path="/" element={<Dashboard />} />


### PR DESCRIPTION
## Summary

- Adds `README.md` at the repo root with a one-paragraph description and the 5-line quickstart — appears on both the GitHub repo page and npmjs.com/package/brunel-agent
- Adds a `GitHub` link in the dashboard header (`brunel.dev`) so visitors can find the repo

## Test plan

- [ ] Verify README renders correctly on the GitHub repo page
- [ ] Verify README renders correctly on npmjs.com/package/brunel-agent (after next publish)
- [ ] Verify GitHub link appears in the dashboard header and navigates to the correct repo

Closes #1104

🤖 Generated with [Claude Code](https://claude.com/claude-code)