### PR TITLE
feat: add /version command and --version flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ Follows MVC with three subdirectories:
 
 - **Models** (`models/`) — `Workspace` (git/npm workspace management), `Settings` (runtime-settable preferences: model, effort, permissions, verbose, thinkOutLoud — seeded from config at startup, then owned by settings for runtime changes), `QueryStats` (token usage/turn counts and API cost from SDK messages), `AgentStatus` (pure state model for worker status — emits `"change"` on updates, subscribed to by `Display` for reactive redraws; also owns static git/id utilities `getCurrentBranch`, `getRemoteRepo`, `generateAgentId`)
 - **Views** (`views/`) — `Display` (TUI terminal I/O — the single doorway to stdout), `Renderer` (pure string producers, no I/O), `Input` (readline-based REPL), `Picker` (arrow-key menus), `style.ts` (terminal color/style constants)
-- **Controllers** (`controllers/`) — `AgentController` (runs queries), `WorkerController` (consolidated worker mode lifecycle: WebSocket protocol, task state, reconnect/heartbeat, `/worker:*` commands; maintains an explicit three-state model: stopped / waiting / active — `transitionToIdle()` is the canonical entry point for the waiting state), `WorkspaceController` (workspace lifecycle + `/workspace:*` slash commands; event listeners are registered once in the constructor, not in `onCreate()` or other per-operation methods), `CommandRegistry`/`CommandController` (slash command registration and dispatch; commands registered with `canRunFromArgs: true` can be invoked directly from CLI args, e.g. `brunel worker:start`; `exitAfterRunFromArgs: true` causes the process to exit after the command completes rather than entering the REPL), `SettingsController` (all `/settings:*` commands and the `/settings` overview picker; call `registerAll()` from the composition root to register commands)
+- **Controllers** (`controllers/`) — `AgentController` (runs queries), `WorkerController` (consolidated worker mode lifecycle: WebSocket protocol, task state, reconnect/heartbeat, `/worker:*` commands; maintains an explicit three-state model: stopped / waiting / active — `transitionToIdle()` is the canonical entry point for the waiting state), `WorkspaceController` (workspace lifecycle + `/workspace:*` slash commands; event listeners are registered once in the constructor, not in `onCreate()` or other per-operation methods), `CommandRegistry`/`CommandController` (slash command registration and dispatch; commands registered with `canRunFromArgs: true` can be invoked directly from CLI args, e.g. `brunel worker:start`; `exitAfterRunFromArgs: true` causes the process to exit after the command completes rather than entering the REPL and also suppresses the startup banner), `SettingsController` (all `/settings:*` commands and the `/settings` overview picker; call `registerAll()` from the composition root to register commands)
 
 ### Shared
 
@@ -88,7 +88,7 @@ npm start
 npm run worker
 ```
 
-Config via `.env` or `brunel.config.ts` (CLI flags also accepted). See `src/config.ts` for all options. Positional args that aren't flag values are treated as command invocations (e.g. `brunel worker:start`, `brunel workspace:prune`, `brunel worker:claim 512`).
+Config via `.env` or `brunel.config.ts` (CLI flags also accepted). See `src/config.ts` for all options. Positional args that aren't flag values are treated as command invocations (e.g. `brunel worker:start`, `brunel workspace:prune`, `brunel worker:claim 512`, `brunel version`). The `--version` flag is a shorthand for `brunel version`.
 
 ## Useful scripts
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -13,6 +13,7 @@ import { Input } from "./views/input.js";
 import { Picker } from "./views/picker.js";
 import { WorkerController } from "./controllers/worker-controller.js";
 import { loadConfig, parseCommandFromArgs, type BrunelConfig } from "../config.js";
+import { PROTOCOL_VERSION } from "../../shared/wire.js";
 import { Workspace } from "./models/workspace.js";
 import { GithubToken } from "./models/github-token.js";
 import { fmtError } from "../utils.js";
@@ -107,12 +108,15 @@ export class BrunelAgent {
     // doExit handles workspace cleanup and stdin/stdout teardown.
     // Returns true if exit should proceed, false if the user cancelled.
     // Called on exit from pure REPL mode (no active worker session).
+    let tuiStarted = false;
     const doExit = async (): Promise<boolean> => {
       const ok = await workspaceController.onDestroy();
       if (!ok) return false;
-      process.stdout.write("\x1b[?2004l\r\n");
-      if (process.stdin.isTTY) process.stdin.setRawMode(false);
-      process.stdin.pause();
+      if (tuiStarted) {
+        process.stdout.write("\x1b[?2004l\r\n");
+        if (process.stdin.isTTY) process.stdin.setRawMode(false);
+        process.stdin.pause();
+      }
       return true;
     };
 
@@ -177,24 +181,12 @@ export class BrunelAgent {
       process.exit(0);
     });
 
-    // Status bar is always shown.
-    this.display.startPersistentBar();
-
-    // Print the startup banner.
-    this.display.print(c.sageGreen(hr("═")));
-    this.display.print(c.skyBlue(this.display.s.bold(`  brunel-agent v${PACKAGE_VERSION}`)));
-    this.display.print(c.lavender(`  Permissions: ${this.settings.permissionMode ?? "default"} | Model: ${this.settings.model ?? "default"} | Effort: ${this.settings.effort ?? "auto"} | Output: ${this.settings.verbose ? "verbose" : "quiet"} | Log: repl.log`));
-    this.display.print(c.sageGreen(hr("═")));
-
-    process.stdout.write("\x1b[?2004h"); // enable bracketed paste mode
-    process.stdin.setRawMode?.(true);
-    process.stdin.resume();
-    process.stdin.setEncoding("utf8");
-
     let sessionId: string | undefined;
 
     // Register all commands. All commands are present in both REPL and worker
     // modes; commands that require a foreman connection degrade gracefully.
+    // Registered before the startup banner so exitAfterRunFromArgs commands
+    // can be detected and the banner suppressed for non-interactive invocations.
     const registry = this.controller.registry;
     workspaceController.registerCommands(registry.scoped("workspace"));
     workerController.registerCommands(registry.scoped("worker"));
@@ -221,6 +213,37 @@ export class BrunelAgent {
       registry,
       () => this.agentController.fetchModels(),
     );
+    registry.register("version", {
+      description: "Print version information",
+      canRunFromArgs: true,
+      exitAfterRunFromArgs: true,
+      handler: async () => {
+        process.stdout.write(`v${PACKAGE_VERSION} (protocol version ${PROTOCOL_VERSION})\n`);
+      },
+    });
+
+    // exitAfterRunFromArgs commands run non-interactively; skip the startup banner,
+    // status bar, and stdin setup so they produce only their own output.
+    const skipStartupUI = (() => {
+      if (!cliCommand) return false;
+      const slashResult = this.controller.parseSlashCommand(`/${cliCommand.command}`);
+      if (!slashResult || slashResult.type !== "command") return false;
+      const entry = registry.lookup(slashResult.name);
+      return !!(entry?.exitAfterRunFromArgs);
+    })();
+
+    if (!skipStartupUI) {
+      tuiStarted = true;
+      this.display.startPersistentBar();
+      this.display.print(c.sageGreen(hr("═")));
+      this.display.print(c.skyBlue(this.display.s.bold(`  brunel-agent v${PACKAGE_VERSION}`)));
+      this.display.print(c.lavender(`  Permissions: ${this.settings.permissionMode ?? "default"} | Model: ${this.settings.model ?? "default"} | Effort: ${this.settings.effort ?? "auto"} | Output: ${this.settings.verbose ? "verbose" : "quiet"} | Log: repl.log`));
+      this.display.print(c.sageGreen(hr("═")));
+      process.stdout.write("\x1b[?2004h"); // enable bracketed paste mode
+      process.stdin.setRawMode?.(true);
+      process.stdin.resume();
+      process.stdin.setEncoding("utf8");
+    }
 
     // ── CLI command dispatch ──────────────────────────────────────────────────
     //

--- a/src/config.ts
+++ b/src/config.ts
@@ -218,6 +218,8 @@ const BOOLEAN_CLI_FLAGS = new Set(["--verbose", "--dangerously-skip-permissions"
  *   → { command: "worker:claim", args: "512" }
  */
 export function parseCommandFromArgs(argv: string[]): { command: string; args: string } | null {
+  if (argv.includes("--version")) return { command: "version", args: "" };
+
   const args = argv.slice(2);
   const consumed = new Set<number>();
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -645,6 +645,27 @@ describe("parseCommandFromArgs", () => {
       args: "",
     });
   });
+
+  it("--version flag returns version command", () => {
+    expect(parseCommandFromArgs(["node", "brunel.js", "--version"])).toEqual({
+      command: "version",
+      args: "",
+    });
+  });
+
+  it("--version flag takes precedence over positional args", () => {
+    expect(parseCommandFromArgs(["node", "brunel.js", "--version", "worker:start"])).toEqual({
+      command: "version",
+      args: "",
+    });
+  });
+
+  it("--version can appear with other flags", () => {
+    expect(parseCommandFromArgs(["node", "brunel.js", "--verbose", "--version"])).toEqual({
+      command: "version",
+      args: "",
+    });
+  });
 });
 
 // ── GitHub App credentials ────────────────────────────────────────────────────

--- a/tests/worker.main.test.ts
+++ b/tests/worker.main.test.ts
@@ -733,4 +733,44 @@ describe("CLI command dispatch", () => {
     // The routing loop ran — ask() was called (got __eof__ and exited)
     expect(mockInput.ask).toHaveBeenCalled();
   });
+
+  it("version command prints version string to stdout and exits", async () => {
+    installMocks();
+    const stdoutWrites: string[] = [];
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((s: unknown) => {
+      stdoutWrites.push(String(s));
+      return true;
+    });
+
+    let startCalled = false;
+    try {
+      await new BrunelAgent(getConfig()).start({ command: "version", args: "" });
+      startCalled = true;
+    } finally {
+      stdoutSpy.mockRestore();
+    }
+
+    expect(startCalled).toBe(true);
+    expect(mockInput.ask).not.toHaveBeenCalled();
+    const output = stdoutWrites.join("");
+    expect(output).toMatch(/^v\d+\.\d+\.\d+ \(protocol version \d+\)\n/);
+  });
+
+  it("version command does not print the startup banner", async () => {
+    installMocks();
+    const agent = new BrunelAgent(getConfig());
+    const printSpy = vi.spyOn(agent.display, "print").mockImplementation(() => {});
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    try {
+      await agent.start({ command: "version", args: "" });
+    } finally {
+      printSpy.mockRestore();
+      stdoutSpy.mockRestore();
+    }
+
+    const printed = printSpy.mock.calls.map(([s]: [unknown]) => stripAnsi(String(s))).join("\n");
+    expect(printed).not.toContain("brunel-agent");
+    expect(printed).not.toContain("Permissions:");
+  });
 });


### PR DESCRIPTION
## Summary

- Adds a `/version` slash command to the worker REPL that prints `v0.1.0 (protocol version 1)` (package version + protocol version)
- `brunel version` and `brunel --version` both print the version and exit without entering the REPL
- Commands with `exitAfterRunFromArgs: true` now suppress the startup banner so their output is clean (no interleaved banner text)
- This required moving command registration before the startup banner check in `BrunelAgent.start()`

## Test plan

- [x] `parseCommandFromArgs` tests: `--version` flag returns `{ command: "version", args: "" }` and takes precedence over positional args
- [x] `BrunelAgent.start` tests: version command writes the correct version string to stdout, exits without entering the routing loop, and does not print the startup banner
- [x] All 1975 existing non-DB tests pass

Closes #1071

🤖 Generated with [Claude Code](https://claude.com/claude-code)