### PR TITLE
feat: add /help command

### DIFF
--- a/src/agent/controllers/command-controller.ts
+++ b/src/agent/controllers/command-controller.ts
@@ -309,6 +309,60 @@ function listSkillNames(
 }
 
 /**
+ * Format a help listing from the given registry entries.
+ * With no namespace: lists root-level canonical commands, then shows available
+ * namespaces with command counts and a hint to drill down.
+ * With a namespace: lists only canonical commands directly under that namespace.
+ */
+export function formatHelp(entries: CommandEntry[], namespace?: string): string {
+  const canonical = entries.filter(e => !e.aliasFor);
+
+  if (namespace) {
+    const prefix = `${namespace}:`;
+    const ns = canonical
+      .filter(e => e.name.startsWith(prefix) && !e.name.slice(prefix.length).includes(":"))
+      .sort((a, b) => a.name.localeCompare(b.name));
+    if (ns.length === 0) return `No commands in namespace: ${namespace}`;
+    const maxLen = Math.max(...ns.map(e => e.name.length));
+    const lines = ns.map(e => `  /${e.name.padEnd(maxLen)}  ${e.description}`);
+    return `${namespace} commands:\n${lines.join("\n")}`;
+  }
+
+  const root = canonical
+    .filter(e => !e.name.includes(":"))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const namespaceCounts = new Map<string, number>();
+  for (const e of canonical) {
+    const colonIdx = e.name.indexOf(":");
+    if (colonIdx > 0) {
+      const ns = e.name.slice(0, colonIdx);
+      namespaceCounts.set(ns, (namespaceCounts.get(ns) ?? 0) + 1);
+    }
+  }
+
+  const parts: string[] = [];
+
+  if (root.length > 0) {
+    const maxLen = Math.max(...root.map(e => e.name.length));
+    const lines = root.map(e => `  /${e.name.padEnd(maxLen)}  ${e.description}`);
+    parts.push(`Commands:\n${lines.join("\n")}`);
+  }
+
+  if (namespaceCounts.size > 0) {
+    const nsList = [...namespaceCounts.keys()].sort();
+    const maxLen = Math.max(...nsList.map(n => n.length));
+    const lines = nsList.map(n => {
+      const count = namespaceCounts.get(n)!;
+      return `  ${n.padEnd(maxLen)}  (${count} command${count === 1 ? "" : "s"})`;
+    });
+    parts.push(`Namespaces:\n${lines.join("\n")}\n\nUse /help <namespace> to list commands in a namespace.`);
+  }
+
+  return parts.join("\n\n");
+}
+
+/**
  * Base registry of slash commands. Supports registration and lookup only.
  *
  * Supports scoped sub-registries via scoped(prefix): the returned registry

--- a/src/agent/controllers/command-controller.ts
+++ b/src/agent/controllers/command-controller.ts
@@ -308,58 +308,74 @@ function listSkillNames(
   return [...new Set(results)].sort();
 }
 
+export interface FormatHelpOptions {
+  /** Limit output to a single namespace. */
+  namespace?: string;
+  /** Foreman dashboard URL shown in the footer. Omitted when not provided. */
+  dashboardUrl?: string;
+}
+
+const README_URL = "https://github.com/jasoncrawford/brunel#readme";
+
+function fmtCommandList(cmds: CommandEntry[]): string {
+  const maxLen = Math.max(...cmds.map(e => e.name.length));
+  return cmds.map(e => `  /${e.name.padEnd(maxLen)}  ${e.description}`).join("\n");
+}
+
+function fmtFooter(dashboardUrl?: string): string {
+  const lines: string[] = [];
+  if (dashboardUrl) lines.push(`Foreman dashboard: ${dashboardUrl}`);
+  lines.push(`README: ${README_URL}`);
+  return lines.join("\n");
+}
+
 /**
  * Format a help listing from the given registry entries.
- * With no namespace: lists root-level canonical commands, then shows available
- * namespaces with command counts and a hint to drill down.
+ * Starts with a blank line to visually separate output from the prompt.
+ * With no namespace: lists root-level canonical commands first, then each
+ * namespace in its own labeled section, all in registration order.
  * With a namespace: lists only canonical commands directly under that namespace.
+ * Always ends with a footer containing the README URL and optional dashboard URL.
  */
-export function formatHelp(entries: CommandEntry[], namespace?: string): string {
+export function formatHelp(entries: CommandEntry[], opts: FormatHelpOptions = {}): string {
+  const { namespace, dashboardUrl } = opts;
   const canonical = entries.filter(e => !e.aliasFor);
+  const footer = fmtFooter(dashboardUrl);
 
   if (namespace) {
     const prefix = `${namespace}:`;
-    const ns = canonical
-      .filter(e => e.name.startsWith(prefix) && !e.name.slice(prefix.length).includes(":"))
-      .sort((a, b) => a.name.localeCompare(b.name));
-    if (ns.length === 0) return `No commands in namespace: ${namespace}`;
-    const maxLen = Math.max(...ns.map(e => e.name.length));
-    const lines = ns.map(e => `  /${e.name.padEnd(maxLen)}  ${e.description}`);
-    return `${namespace} commands:\n${lines.join("\n")}`;
+    const ns = canonical.filter(
+      e => e.name.startsWith(prefix) && !e.name.slice(prefix.length).includes(":"),
+    );
+    if (ns.length === 0) return `\nNo commands in namespace: ${namespace}\n\n${footer}`;
+    return `\n${fmtCommandList(ns)}\n\n${footer}`;
   }
 
-  const root = canonical
-    .filter(e => !e.name.includes(":"))
-    .sort((a, b) => a.name.localeCompare(b.name));
+  const root = canonical.filter(e => !e.name.includes(":"));
 
-  const namespaceCounts = new Map<string, number>();
+  // Collect namespaces in first-seen order (Map preserves insertion order).
+  const namespaceMap = new Map<string, CommandEntry[]>();
   for (const e of canonical) {
     const colonIdx = e.name.indexOf(":");
     if (colonIdx > 0) {
       const ns = e.name.slice(0, colonIdx);
-      namespaceCounts.set(ns, (namespaceCounts.get(ns) ?? 0) + 1);
+      if (!namespaceMap.has(ns)) namespaceMap.set(ns, []);
+      namespaceMap.get(ns)!.push(e);
     }
   }
 
   const parts: string[] = [];
 
   if (root.length > 0) {
-    const maxLen = Math.max(...root.map(e => e.name.length));
-    const lines = root.map(e => `  /${e.name.padEnd(maxLen)}  ${e.description}`);
-    parts.push(`Commands:\n${lines.join("\n")}`);
+    parts.push(fmtCommandList(root));
   }
 
-  if (namespaceCounts.size > 0) {
-    const nsList = [...namespaceCounts.keys()].sort();
-    const maxLen = Math.max(...nsList.map(n => n.length));
-    const lines = nsList.map(n => {
-      const count = namespaceCounts.get(n)!;
-      return `  ${n.padEnd(maxLen)}  (${count} command${count === 1 ? "" : "s"})`;
-    });
-    parts.push(`Namespaces:\n${lines.join("\n")}\n\nUse /help <namespace> to list commands in a namespace.`);
+  for (const [ns, cmds] of namespaceMap) {
+    parts.push(`${ns}:\n${fmtCommandList(cmds)}`);
   }
 
-  return parts.join("\n\n");
+  parts.push(footer);
+  return "\n" + parts.join("\n\n");
 }
 
 /**

--- a/src/agent/controllers/command-controller.ts
+++ b/src/agent/controllers/command-controller.ts
@@ -367,7 +367,7 @@ export function formatHelp(entries: CommandEntry[], opts: FormatHelpOptions = {}
   const parts: string[] = [];
 
   if (root.length > 0) {
-    parts.push(fmtCommandList(root));
+    parts.push(`commands:\n${fmtCommandList(root)}`);
   }
 
   for (const [ns, cmds] of namespaceMap) {

--- a/src/agent/controllers/worker-controller.ts
+++ b/src/agent/controllers/worker-controller.ts
@@ -604,22 +604,8 @@ export class WorkerController extends EventEmitter {
     await this.agentStatus.refreshBranch();
   }
 
-  /** Register /worker:complete, /worker:start, /worker:stop, /worker:claim into the given (already-scoped) registry. */
+  /** Register worker slash commands into the given (already-scoped) registry. */
   registerCommands(registry: CommandRegistry): void {
-    registry.register("complete", {
-      description: "Mark the current task as done",
-      aliases: ["done"],
-      handler: async () => {
-        if (!this._isActive) {
-          this.display.print(c.boldRed("Not connected to a foreman."));
-          return undefined;
-        }
-        try { return await this.completeCurrentTask(); } catch (err) {
-          if (err instanceof UserCancelledError) return undefined;
-          throw err;
-        }
-      },
-    });
     registry.register("start", {
       description: "Start accepting tasks from the foreman",
       aliases: ["ready"],
@@ -671,28 +657,6 @@ export class WorkerController extends EventEmitter {
         await this.stop();
       },
     });
-    registry.register("resume-events", {
-      description: "Resume processing of GitHub events, when paused, and process queued events",
-      handler: async () => {
-        if (!this._isActive) {
-          this.display.print(c.boldRed("Not connected to a foreman."));
-          return undefined;
-        }
-        if (!this._eventsPaused) {
-          this.display.print(c.amber("Event processing is not paused."));
-          return undefined;
-        }
-        const events = this.pendingEvents.splice(0);
-        this._eventsPaused = false;
-        this._syncPendingEventsStatus();
-        if (events.length === 0) {
-          this.display.print(c.amber("Event processing resumed — no events queued."));
-        } else if (this.currentTaskId && this.currentIssue) {
-          this.enqueuePrompt(this.buildAndLogEventPrompt(events), false);
-        }
-        return undefined;
-      },
-    });
     registry.register("claim", {
       description: "Claim a specific task by ID",
       canRunFromArgs: true,
@@ -739,6 +703,42 @@ export class WorkerController extends EventEmitter {
           this.sendClaimTask(taskId);
         } else {
           this._pendingClaimTaskId = taskId;
+        }
+        return undefined;
+      },
+    });
+    registry.register("complete", {
+      description: "Mark the current task as done",
+      aliases: ["done"],
+      handler: async () => {
+        if (!this._isActive) {
+          this.display.print(c.boldRed("Not connected to a foreman."));
+          return undefined;
+        }
+        try { return await this.completeCurrentTask(); } catch (err) {
+          if (err instanceof UserCancelledError) return undefined;
+          throw err;
+        }
+      },
+    });
+    registry.register("resume-events", {
+      description: "Resume processing of GitHub events, when paused, and process queued events",
+      handler: async () => {
+        if (!this._isActive) {
+          this.display.print(c.boldRed("Not connected to a foreman."));
+          return undefined;
+        }
+        if (!this._eventsPaused) {
+          this.display.print(c.amber("Event processing is not paused."));
+          return undefined;
+        }
+        const events = this.pendingEvents.splice(0);
+        this._eventsPaused = false;
+        this._syncPendingEventsStatus();
+        if (events.length === 0) {
+          this.display.print(c.amber("Event processing resumed — no events queued."));
+        } else if (this.currentTaskId && this.currentIssue) {
+          this.enqueuePrompt(this.buildAndLogEventPrompt(events), false);
         }
         return undefined;
       },

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -223,11 +223,10 @@ export class BrunelAgent {
     });
     registry.register("help", {
       description: "List available commands",
-      handler: async (args) => {
-        const namespace = args.trim() || undefined;
+      handler: async () => {
         const wsUrl = config.foremanUrl;
         const dashboardUrl = wsUrl.replace(/^wss:\/\//, "https://").replace(/^ws:\/\//, "http://");
-        this.display.print(formatHelp(registry.listAll(), { namespace, dashboardUrl }));
+        this.display.print(formatHelp(registry.listAll(), { dashboardUrl }));
       },
     });
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -18,7 +18,7 @@ import { Workspace } from "./models/workspace.js";
 import { GithubToken } from "./models/github-token.js";
 import { fmtError } from "../utils.js";
 import { Settings } from "./models/settings.js";
-import { CommandRegistry, CommandController } from "./controllers/command-controller.js";
+import { CommandRegistry, CommandController, formatHelp } from "./controllers/command-controller.js";
 import { SettingsController } from "./controllers/settings-controller.js";
 import { WorkspaceController } from "./controllers/workspace-controller.js";
 import { AgentController, logFull } from "./controllers/agent-controller.js";
@@ -219,6 +219,13 @@ export class BrunelAgent {
       exitAfterRunFromArgs: true,
       handler: async () => {
         process.stdout.write(`v${PACKAGE_VERSION} (protocol version ${PROTOCOL_VERSION})\n`);
+      },
+    });
+    registry.register("help", {
+      description: "List available commands",
+      handler: async (args) => {
+        const namespace = args.trim() || undefined;
+        this.display.print(formatHelp(registry.listAll(), namespace));
       },
     });
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -225,7 +225,9 @@ export class BrunelAgent {
       description: "List available commands",
       handler: async (args) => {
         const namespace = args.trim() || undefined;
-        this.display.print(formatHelp(registry.listAll(), namespace));
+        const wsUrl = config.foremanUrl;
+        const dashboardUrl = wsUrl.replace(/^wss:\/\//, "https://").replace(/^ws:\/\//, "http://");
+        this.display.print(formatHelp(registry.listAll(), { namespace, dashboardUrl }));
       },
     });
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -190,17 +190,6 @@ export class BrunelAgent {
     const registry = this.controller.registry;
     workspaceController.registerCommands(registry.scoped("workspace"));
     workerController.registerCommands(registry.scoped("worker"));
-    registry.register("exit", {
-      description: "Exit",
-      aliases: ["quit"],
-      handler: async () => {
-        if (workerController.isActive) {
-          await workerController.stop();
-          if (workerController.isActive) return undefined; // user cancelled
-        }
-        return "exit";
-      },
-    });
     registry.register("clear", {
       description: "Clear the conversation",
       handler: async () => {
@@ -227,6 +216,17 @@ export class BrunelAgent {
         const wsUrl = config.foremanUrl;
         const dashboardUrl = wsUrl.replace(/^wss:\/\//, "https://").replace(/^ws:\/\//, "http://");
         this.display.print(formatHelp(registry.listAll(), { dashboardUrl }));
+      },
+    });
+    registry.register("exit", {
+      description: "Exit",
+      aliases: ["quit"],
+      handler: async () => {
+        if (workerController.isActive) {
+          await workerController.stop();
+          if (workerController.isActive) return undefined; // user cancelled
+        }
+        return "exit";
       },
     });
 

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -46,6 +46,7 @@ describe("listAll", () => {
     expect(names).toContain("settings");
     expect(names).toContain("settings:model");
     expect(names).toContain("settings:effort");
+    expect(names).toContain("help");
     expect(names).toContain("worker:complete");
   });
 

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -26,7 +26,6 @@ export async function registerTestCommands(): Promise<CommandController> {
   const noopDisplay = { print: () => {}, printForemanMessage: () => {} } as WorkerDisplay;
   new WorkspaceController(undefined, noopDisplay, { verbose: false }).registerCommands(registry.scoped("workspace"));
   const noop = async () => {};
-  registry.register("exit",   { description: "Exit", aliases: ["quit"], handler: noop });
   registry.register("clear",  { description: "Clear the conversation", handler: noop });
   registry.register("settings", { description: "View and edit all settings", handler: noop });
   const settingsRegistry = registry.scoped("settings");
@@ -36,6 +35,7 @@ export async function registerTestCommands(): Promise<CommandController> {
   settingsRegistry.register("verbose",        { description: "Set verbose output mode", handler: noop });
   settingsRegistry.register("think-out-loud", { description: "Set think-out-loud mode", handler: noop });
   registry.register("help", { description: "List available commands", handler: noop });
+  registry.register("exit", { description: "Exit", aliases: ["quit"], handler: noop });
   const workerRegistry = registry.scoped("worker");
   workerRegistry.register("start",         { description: "Start accepting tasks from the foreman", handler: noop });
   workerRegistry.register("stop",          { description: "Disconnect from the foreman", handler: noop });

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -37,13 +37,10 @@ export async function registerTestCommands(): Promise<CommandController> {
   settingsRegistry.register("think-out-loud", { description: "Set think-out-loud mode", handler: noop });
   registry.register("help", { description: "List available commands", handler: noop });
   const workerRegistry = registry.scoped("worker");
-  workerRegistry.register("complete", {
-    description: "Mark the current task as done",
-    aliases: ["done"],
-    handler: async () => "task-complete",
-  });
-  workerRegistry.register("start", { description: "Connect to the foreman and start accepting tasks", handler: noop });
-  workerRegistry.register("stop", { description: "Disconnect from the foreman", handler: noop });
-  workerRegistry.register("claim", { description: "Claim a specific task by ID", handler: noop });
+  workerRegistry.register("start",         { description: "Start accepting tasks from the foreman", handler: noop });
+  workerRegistry.register("stop",          { description: "Disconnect from the foreman", handler: noop });
+  workerRegistry.register("claim",         { description: "Claim a specific task by ID", handler: noop });
+  workerRegistry.register("complete",      { description: "Mark the current task as done", aliases: ["done"], handler: async () => "task-complete" });
+  workerRegistry.register("resume-events", { description: "Resume processing of GitHub events", handler: noop });
   return controller;
 }

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -30,11 +30,12 @@ export async function registerTestCommands(): Promise<CommandController> {
   registry.register("clear",  { description: "Clear the conversation", handler: noop });
   registry.register("settings", { description: "View and edit all settings", handler: noop });
   const settingsRegistry = registry.scoped("settings");
-  settingsRegistry.register("model",       { description: "Select the Claude model to use", handler: noop });
-  settingsRegistry.register("effort",      { description: "Set the effort level for Claude's thinking", handler: noop });
-  settingsRegistry.register("permissions", { description: "Set the permission mode for tool use", handler: noop });
-  settingsRegistry.register("verbose",     { description: "Set verbose output mode", handler: noop });
+  settingsRegistry.register("model",          { description: "Select the Claude model to use", handler: noop });
+  settingsRegistry.register("effort",         { description: "Set the effort level for Claude's thinking", handler: noop });
+  settingsRegistry.register("permissions",    { description: "Set the permission mode for tool use", handler: noop });
+  settingsRegistry.register("verbose",        { description: "Set verbose output mode", handler: noop });
   settingsRegistry.register("think-out-loud", { description: "Set think-out-loud mode", handler: noop });
+  registry.register("help", { description: "List available commands", handler: noop });
   const workerRegistry = registry.scoped("worker");
   workerRegistry.register("complete", {
     description: "Mark the current task as done",

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -34,6 +34,7 @@ export async function registerTestCommands(): Promise<CommandController> {
   settingsRegistry.register("permissions",    { description: "Set the permission mode for tool use", handler: noop });
   settingsRegistry.register("verbose",        { description: "Set verbose output mode", handler: noop });
   settingsRegistry.register("think-out-loud", { description: "Set think-out-loud mode", handler: noop });
+  registry.register("version", { description: "Print version information", handler: noop });
   registry.register("help", { description: "List available commands", handler: noop });
   registry.register("exit", { description: "Exit", aliases: ["quit"], handler: noop });
   const workerRegistry = registry.scoped("worker");

--- a/tests/repl.autocomplete.test.ts
+++ b/tests/repl.autocomplete.test.ts
@@ -64,7 +64,7 @@ describe("listCommandNames", () => {
     expect(result).toEqual([
       "clear", "exit", "help", "settings", "settings:effort", "settings:model",
       "settings:permissions", "settings:think-out-loud", "settings:verbose",
-      "worker:claim", "worker:complete", "worker:start", "worker:stop",
+      "worker:claim", "worker:complete", "worker:resume-events", "worker:start", "worker:stop",
       "workspace:create", "workspace:prune", "workspace:remove", "workspace:reset",
     ]);
   });

--- a/tests/repl.autocomplete.test.ts
+++ b/tests/repl.autocomplete.test.ts
@@ -64,7 +64,7 @@ describe("listCommandNames", () => {
     expect(result).toEqual([
       "clear", "exit", "help", "settings", "settings:effort", "settings:model",
       "settings:permissions", "settings:think-out-loud", "settings:verbose",
-      "worker:claim", "worker:complete", "worker:resume-events", "worker:start", "worker:stop",
+      "version", "worker:claim", "worker:complete", "worker:resume-events", "worker:start", "worker:stop",
       "workspace:create", "workspace:prune", "workspace:remove", "workspace:reset",
     ]);
   });

--- a/tests/repl.autocomplete.test.ts
+++ b/tests/repl.autocomplete.test.ts
@@ -62,7 +62,7 @@ describe("listCommandNames", () => {
   it("returns only builtins when directory is missing", () => {
     const result = registry.listCommandNames(() => null);
     expect(result).toEqual([
-      "clear", "exit", "settings", "settings:effort", "settings:model",
+      "clear", "exit", "help", "settings", "settings:effort", "settings:model",
       "settings:permissions", "settings:think-out-loud", "settings:verbose",
       "worker:claim", "worker:complete", "worker:start", "worker:stop",
       "workspace:create", "workspace:prune", "workspace:remove", "workspace:reset",

--- a/tests/repl.help.test.ts
+++ b/tests/repl.help.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import { formatHelp, type CommandEntry } from "../src/agent/controllers/command-controller.js";
+
+function makeEntry(name: string, description: string, extra: Partial<CommandEntry> = {}): CommandEntry {
+  return { name, description, handler: async () => {}, ...extra };
+}
+
+// ── formatHelp — no namespace ─────────────────────────────────────────────────
+
+describe("formatHelp — no namespace", () => {
+  const entries: CommandEntry[] = [
+    makeEntry("clear",              "Clear the conversation"),
+    makeEntry("exit",               "Exit (alias: quit)", { aliases: ["quit"] }),
+    makeEntry("quit",               "Exit (alias for exit)",  { aliasFor: "exit" }),
+    makeEntry("help",               "Show available commands"),
+    makeEntry("worker:complete",    "Mark the current task as done", { aliases: ["worker:done"] }),
+    makeEntry("worker:done",        "Mark the current task as done (alias for worker:complete)", { aliasFor: "worker:complete" }),
+    makeEntry("worker:start",       "Connect to the foreman"),
+    makeEntry("workspace:create",   "Create an isolated git checkout"),
+    makeEntry("workspace:reset",    "Reset to clean main branch"),
+  ];
+
+  it("includes root-level canonical commands", () => {
+    const text = formatHelp(entries);
+    expect(text).toContain("/clear");
+    expect(text).toContain("/exit");
+    expect(text).toContain("/help");
+  });
+
+  it("excludes alias entries from the listing", () => {
+    const text = formatHelp(entries);
+    // /quit is an alias for exit — should not appear as a top-level command
+    const lines = text.split("\n");
+    expect(lines.some(l => l.match(/^\s+\/quit\s/))).toBe(false);
+    // /worker:done is an alias — should not appear as a top-level entry
+    expect(lines.some(l => l.match(/^\s+\/worker:done\s/))).toBe(false);
+  });
+
+  it("lists namespaces in a Namespaces section", () => {
+    const text = formatHelp(entries);
+    expect(text).toContain("worker");
+    expect(text).toContain("workspace");
+    expect(text).toContain("Namespaces:");
+  });
+
+  it("shows namespace command counts", () => {
+    const text = formatHelp(entries);
+    // worker has 2 canonical commands (complete, start); workspace has 2
+    expect(text).toMatch(/worker\s+.*2 command/);
+    expect(text).toMatch(/workspace\s+.*2 command/);
+  });
+
+  it("includes hint to use /help <namespace>", () => {
+    const text = formatHelp(entries);
+    expect(text).toContain("/help <namespace>");
+  });
+
+  it("root commands are sorted alphabetically", () => {
+    const text = formatHelp(entries);
+    const clearPos   = text.indexOf("/clear");
+    const exitPos    = text.indexOf("/exit");
+    const helpPos    = text.indexOf("/help");
+    expect(clearPos).toBeLessThan(exitPos);
+    expect(exitPos).toBeLessThan(helpPos);
+  });
+
+  it("includes command descriptions", () => {
+    const text = formatHelp(entries);
+    expect(text).toContain("Clear the conversation");
+  });
+});
+
+// ── formatHelp — with namespace ───────────────────────────────────────────────
+
+describe("formatHelp — with namespace", () => {
+  const entries: CommandEntry[] = [
+    makeEntry("clear",            "Clear the conversation"),
+    makeEntry("workspace:create", "Create an isolated git checkout"),
+    makeEntry("workspace:reset",  "Reset to clean main branch"),
+    makeEntry("workspace:remove", "Remove the checkout"),
+    makeEntry("worker:start",     "Connect to the foreman"),
+    makeEntry("worker:complete",  "Mark the current task as done", { aliases: ["worker:done"] }),
+    makeEntry("worker:done",      "Mark done (alias for worker:complete)", { aliasFor: "worker:complete" }),
+  ];
+
+  it("shows only commands in the given namespace", () => {
+    const text = formatHelp(entries, "workspace");
+    expect(text).toContain("/workspace:create");
+    expect(text).toContain("/workspace:reset");
+    expect(text).toContain("/workspace:remove");
+    expect(text).not.toContain("/worker:");
+    expect(text).not.toContain("/clear");
+  });
+
+  it("excludes alias entries from namespace listing", () => {
+    const text = formatHelp(entries, "worker");
+    expect(text).toContain("/worker:complete");
+    const lines = text.split("\n");
+    expect(lines.some(l => l.match(/^\s+\/worker:done\s/))).toBe(false);
+  });
+
+  it("includes descriptions for namespace commands", () => {
+    const text = formatHelp(entries, "workspace");
+    expect(text).toContain("Create an isolated git checkout");
+  });
+
+  it("shows a header naming the namespace", () => {
+    const text = formatHelp(entries, "workspace");
+    expect(text).toMatch(/workspace/i);
+  });
+
+  it("returns a 'no commands' message for unknown namespace", () => {
+    const text = formatHelp(entries, "nonexistent");
+    expect(text).toContain("nonexistent");
+    expect(text).toMatch(/no commands/i);
+  });
+});
+
+// ── formatHelp — edge cases ───────────────────────────────────────────────────
+
+describe("formatHelp — edge cases", () => {
+  it("handles empty entry list", () => {
+    const text = formatHelp([]);
+    expect(typeof text).toBe("string");
+  });
+
+  it("handles only namespace commands (no root commands)", () => {
+    const entries = [
+      makeEntry("worker:start", "Connect"),
+      makeEntry("worker:stop",  "Disconnect"),
+    ];
+    const text = formatHelp(entries);
+    expect(text).toContain("worker");
+    expect(text).not.toContain("Commands:\n"); // no root section
+  });
+
+  it("singular 'command' for namespace with exactly one command", () => {
+    const entries = [makeEntry("worker:start", "Connect")];
+    const text = formatHelp(entries);
+    expect(text).toMatch(/1 command[^s]/);
+  });
+});

--- a/tests/repl.help.test.ts
+++ b/tests/repl.help.test.ts
@@ -136,6 +136,13 @@ describe("root command registration order", () => {
     helpText = formatHelp(controller.registry.listAll());
   });
 
+  it("/version appears before /help in the root commands section", () => {
+    const versionPos = helpText.indexOf("/version");
+    const helpPos    = helpText.indexOf("/help");
+    expect(versionPos).toBeGreaterThan(0);
+    expect(helpPos).toBeGreaterThan(versionPos);
+  });
+
   it("/exit appears after /help in the root commands section", () => {
     const helpPos = helpText.indexOf("/help");
     const exitPos = helpText.indexOf("/exit");

--- a/tests/repl.help.test.ts
+++ b/tests/repl.help.test.ts
@@ -5,114 +5,145 @@ function makeEntry(name: string, description: string, extra: Partial<CommandEntr
   return { name, description, handler: async () => {}, ...extra };
 }
 
-// ── formatHelp — no namespace ─────────────────────────────────────────────────
+const ENTRIES: CommandEntry[] = [
+  makeEntry("clear",            "Clear the conversation"),
+  makeEntry("exit",             "Exit (alias: quit)", { aliases: ["quit"] }),
+  makeEntry("quit",             "Exit (alias for exit)", { aliasFor: "exit" }),
+  makeEntry("help",             "List available commands"),
+  makeEntry("worker:complete",  "Mark the current task as done", { aliases: ["worker:done"] }),
+  makeEntry("worker:done",      "Mark done (alias for worker:complete)", { aliasFor: "worker:complete" }),
+  makeEntry("worker:start",     "Connect to the foreman"),
+  makeEntry("workspace:create", "Create an isolated git checkout"),
+  makeEntry("workspace:reset",  "Reset to clean main branch"),
+];
+
+// ── formatHelp — no namespace (show all) ──────────────────────────────────────
 
 describe("formatHelp — no namespace", () => {
-  const entries: CommandEntry[] = [
-    makeEntry("clear",              "Clear the conversation"),
-    makeEntry("exit",               "Exit (alias: quit)", { aliases: ["quit"] }),
-    makeEntry("quit",               "Exit (alias for exit)",  { aliasFor: "exit" }),
-    makeEntry("help",               "Show available commands"),
-    makeEntry("worker:complete",    "Mark the current task as done", { aliases: ["worker:done"] }),
-    makeEntry("worker:done",        "Mark the current task as done (alias for worker:complete)", { aliasFor: "worker:complete" }),
-    makeEntry("worker:start",       "Connect to the foreman"),
-    makeEntry("workspace:create",   "Create an isolated git checkout"),
-    makeEntry("workspace:reset",    "Reset to clean main branch"),
-  ];
+  it("starts with a blank line", () => {
+    const text = formatHelp(ENTRIES);
+    expect(text.startsWith("\n")).toBe(true);
+  });
 
   it("includes root-level canonical commands", () => {
-    const text = formatHelp(entries);
+    const text = formatHelp(ENTRIES);
     expect(text).toContain("/clear");
     expect(text).toContain("/exit");
     expect(text).toContain("/help");
   });
 
+  it("includes namespace commands in the same output", () => {
+    const text = formatHelp(ENTRIES);
+    expect(text).toContain("/worker:complete");
+    expect(text).toContain("/workspace:create");
+  });
+
+  it("shows each namespace as its own labeled section", () => {
+    const text = formatHelp(ENTRIES);
+    expect(text).toContain("worker:");
+    expect(text).toContain("workspace:");
+  });
+
+  it("root commands appear before namespace sections", () => {
+    const text = formatHelp(ENTRIES);
+    const clearPos    = text.indexOf("/clear");
+    const workerPos   = text.indexOf("worker:");
+    expect(clearPos).toBeLessThan(workerPos);
+  });
+
   it("excludes alias entries from the listing", () => {
-    const text = formatHelp(entries);
-    // /quit is an alias for exit — should not appear as a top-level command
+    const text = formatHelp(ENTRIES);
     const lines = text.split("\n");
+    // /quit is an alias for exit — should not appear as a top-level command
     expect(lines.some(l => l.match(/^\s+\/quit\s/))).toBe(false);
-    // /worker:done is an alias — should not appear as a top-level entry
+    // /worker:done is an alias — should not appear as a section entry
     expect(lines.some(l => l.match(/^\s+\/worker:done\s/))).toBe(false);
   });
 
-  it("lists namespaces in a Namespaces section", () => {
-    const text = formatHelp(entries);
-    expect(text).toContain("worker");
-    expect(text).toContain("workspace");
-    expect(text).toContain("Namespaces:");
-  });
-
-  it("shows namespace command counts", () => {
-    const text = formatHelp(entries);
-    // worker has 2 canonical commands (complete, start); workspace has 2
-    expect(text).toMatch(/worker\s+.*2 command/);
-    expect(text).toMatch(/workspace\s+.*2 command/);
-  });
-
-  it("includes hint to use /help <namespace>", () => {
-    const text = formatHelp(entries);
-    expect(text).toContain("/help <namespace>");
-  });
-
-  it("root commands are sorted alphabetically", () => {
-    const text = formatHelp(entries);
-    const clearPos   = text.indexOf("/clear");
-    const exitPos    = text.indexOf("/exit");
-    const helpPos    = text.indexOf("/help");
+  it("preserves registration order for root commands (no alphabetizing)", () => {
+    // Registration order: clear, exit, help — so clear before exit before help
+    const text = formatHelp(ENTRIES);
+    const clearPos = text.indexOf("/clear");
+    const exitPos  = text.indexOf("/exit");
+    const helpPos  = text.indexOf("/help");
     expect(clearPos).toBeLessThan(exitPos);
     expect(exitPos).toBeLessThan(helpPos);
   });
 
+  it("preserves registration order within namespaces", () => {
+    // worker:complete registered before worker:start
+    const text = formatHelp(ENTRIES);
+    const completePos = text.indexOf("/worker:complete");
+    const startPos    = text.indexOf("/worker:start");
+    expect(completePos).toBeLessThan(startPos);
+  });
+
   it("includes command descriptions", () => {
-    const text = formatHelp(entries);
+    const text = formatHelp(ENTRIES);
     expect(text).toContain("Clear the conversation");
+    expect(text).toContain("Mark the current task as done");
+  });
+
+  it("includes footer with README link", () => {
+    const text = formatHelp(ENTRIES);
+    expect(text).toContain("README:");
+    expect(text).toContain("https://github.com/jasoncrawford/brunel#readme");
+  });
+
+  it("includes dashboard URL when provided", () => {
+    const text = formatHelp(ENTRIES, { dashboardUrl: "https://brunel.dev" });
+    expect(text).toContain("Foreman dashboard: https://brunel.dev");
+  });
+
+  it("omits dashboard line when dashboardUrl not provided", () => {
+    const text = formatHelp(ENTRIES);
+    expect(text).not.toContain("Foreman dashboard:");
   });
 });
 
 // ── formatHelp — with namespace ───────────────────────────────────────────────
 
 describe("formatHelp — with namespace", () => {
-  const entries: CommandEntry[] = [
-    makeEntry("clear",            "Clear the conversation"),
-    makeEntry("workspace:create", "Create an isolated git checkout"),
-    makeEntry("workspace:reset",  "Reset to clean main branch"),
-    makeEntry("workspace:remove", "Remove the checkout"),
-    makeEntry("worker:start",     "Connect to the foreman"),
-    makeEntry("worker:complete",  "Mark the current task as done", { aliases: ["worker:done"] }),
-    makeEntry("worker:done",      "Mark done (alias for worker:complete)", { aliasFor: "worker:complete" }),
-  ];
+  it("starts with a blank line", () => {
+    const text = formatHelp(ENTRIES, { namespace: "workspace" });
+    expect(text.startsWith("\n")).toBe(true);
+  });
 
   it("shows only commands in the given namespace", () => {
-    const text = formatHelp(entries, "workspace");
+    const text = formatHelp(ENTRIES, { namespace: "workspace" });
     expect(text).toContain("/workspace:create");
     expect(text).toContain("/workspace:reset");
-    expect(text).toContain("/workspace:remove");
     expect(text).not.toContain("/worker:");
     expect(text).not.toContain("/clear");
   });
 
   it("excludes alias entries from namespace listing", () => {
-    const text = formatHelp(entries, "worker");
+    const text = formatHelp(ENTRIES, { namespace: "worker" });
     expect(text).toContain("/worker:complete");
     const lines = text.split("\n");
     expect(lines.some(l => l.match(/^\s+\/worker:done\s/))).toBe(false);
   });
 
   it("includes descriptions for namespace commands", () => {
-    const text = formatHelp(entries, "workspace");
+    const text = formatHelp(ENTRIES, { namespace: "workspace" });
     expect(text).toContain("Create an isolated git checkout");
   });
 
-  it("shows a header naming the namespace", () => {
-    const text = formatHelp(entries, "workspace");
-    expect(text).toMatch(/workspace/i);
-  });
-
   it("returns a 'no commands' message for unknown namespace", () => {
-    const text = formatHelp(entries, "nonexistent");
+    const text = formatHelp(ENTRIES, { namespace: "nonexistent" });
     expect(text).toContain("nonexistent");
     expect(text).toMatch(/no commands/i);
+  });
+
+  it("includes footer with README link", () => {
+    const text = formatHelp(ENTRIES, { namespace: "workspace" });
+    expect(text).toContain("README:");
+    expect(text).toContain("https://github.com/jasoncrawford/brunel#readme");
+  });
+
+  it("includes dashboard URL when provided", () => {
+    const text = formatHelp(ENTRIES, { namespace: "workspace", dashboardUrl: "https://brunel.dev" });
+    expect(text).toContain("Foreman dashboard: https://brunel.dev");
   });
 });
 
@@ -130,13 +161,7 @@ describe("formatHelp — edge cases", () => {
       makeEntry("worker:stop",  "Disconnect"),
     ];
     const text = formatHelp(entries);
-    expect(text).toContain("worker");
-    expect(text).not.toContain("Commands:\n"); // no root section
-  });
-
-  it("singular 'command' for namespace with exactly one command", () => {
-    const entries = [makeEntry("worker:start", "Connect")];
-    const text = formatHelp(entries);
-    expect(text).toMatch(/1 command[^s]/);
+    expect(text).toContain("worker:");
+    expect(text).toContain("/worker:start");
   });
 });

--- a/tests/repl.help.test.ts
+++ b/tests/repl.help.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { formatHelp, type CommandEntry } from "../src/agent/controllers/command-controller.js";
+import { registerTestCommands } from "./helpers.js";
 
 function makeEntry(name: string, description: string, extra: Partial<CommandEntry> = {}): CommandEntry {
   return { name, description, handler: async () => {}, ...extra };
@@ -17,12 +18,21 @@ const ENTRIES: CommandEntry[] = [
   makeEntry("workspace:reset",  "Reset to clean main branch"),
 ];
 
-// ── formatHelp — no namespace (show all) ──────────────────────────────────────
+// ── formatHelp — layout ───────────────────────────────────────────────────────
 
-describe("formatHelp — no namespace", () => {
+describe("formatHelp — layout", () => {
   it("starts with a blank line", () => {
     const text = formatHelp(ENTRIES);
     expect(text.startsWith("\n")).toBe(true);
+  });
+
+  it("has a 'commands:' header above root commands", () => {
+    const text = formatHelp(ENTRIES);
+    expect(text).toContain("commands:");
+    // header appears before the root command lines
+    const headerPos  = text.indexOf("commands:");
+    const clearPos   = text.indexOf("/clear");
+    expect(headerPos).toBeLessThan(clearPos);
   });
 
   it("includes root-level canonical commands", () => {
@@ -46,22 +56,19 @@ describe("formatHelp — no namespace", () => {
 
   it("root commands appear before namespace sections", () => {
     const text = formatHelp(ENTRIES);
-    const clearPos    = text.indexOf("/clear");
-    const workerPos   = text.indexOf("worker:");
+    const clearPos  = text.indexOf("/clear");
+    const workerPos = text.indexOf("worker:");
     expect(clearPos).toBeLessThan(workerPos);
   });
 
   it("excludes alias entries from the listing", () => {
     const text = formatHelp(ENTRIES);
     const lines = text.split("\n");
-    // /quit is an alias for exit — should not appear as a top-level command
     expect(lines.some(l => l.match(/^\s+\/quit\s/))).toBe(false);
-    // /worker:done is an alias — should not appear as a section entry
     expect(lines.some(l => l.match(/^\s+\/worker:done\s/))).toBe(false);
   });
 
-  it("preserves registration order for root commands (no alphabetizing)", () => {
-    // Registration order: clear, exit, help — so clear before exit before help
+  it("preserves registration order for root commands", () => {
     const text = formatHelp(ENTRIES);
     const clearPos = text.indexOf("/clear");
     const exitPos  = text.indexOf("/exit");
@@ -71,7 +78,6 @@ describe("formatHelp — no namespace", () => {
   });
 
   it("preserves registration order within namespaces", () => {
-    // worker:complete registered before worker:start
     const text = formatHelp(ENTRIES);
     const completePos = text.indexOf("/worker:complete");
     const startPos    = text.indexOf("/worker:start");
@@ -101,52 +107,6 @@ describe("formatHelp — no namespace", () => {
   });
 });
 
-// ── formatHelp — with namespace ───────────────────────────────────────────────
-
-describe("formatHelp — with namespace", () => {
-  it("starts with a blank line", () => {
-    const text = formatHelp(ENTRIES, { namespace: "workspace" });
-    expect(text.startsWith("\n")).toBe(true);
-  });
-
-  it("shows only commands in the given namespace", () => {
-    const text = formatHelp(ENTRIES, { namespace: "workspace" });
-    expect(text).toContain("/workspace:create");
-    expect(text).toContain("/workspace:reset");
-    expect(text).not.toContain("/worker:");
-    expect(text).not.toContain("/clear");
-  });
-
-  it("excludes alias entries from namespace listing", () => {
-    const text = formatHelp(ENTRIES, { namespace: "worker" });
-    expect(text).toContain("/worker:complete");
-    const lines = text.split("\n");
-    expect(lines.some(l => l.match(/^\s+\/worker:done\s/))).toBe(false);
-  });
-
-  it("includes descriptions for namespace commands", () => {
-    const text = formatHelp(ENTRIES, { namespace: "workspace" });
-    expect(text).toContain("Create an isolated git checkout");
-  });
-
-  it("returns a 'no commands' message for unknown namespace", () => {
-    const text = formatHelp(ENTRIES, { namespace: "nonexistent" });
-    expect(text).toContain("nonexistent");
-    expect(text).toMatch(/no commands/i);
-  });
-
-  it("includes footer with README link", () => {
-    const text = formatHelp(ENTRIES, { namespace: "workspace" });
-    expect(text).toContain("README:");
-    expect(text).toContain("https://github.com/jasoncrawford/brunel#readme");
-  });
-
-  it("includes dashboard URL when provided", () => {
-    const text = formatHelp(ENTRIES, { namespace: "workspace", dashboardUrl: "https://brunel.dev" });
-    expect(text).toContain("Foreman dashboard: https://brunel.dev");
-  });
-});
-
 // ── formatHelp — edge cases ───────────────────────────────────────────────────
 
 describe("formatHelp — edge cases", () => {
@@ -163,5 +123,32 @@ describe("formatHelp — edge cases", () => {
     const text = formatHelp(entries);
     expect(text).toContain("worker:");
     expect(text).toContain("/worker:start");
+  });
+});
+
+// ── Worker command registration order ─────────────────────────────────────────
+
+describe("worker command registration order", () => {
+  let helpText: string;
+
+  beforeEach(async () => {
+    const controller = await registerTestCommands();
+    helpText = formatHelp(controller.registry.listAll());
+  });
+
+  it("worker:start appears before worker:stop", () => {
+    expect(helpText.indexOf("/worker:start")).toBeLessThan(helpText.indexOf("/worker:stop"));
+  });
+
+  it("worker:stop appears before worker:claim", () => {
+    expect(helpText.indexOf("/worker:stop")).toBeLessThan(helpText.indexOf("/worker:claim"));
+  });
+
+  it("worker:claim appears before worker:complete", () => {
+    expect(helpText.indexOf("/worker:claim")).toBeLessThan(helpText.indexOf("/worker:complete"));
+  });
+
+  it("worker:complete appears before worker:resume-events", () => {
+    expect(helpText.indexOf("/worker:complete")).toBeLessThan(helpText.indexOf("/worker:resume-events"));
   });
 });

--- a/tests/repl.help.test.ts
+++ b/tests/repl.help.test.ts
@@ -126,6 +126,24 @@ describe("formatHelp — edge cases", () => {
   });
 });
 
+// ── Root command registration order ──────────────────────────────────────────
+
+describe("root command registration order", () => {
+  let helpText: string;
+
+  beforeEach(async () => {
+    const controller = await registerTestCommands();
+    helpText = formatHelp(controller.registry.listAll());
+  });
+
+  it("/exit appears after /help in the root commands section", () => {
+    const helpPos = helpText.indexOf("/help");
+    const exitPos = helpText.indexOf("/exit");
+    expect(helpPos).toBeGreaterThan(0);
+    expect(exitPos).toBeGreaterThan(helpPos);
+  });
+});
+
 // ── Worker command registration order ─────────────────────────────────────────
 
 describe("worker command registration order", () => {

--- a/tests/repl.slash.test.ts
+++ b/tests/repl.slash.test.ts
@@ -77,6 +77,10 @@ describe("parseSlashCommand", () => {
   it("recognizes /settings", () => {
     expect(registry.parseSlashCommand("/settings")).toEqual({ type: "command", name: "settings" });
   });
+
+  it("recognizes /help", () => {
+    expect(registry.parseSlashCommand("/help")).toEqual({ type: "command", name: "help" });
+  });
 });
 
 // ── Unambiguous namespace-less resolution ─────────────────────────────────────

--- a/tests/repl.slash.test.ts
+++ b/tests/repl.slash.test.ts
@@ -81,6 +81,10 @@ describe("parseSlashCommand", () => {
   it("recognizes /help", () => {
     expect(registry.parseSlashCommand("/help")).toEqual({ type: "command", name: "help" });
   });
+
+  it("recognizes /version", () => {
+    expect(registry.parseSlashCommand("/version")).toEqual({ type: "command", name: "version" });
+  });
 });
 
 // ── Unambiguous namespace-less resolution ─────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds a `/help` command that lists all built-in slash commands
- With no arguments: shows root-level commands, then a `Namespaces:` section listing available namespaces with command counts and a hint (`Use /help <namespace> to list commands in a namespace.`)
- With a namespace argument (e.g. `/help workspace`): lists only the commands directly under that namespace, excluding aliases
- Aliases are excluded from all listings (they already appear in canonical command descriptions)
- Implements `formatHelp(entries, namespace?)` as a pure exported function in `command-controller.ts`, covered by 15 new unit tests

## Test plan

- [ ] Run `npm test` — all 1985 non-DB tests pass
- [ ] Run `npx tsc --noEmit` — no type errors
- [ ] Manually: type `/help` in the REPL — see a list of root commands plus namespace summary
- [ ] Manually: type `/help workspace` — see only workspace commands
- [ ] Manually: type `/help worker` — see only worker commands
- [ ] Manually: type `/help nonexistent` — see "No commands in namespace: nonexistent"

Closes #609

🤖 Generated with [Claude Code](https://claude.com/claude-code)