### PR TITLE
fix: reset _prefixRows in _drawFresh() to prevent last comment line from being erased

### DIFF
--- a/src/agent/views/input.ts
+++ b/src/agent/views/input.ts
@@ -233,6 +233,11 @@ export class Input extends EventEmitter {
   private _drawFresh() {
     if (this._done) return;
     this._totalDrawnRows = 0; // reset: we're drawing from a new position
+    // The blank prefix rows (from the leading \n in promptStr) were cleared by
+    // _clearForPrint() and are now occupied by printed content. The prompt is
+    // redrawn at the new position without any prefix above it, so cancel() must
+    // not try to navigate up into the content to clear a prefix that no longer exists.
+    this._prefixRows = 0;
     const displayStr = this._buffer.replace(/\n/g, "\x1b[K\r\n    ");
     // print() already moved the cursor to a new line via console.log's
     // trailing \n; \r ensures we're at column 0 without adding an extra blank line.

--- a/tests/repl.input.test.ts
+++ b/tests/repl.input.test.ts
@@ -621,6 +621,34 @@ describe("ask() - blank line suppression with \\n prefix prompt", () => {
       await p;
     });
   });
+
+  it("cancel() after print() with \\n prefix does NOT go up into printed content (issue #1146)", async () => {
+    // Regression test for issue #1146: when display.print() fires while ask() with
+    // a \n prefix is active, _drawFresh() redraws the prompt below the new content
+    // without the blank prefix row above it. cancel() must NOT move up by _prefixRows
+    // (those rows are now content), or it erases the last line of the printed text.
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const writeSpy = vi.mocked(process.stdout.write);
+
+    await withFakeStdin(async () => {
+      const p = testInput.ask("\n[agent] > ", () => []);
+
+      // Simulate an external print arriving while the prompt is visible
+      testDisplay.print("line one\nline two\nlast line");
+
+      // Clear spy to isolate only cancel()'s writes
+      writeSpy.mockClear();
+
+      testInput.cancel();
+      await p;
+    });
+
+    // cancel() must NOT write any cursor-up escape — the prefix blank row was
+    // consumed by printed content, so going up would erase content, not blank space.
+    const writes = writeSpy.mock.calls.map((c) => String(c[0]));
+    const hasCursorUp = writes.some((w) => /\x1b\[\d+A/.test(w));
+    expect(hasCursorUp).toBe(false);
+  });
 });
 
 describe("ask() - status bar repositioning on start (issue #757)", () => {


### PR DESCRIPTION
## Summary

- When a foreman event notification (e.g. an issue comment) is printed while the worker is sitting at the `\n[agent] > ` prompt, the last line of the printed text was being erased before the agent started running.
- Root cause: `_drawFresh()` redraws the prompt at a new position after printing content, but never reset `_prefixRows`. When `cancel()` was subsequently called, it moved up by `_prefixRows = 1` rows before erasing — landing on the last line of the printed content instead of the (now-gone) blank prefix row.
- Fix: reset `_prefixRows = 0` in `_drawFresh()`, since after a fresh redraw the blank prefix rows have been consumed by printed content and no longer exist above the new prompt position.

## Test plan

- Added regression test: `cancel() after print() with \n prefix does NOT go up into printed content (issue #1146)` — verifies that `cancel()` writes no cursor-up escape after `display.print()` has fired.
- All existing tests pass unchanged, including the test that verifies `cancel()` *does* write cursor-up when no print has occurred (the normal case is preserved).

Closes #1146

🤖 Generated with [Claude Code](https://claude.com/claude-code)