### PR TITLE
fix: use Basic auth for git to support classic PATs

### DIFF
--- a/docs/2026-05-04-github-app-phase2.md
+++ b/docs/2026-05-04-github-app-phase2.md
@@ -80,10 +80,10 @@ Workers use their own personal GitHub token (already obtained for identity verif
 **Git authentication uses `http.extraHeader`, not a token-in-URL.** After cloning, the workspace sets:
 
 ```bash
-git config --local http.https://github.com/.extraheader "Authorization: Bearer {token}"
+git config --local http.https://github.com/.extraheader "Authorization: Basic $(echo -n 'x-access-token:{token}' | base64)"
 ```
 
-The remote URL stays clean (`https://github.com/owner/repo.git`). This is how GitHub Actions handles `GITHUB_TOKEN` internally — the token doesn't appear in `git remote -v` or process listings. The existing clone-URL approach in `Workspace` is replaced with this pattern as part of this work.
+Basic auth with `x-access-token` as the username works for both classic PATs and GitHub App installation tokens. The remote URL stays clean (`https://github.com/owner/repo.git`) — the token doesn't appear in `git remote -v` or process listings. The existing clone-URL approach in `Workspace` is replaced with this pattern as part of this work.
 
 ### App not installed: clear error
 

--- a/src/agent/models/workspace.ts
+++ b/src/agent/models/workspace.ts
@@ -131,11 +131,12 @@ export class Workspace extends EventEmitter {
     await this._npmInstall();
   }
 
-  /** Set http.extraHeader so git auth uses a Bearer token instead of a token-in-URL. */
+  /** Set http.extraHeader so git auth uses Basic auth instead of a token-in-URL. */
   private async _configureAuth(): Promise<void> {
     if (!this.githubToken) return;
+    const encoded = Buffer.from(`x-access-token:${this.githubToken}`).toString("base64");
     await gitExec(
-      ["config", "--local", "http.https://github.com/.extraheader", `Authorization: Bearer ${this.githubToken}`],
+      ["config", "--local", "http.https://github.com/.extraheader", `Authorization: Basic ${encoded}`],
       this.dir,
     );
   }

--- a/tests/workspace.test.ts
+++ b/tests/workspace.test.ts
@@ -457,9 +457,10 @@ describe("Workspace.attach", () => {
     const ws = new Workspace(BASE_DIR, WORKER_ID, REPO_URL, "/original-cwd", async () => true, "ghp_token");
     await ws.attach();
 
+    const expected = "Authorization: Basic " + Buffer.from("x-access-token:ghp_token").toString("base64");
     expect(mockExecFile).toHaveBeenCalledWith(
       "git",
-      ["config", "--local", "http.https://github.com/.extraheader", "Authorization: Bearer ghp_token"],
+      ["config", "--local", "http.https://github.com/.extraheader", expected],
       { cwd: workerDir },
       expect.any(Function),
     );
@@ -556,9 +557,10 @@ async function makeWorkspaceWithToken(token: string): Promise<Workspace> {
 describe("Workspace git auth via extraHeader", () => {
   it("sets http.extraHeader via git config after clone when token is provided", async () => {
     await makeWorkspaceWithToken("ghp_mytoken");
+    const expected = "Authorization: Basic " + Buffer.from("x-access-token:ghp_mytoken").toString("base64");
     expect(mockExecFile).toHaveBeenCalledWith(
       "git",
-      ["config", "--local", "http.https://github.com/.extraheader", "Authorization: Bearer ghp_mytoken"],
+      ["config", "--local", "http.https://github.com/.extraheader", expected],
       { cwd: path.join(BASE_DIR, WORKER_ID) },
       expect.any(Function),
     );
@@ -589,9 +591,10 @@ describe("Workspace git auth via extraHeader", () => {
     fetchCalls = 0;
     await ws.reset();
 
+    const expected = "Authorization: Basic " + Buffer.from("x-access-token:ghp_mytoken").toString("base64");
     expect(mockExecFile).toHaveBeenCalledWith(
       "git",
-      ["config", "--local", "http.https://github.com/.extraheader", "Authorization: Bearer ghp_mytoken"],
+      ["config", "--local", "http.https://github.com/.extraheader", expected],
       { cwd: path.join(BASE_DIR, WORKER_ID) },
       expect.any(Function),
     );


### PR DESCRIPTION
## Summary

- `Workspace._configureAuth()` was setting `Authorization: Bearer <token>`, which GitHub's git-over-HTTPS server rejects for classic PATs (`github_pat_*` / `ghp_*`)
- Changed to `Authorization: Basic <base64(x-access-token:<token>)>`, which works for both classic PATs and App installation tokens
- Updated the three tests that asserted on the Bearer header format

## Test plan

- [x] Updated existing tests to assert Basic auth header format — watched them fail before implementing
- [x] Implemented fix — all 43 workspace tests pass
- [x] Full test suite: 1968 tests pass (5 DB test files skip due to no Supabase in this environment, same as before)

Closes #1119