### PR TITLE
fix: suppress stall/retry watchdog while SDK is compacting context

### DIFF
--- a/src/agent/controllers/agent-controller.ts
+++ b/src/agent/controllers/agent-controller.ts
@@ -145,13 +145,15 @@ export class AgentController {
     let resultReceived = false;
     let receivedSubstantiveContent = false;
     let stallRetry = false;
+    let isCompacting = false;
 
     // Log a single warning when no SDK message has arrived for STALL_THRESHOLD_SECS.
     // This fires via a watchdog so it captures hangs inside the for-await wait itself.
     // If no substantive content has arrived yet, auto-abort and signal the caller to retry.
+    // Compaction can legitimately take longer than the stall threshold, so skip while compacting.
     let stallLogged = false;
     const stallWatcher = setInterval(() => {
-      if (!stallLogged && stats.secsSinceLastActivity >= STALL_THRESHOLD_SECS) {
+      if (!stallLogged && stats.secsSinceLastActivity >= STALL_THRESHOLD_SECS && !isCompacting) {
         stallLogged = true;
         logFull("STALL_DETECTED", {
           secsSinceLastActivity: stats.secsSinceLastActivity,
@@ -170,6 +172,16 @@ export class AgentController {
       for await (const message of iterable) {
         stats.noteActivity();
         if (message.type !== "system") receivedSubstantiveContent = true;
+
+        // Track compaction to suppress false stall during (potentially slow) context compaction.
+        const sysMsg = message as { type: string; subtype?: string; status?: string };
+        if (sysMsg.type === "system" && sysMsg.subtype === "status" && sysMsg.status === "compacting") {
+          isCompacting = true;
+        } else if (sysMsg.type === "system" && sysMsg.subtype === "compact_boundary") {
+          isCompacting = false;
+        } else if (sysMsg.type !== "system") {
+          isCompacting = false;
+        }
 
         if (!(message.type === "stream_event" && (message.event as { type?: string }).type === "content_block_delta")) {
           logFull("MESSAGE", message);

--- a/tests/repl.query.test.ts
+++ b/tests/repl.query.test.ts
@@ -953,3 +953,79 @@ describe("runQuery - first-message stall auto-retry", () => {
     expect(output).not.toContain("Interrupted");
   });
 });
+
+describe("runQuery - stall suppression during compaction", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does NOT trigger stallRetry when silence exceeds threshold while compacting", async () => {
+    vi.useFakeTimers();
+
+    (query as any).mockImplementation((opts: any) => {
+      return (async function* () {
+        yield { type: "system", subtype: "status", status: "compacting" };
+        // Compaction takes longer than the stall threshold — hang until abort
+        await new Promise<void>((resolve) => {
+          opts.options.abortController.signal.addEventListener("abort", resolve, { once: true });
+        });
+      })();
+    });
+
+    const ac = new AbortController();
+    const cap = captureConsole();
+    const queryPromise = testController.runQuery("test", undefined, ac);
+
+    // Advance well past the stall threshold
+    await vi.advanceTimersByTimeAsync(130_000);
+
+    // The stall warning should NOT have been printed
+    const output = cap.lines.map(stripAnsi).join("\n");
+    expect(output).not.toContain("Connection stalled before receiving a response");
+
+    // Clean up — the query is still running (not auto-aborted)
+    ac.abort();
+    const result = await queryPromise;
+    cap.restore();
+
+    expect(result.stallRetry).toBe(false);
+  });
+
+  it("resumes normal stall detection after compaction ends", async () => {
+    vi.useFakeTimers();
+
+    let resolveCompaction!: () => void;
+    const compactionDone = new Promise<void>((resolve) => { resolveCompaction = resolve; });
+
+    (query as any).mockImplementation((opts: any) => {
+      return (async function* () {
+        yield { type: "system", subtype: "status", status: "compacting" };
+        await compactionDone;
+        yield { type: "system", subtype: "compact_boundary", compact_metadata: { trigger: "auto" } };
+        // Silence again after compaction — long enough to trigger stall
+        await new Promise<void>((resolve) => {
+          opts.options.abortController.signal.addEventListener("abort", resolve, { once: true });
+        });
+      })();
+    });
+
+    const cap = captureConsole();
+    const queryPromise = testController.runQuery("test", undefined);
+
+    // Advance into the compaction window — stall should NOT fire
+    await vi.advanceTimersByTimeAsync(130_000);
+    expect(cap.lines.map(stripAnsi).join("\n")).not.toContain("Connection stalled");
+
+    // Resolve compaction
+    resolveCompaction();
+    await vi.advanceTimersByTimeAsync(10);
+
+    // Advance past stall threshold again, now after compaction
+    await vi.advanceTimersByTimeAsync(130_000);
+    await queryPromise;
+    cap.restore();
+
+    const output = cap.lines.map(stripAnsi).join("\n");
+    expect(output).toContain("Connection stalled before receiving a response");
+  });
+});


### PR DESCRIPTION
## Summary

- Track `isCompacting` state in `AgentController.runQuery()`, set when the SDK emits `{ type: "system", subtype: "status", status: "compacting" }` and cleared on `compact_boundary` or any non-system message
- Skip the stall watcher logic (`stallRetry` + abort) while `isCompacting` is true, since compaction can legitimately take longer than the 120-second threshold
- After compaction ends, normal stall detection resumes with a fresh 120-second window

## Test plan

- [x] New test: stall watcher does NOT trigger `stallRetry` when silence exceeds threshold while a `compacting` status is active
- [x] New test: stall detection resumes correctly after compaction completes (`compact_boundary` received)
- [x] All existing stall detection tests continue to pass unchanged (non-compaction stalls still fire normally)
- [x] Full test suite: 1932 tests pass, 0 regressions

Closes #1130

🤖 Generated with [Claude Code](https://claude.com/claude-code)