### PR TITLE
fix: detach workspace on foreman rejection during /worker:resume

### DIFF
--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -797,24 +797,18 @@ export class WorkerController extends EventEmitter {
 
         const agentId = matches[0];
 
-        // Refuse to take over a workspace whose worker process is still alive.
-        const lockPath = path.join(workspaceDir, agentId, ".brunel.lock");
-        if (fs.existsSync(lockPath)) {
-          const pid = parseInt(fs.readFileSync(lockPath, "utf8").trim(), 10);
-          if (!isNaN(pid)) {
-            try {
-              process.kill(pid, 0); // throws ESRCH if not running
-              this.display.print(c.boldRed(`Worker ${agentId} (PID ${pid}) is still running. Stop it first.`));
-              return undefined;
-            } catch { /* process is gone — safe to resume */ }
-          }
-        }
-
         // Take on the dead worker's identity
         this.agentStatus.setAgentId(agentId);
 
-        // Attach to the existing workspace directory
-        await this.workspaceController!.attachExisting(agentId, this.options?.githubToken);
+        // Attach to the existing workspace directory. attach() enforces the
+        // live-lock check and throws if the workspace is still owned by a live
+        // process — no need to duplicate that check here.
+        try {
+          await this.workspaceController!.attachExisting(agentId, this.options?.githubToken);
+        } catch (err) {
+          this.display.print(c.boldRed(`Cannot resume: ${fmtError(err)}`));
+          return undefined;
+        }
         this._attachedViaResume = true;
 
         // Look up the last Claude session for this workspace
@@ -1100,7 +1094,7 @@ export class WorkerController extends EventEmitter {
         // If we attached a workspace for this resume but the foreman rejected us,
         // detach (release the lock) without destroying the directory.
         if (this._attachedViaResume) {
-          this.workspaceController?.workspace?.detach();
+          this.workspaceController?.onDetach();
           this._attachedViaResume = false;
         }
         this._deactivate();

--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -148,6 +148,9 @@ export class WorkerController extends EventEmitter {
   // ── Resume state ───────────────────────────────────────────────────────────
   private _isResuming = false;
   private _pendingResumeSessionId: string | undefined;
+  // True from attach() until the foreman accepts or rejects — lets the fatal
+  // error handler detach (not destroy) the workspace on rejection.
+  private _attachedViaResume = false;
 
   // ── Connection state (cleared by stop()) ──────────────────────────────────
   private ws: WebSocket | undefined;
@@ -812,6 +815,7 @@ export class WorkerController extends EventEmitter {
 
         // Attach to the existing workspace directory
         await this.workspaceController!.attachExisting(agentId, this.options?.githubToken);
+        this._attachedViaResume = true;
 
         // Look up the last Claude session for this workspace
         const workspaceDir2 = this.workspaceController!.workspace!.dir;
@@ -871,6 +875,7 @@ export class WorkerController extends EventEmitter {
     this._pendingClaimTaskId = undefined;
     this._isResuming = false;
     this._pendingResumeSessionId = undefined;
+    this._attachedViaResume = false;
     this._isReserved = false;
     this.lastSeenEventSeqId = undefined;
     this.ws = undefined;
@@ -1092,6 +1097,12 @@ export class WorkerController extends EventEmitter {
 
     if (msg.type === "foreman_error") {
       if (msg.fatal) {
+        // If we attached a workspace for this resume but the foreman rejected us,
+        // detach (release the lock) without destroying the directory.
+        if (this._attachedViaResume) {
+          this.workspaceController?.workspace?.detach();
+          this._attachedViaResume = false;
+        }
         this._deactivate();
         this.currentAc?.abort(); // abort any running query immediately
         this.ws?.close();
@@ -1111,6 +1122,7 @@ export class WorkerController extends EventEmitter {
 
     if (msg.type === "hello_ack") {
       this.reconnectAttempts = 0; // connection succeeded; reset backoff
+      this._attachedViaResume = false; // foreman accepted — workspace is legitimately ours
       if (msg.status === "cancelled") {
         // Task was reassigned while worker was disconnected — stop and reset.
         this.currentAc?.abort(); // abort any running query immediately

--- a/src/agent/controllers/workspace-controller.ts
+++ b/src/agent/controllers/workspace-controller.ts
@@ -210,6 +210,18 @@ export class WorkspaceController {
   }
 
   /**
+   * Detach from a resume-attached workspace without destroying it. Releases the
+   * lock file, clears isCreated, and returns to the original cwd. Called when
+   * the foreman rejects a resume attempt after attach() has already run.
+   */
+  onDetach(): void {
+    const { workspace } = this;
+    if (!workspace?.isCreated) return;
+    workspace.detach();
+    process.chdir(workspace.originalCwd);
+  }
+
+  /**
    * Confirm if unsafe, then destroy the workspace. Used during clean shutdown
    * (^D, /exit). Returns true if the caller should proceed with exit (no workspace,
    * workspace not yet created, or user confirmed), false if the user cancelled.

--- a/src/agent/models/workspace.ts
+++ b/src/agent/models/workspace.ts
@@ -31,6 +31,10 @@ export class Workspace extends EventEmitter {
   readonly workspaceDir: string;
   isCreated = false;
 
+  private get lockPath(): string {
+    return path.join(this.dir, ".brunel.lock");
+  }
+
   constructor(
     workspaceDir: string,
     readonly sessionId: string,
@@ -59,7 +63,7 @@ export class Workspace extends EventEmitter {
       await this._configureAuth();
       await this._npmInstall();
     }
-    fs.writeFileSync(path.join(this.dir, ".brunel.lock"), String(process.pid));
+    fs.writeFileSync(this.lockPath, String(process.pid));
     this._ensureLocallyIgnored(".brunel.lock");
     this.isCreated = true;
   }
@@ -77,7 +81,7 @@ export class Workspace extends EventEmitter {
     if (!fs.existsSync(path.join(this.dir, ".git"))) {
       throw new Error(`${this.dir} is not a git repository`);
     }
-    const lockPath = path.join(this.dir, ".brunel.lock");
+    const { lockPath } = this;
     if (fs.existsSync(lockPath)) {
       const existing = parseInt(fs.readFileSync(lockPath, "utf8").trim(), 10);
       if (!isNaN(existing) && isProcessAlive(existing)) {
@@ -113,7 +117,7 @@ export class Workspace extends EventEmitter {
       this.emit("clone-start", { repoUrl: this.repoUrl, dir: this.dir });
       await gitExec(["clone", this.repoUrl, this.dir], undefined);
       await this._configureAuth();
-      fs.writeFileSync(path.join(this.dir, ".brunel.lock"), String(process.pid));
+      fs.writeFileSync(this.lockPath, String(process.pid));
       this._ensureLocallyIgnored(".brunel.lock");
       await this._doReset(); // throws if still broken — propagates to caller
     }
@@ -221,8 +225,7 @@ export class Workspace extends EventEmitter {
    * Used when the foreman rejects a resume attempt after attach() has already run.
    */
   detach(): void {
-    const lockPath = path.join(this.dir, ".brunel.lock");
-    if (fs.existsSync(lockPath)) fs.rmSync(lockPath);
+    if (fs.existsSync(this.lockPath)) fs.rmSync(this.lockPath);
     this.isCreated = false;
   }
 

--- a/src/agent/models/workspace.ts
+++ b/src/agent/models/workspace.ts
@@ -77,8 +77,15 @@ export class Workspace extends EventEmitter {
     if (!fs.existsSync(path.join(this.dir, ".git"))) {
       throw new Error(`${this.dir} is not a git repository`);
     }
+    const lockPath = path.join(this.dir, ".brunel.lock");
+    if (fs.existsSync(lockPath)) {
+      const existing = parseInt(fs.readFileSync(lockPath, "utf8").trim(), 10);
+      if (!isNaN(existing) && isProcessAlive(existing)) {
+        throw new Error(`Workspace is owned by process ${existing}, which is still running`);
+      }
+    }
     await this._configureAuth();
-    fs.writeFileSync(path.join(this.dir, ".brunel.lock"), String(process.pid));
+    fs.writeFileSync(lockPath, String(process.pid));
     this._ensureLocallyIgnored(".brunel.lock");
     this.isCreated = true;
   }
@@ -206,6 +213,17 @@ export class Workspace extends EventEmitter {
       removed.push(dir);
     }
     return removed;
+  }
+
+  /**
+   * Undo an attach() without deleting the directory. Removes the lock file and
+   * clears isCreated so the workspace is no longer considered owned by this process.
+   * Used when the foreman rejects a resume attempt after attach() has already run.
+   */
+  detach(): void {
+    const lockPath = path.join(this.dir, ".brunel.lock");
+    if (fs.existsSync(lockPath)) fs.rmSync(lockPath);
+    this.isCreated = false;
   }
 
   /** Remove the entire checkout directory. */

--- a/tests/worker.resume.test.ts
+++ b/tests/worker.resume.test.ts
@@ -231,6 +231,55 @@ describe("/worker:resume — status in worker_hello", () => {
   });
 });
 
+// ── Foreman rejection rollback ─────────────────────────────────────────────────
+
+describe("/worker:resume — foreman rejection rollback", () => {
+  it("detaches workspace (removes lock) when foreman sends fatal error", async () => {
+    const agentId = "harold-aaaa-1111-2222-3333-bbbbccccdddd";
+    const workerDir = makeWorkspaceDir(agentId);
+
+    const { registry, getFakeWs } = makeSession(BASE_DIR);
+    await registry.execute("worker:resume", "harold-aaaa");
+
+    // Lock was written by attach() — confirm it exists
+    expect(fs.existsSync(path.join(workerDir, ".brunel.lock"))).toBe(true);
+
+    // Foreman rejects the resume
+    getFakeWs().emit("message", Buffer.from(JSON.stringify({
+      type: "foreman_error",
+      message: "Worker is currently connected — cannot resume",
+      fatal: true,
+    } satisfies Wire.ForemanMessage)));
+
+    // Lock should be gone — workspace detached
+    expect(fs.existsSync(path.join(workerDir, ".brunel.lock"))).toBe(false);
+    // Directory itself must still exist (not destroyed)
+    expect(fs.existsSync(workerDir)).toBe(true);
+  });
+
+  it("allows a second /worker:resume after a fatal rejection", async () => {
+    const agentId = "rufus-bbbb-1111-2222-3333-ccccddddeeee";
+    const workerDir = makeWorkspaceDir(agentId);
+
+    const { registry, getFakeWs, display } = makeSession(BASE_DIR);
+
+    // First attempt — foreman rejects
+    await registry.execute("worker:resume", "rufus-bbbb");
+    getFakeWs().emit("message", Buffer.from(JSON.stringify({
+      type: "foreman_error",
+      message: "Worker is currently connected",
+      fatal: true,
+    } satisfies Wire.ForemanMessage)));
+
+    // Second attempt — must not report "still running"
+    await registry.execute("worker:resume", "rufus-bbbb");
+    const printed = (display.print as ReturnType<typeof vi.fn>).mock.calls.map(([l]) => l as string).join("\n");
+    expect(printed).not.toMatch(/still running/i);
+    // Lock should exist again (written by the second attach)
+    expect(fs.existsSync(path.join(workerDir, ".brunel.lock"))).toBe(true);
+  });
+});
+
 // ── Wire protocol — PROTOCOL_VERSION ─────────────────────────────────────────
 
 describe("wire protocol — resume status", () => {

--- a/tests/worker.resume.test.ts
+++ b/tests/worker.resume.test.ts
@@ -234,15 +234,17 @@ describe("/worker:resume — status in worker_hello", () => {
 // ── Foreman rejection rollback ─────────────────────────────────────────────────
 
 describe("/worker:resume — foreman rejection rollback", () => {
-  it("detaches workspace (removes lock) when foreman sends fatal error", async () => {
+  it("detaches workspace (removes lock, restores cwd) when foreman sends fatal error", async () => {
     const agentId = "harold-aaaa-1111-2222-3333-bbbbccccdddd";
     const workerDir = makeWorkspaceDir(agentId);
+    const originalCwd = process.cwd();
 
     const { registry, getFakeWs } = makeSession(BASE_DIR);
     await registry.execute("worker:resume", "harold-aaaa");
 
-    // Lock was written by attach() — confirm it exists
+    // Lock was written by attach() and cwd was changed — confirm both
     expect(fs.existsSync(path.join(workerDir, ".brunel.lock"))).toBe(true);
+    expect(process.cwd()).toBe(workerDir);
 
     // Foreman rejects the resume
     getFakeWs().emit("message", Buffer.from(JSON.stringify({
@@ -255,6 +257,8 @@ describe("/worker:resume — foreman rejection rollback", () => {
     expect(fs.existsSync(path.join(workerDir, ".brunel.lock"))).toBe(false);
     // Directory itself must still exist (not destroyed)
     expect(fs.existsSync(workerDir)).toBe(true);
+    // cwd should be restored
+    expect(process.cwd()).toBe(originalCwd);
   });
 
   it("allows a second /worker:resume after a fatal rejection", async () => {

--- a/tests/workspace.test.ts
+++ b/tests/workspace.test.ts
@@ -490,6 +490,57 @@ describe("Workspace.attach", () => {
     const lines = fs.readFileSync(excludePath, "utf8").split("\n").map(l => l.trim());
     expect(lines).toContain(".brunel.lock");
   });
+
+  it("throws without overwriting lock when existing lock PID is alive", async () => {
+    const workerDir = path.join(BASE_DIR, WORKER_ID);
+    fs.mkdirSync(path.join(workerDir, ".git"), { recursive: true });
+    fs.writeFileSync(path.join(workerDir, ".brunel.lock"), String(process.pid));
+
+    const ws = new Workspace(BASE_DIR, WORKER_ID, REPO_URL, "/original-cwd", async () => true);
+    await expect(ws.attach()).rejects.toThrow(/still running/i);
+    expect(ws.isCreated).toBe(false);
+    // Lock should still have original PID, not be overwritten
+    expect(fs.readFileSync(path.join(workerDir, ".brunel.lock"), "utf8").trim()).toBe(String(process.pid));
+  });
+
+  it("proceeds when existing lock PID is dead", async () => {
+    const workerDir = path.join(BASE_DIR, WORKER_ID);
+    fs.mkdirSync(path.join(workerDir, ".git"), { recursive: true });
+    fs.writeFileSync(path.join(workerDir, ".brunel.lock"), "2147483647");
+
+    const ws = new Workspace(BASE_DIR, WORKER_ID, REPO_URL, "/original-cwd", async () => true);
+    await ws.attach();
+    expect(ws.isCreated).toBe(true);
+    expect(fs.readFileSync(path.join(workerDir, ".brunel.lock"), "utf8").trim()).toBe(String(process.pid));
+  });
+});
+
+// ── detach ─────────────────────────────────────────────────────────────────────
+
+describe("Workspace.detach", () => {
+  it("clears isCreated and removes the lock file without deleting the directory", async () => {
+    const workerDir = path.join(BASE_DIR, WORKER_ID);
+    fs.mkdirSync(path.join(workerDir, ".git"), { recursive: true });
+
+    const ws = new Workspace(BASE_DIR, WORKER_ID, REPO_URL, "/original-cwd", async () => true);
+    await ws.attach();
+    expect(ws.isCreated).toBe(true);
+
+    ws.detach();
+
+    expect(ws.isCreated).toBe(false);
+    expect(fs.existsSync(path.join(workerDir, ".brunel.lock"))).toBe(false);
+    expect(fs.existsSync(workerDir)).toBe(true);
+  });
+
+  it("is a no-op when no lock file exists", async () => {
+    const workerDir = path.join(BASE_DIR, WORKER_ID);
+    fs.mkdirSync(path.join(workerDir, ".git"), { recursive: true });
+
+    const ws = new Workspace(BASE_DIR, WORKER_ID, REPO_URL, "/original-cwd", async () => true);
+    expect(() => ws.detach()).not.toThrow();
+    expect(ws.isCreated).toBe(false);
+  });
 });
 
 // ── http.extraHeader auth ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `Workspace.attach()` now checks the existing lock PID **before** overwriting it, throwing (without setting `isCreated`) if the workspace is still live
- `WorkerController` tracks `_attachedViaResume` and calls `workspace.detach()` on a fatal `foreman_error`, releasing the lock without deleting the directory

## Root cause

When `/worker:resume` ran and the foreman rejected the connection (e.g. "worker currently connected"), `attach()` had already written the REPL's own PID to the lock file and set `isCreated = true`. A second resume attempt then read the REPL's own PID from the lock, found it alive, and refused with "still running. Stop it first." — causing the user to kill their own REPL, whose exit handler then destroyed the workspace and all unpushed work.

## Test plan

- `Workspace.attach()` throws without overwriting the lock when the existing PID is alive
- `Workspace.attach()` proceeds normally when the existing lock PID is dead
- `Workspace.detach()` clears `isCreated`, removes the lock, leaves the directory intact
- `WorkerController`: fatal foreman error removes the lock (workspace detached)
- `WorkerController`: a second `/worker:resume` succeeds after a fatal rejection

Fixes #1134