### PR TITLE
Bundle brunel-specific skills as SDK plugin for worker sessions

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "brunel",
+  "version": "0.1.0",
+  "description": "Skills bundled with brunel for worker agent sessions"
+}

--- a/.claude-plugin/skills/branch-discipline/SKILL.md
+++ b/.claude-plugin/skills/branch-discipline/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: branch-discipline
+description: Use when editing files in projects that have CI or PRs set up, or otherwise use branches, or whenever multiple agents might work in parallel
+---
+
+# Branch Discipline
+
+## When This Skill Applies
+
+This skill applies when a project has:
+- GitHub CI configured (Actions workflows, branch protection rules), **or**
+- Pull requests as the standard integration path, **or**
+- Multiple agents working in parallel on independent tasks
+
+**It may not apply** in the earliest experimental or prototype stages of a project, or in small repos that have no automated tests and consist mainly of config rather than code — situations where the overhead of branches and PRs adds friction without providing meaningful safety. When in doubt, ask the user.
+
+## Overview
+
+All changes go through branches and pull requests. Nothing is ever committed directly to main. The only way code reaches main is through a PR that passes CI. No exceptions — not for "quick fixes," not for "just one line," not for config changes.
+
+## The Rule
+
+```
+main is read-only. Always.
+```
+
+## Worktrees
+
+Whether you need a worktree depends on your environment:
+
+- **Isolated checkout** (e.g., a worker agent with its own cloned workspace): just create a branch — you're already isolated.
+- **Shared checkout** (a repo directory used by multiple agents or by a human alongside you): use a worktree to avoid cross-contamination. See the `superpowers:using-git-worktrees` skill.
+
+## Workflow
+
+1. **Pull latest main** before making any changes
+2. **Create a branch** (and a worktree if needed — see above)
+3. **Do all work** on the branch — commits, edits, iterations
+4. **Push the branch and open a PR** — but do not auto-merge
+5. **CI runs** automatically on the PR
+6. **User reviews** → merges when satisfied → branch is deleted
+7. **CI fails** → fix on the same branch, push again, CI re-runs
+
+**Never enable auto-merge.** Always leave the PR open for the user to review and merge.
+
+**Create the PR proactively.** Don't wait to be asked — when the branch is ready, push it and open the PR as part of completing the work.
+
+If this PR resolves a GitHub issue, include a closing keyword in the PR body: `Closes #42` / `Fixes #42` / `Resolves #42`. A plain link (`see #42`) does NOT auto-close the issue on merge.
+
+## Anti-Patterns
+
+**Never cherry-pick** — see `no-cherry-pick` skill. If you think you need it, you have a workflow problem. Ask the user.
+
+**Never force-push to main** — see `no-force-push-main` skill. On feature branches, `--force-with-lease` after a rebase is correct. On main, never.
+
+**Bad git state?** Ask the user before taking any destructive action. Explain what went wrong and propose a safe fix.
+
+## Branch Naming
+
+Keep it short and descriptive. Use the work being done, not metadata:
+
+- `add-hyperlink-support`
+- `fix-cursor-position`
+- `ci-setup`
+- `issue-42-sync-retry`
+
+## When CI Fails
+
+Fix on the same branch. Do not:
+- Merge with failing CI
+- Bypass branch protection
+- Push the fix directly to main "to unblock things"
+
+The branch stays open until CI is green. This is the point — the gate works because it's non-negotiable.
+
+## When PR Review Requests Changes
+
+Push fixes to the same branch — the PR updates automatically. See `receiving-code-review` skill. Do not open a new PR.
+
+## Multiple Workstreams
+
+Each piece of work gets its own branch, based on current main. Don't stack branches. If main moves forward, rebase before merging.
+
+## What Belongs on a Branch
+
+Everything — features, fixes, refactors, config, docs, dependency upgrades, "one-line fixes." No change is too small to skip the branch workflow.
+
+## One Concern Per Branch
+
+**Each branch must contain only work related to a single concern.** Never commit work for concern X onto a branch that belongs to concern Y.
+
+This applies especially to spec and plan documents: a spec or plan for feature X must go on its own dedicated branch (e.g., `docs/feature-x`), not on an existing feature branch for unrelated work. Mixing concerns:
+- Makes PR review confusing ("why is this plan doc here?")
+- Can require destructive cleanup (force-push) to separate them
+- Creates misleading history
+
+Before committing any spec, plan, or document: check your current branch. If it belongs to different work, create a new dedicated branch first.
+
+## Common Rationalizations
+
+| Excuse | Reality |
+|--------|---------|
+| "It's just a one-line fix" | One-line fixes can break things. Branch takes 30 seconds. |
+| "CI is slow, I'll push to main and fix later" | "Fix later" means "forget and ship broken." |
+| "I'm the only one working on this" | Once CI exists, you're not — AI agents may be working in parallel, and future-you is a collaborator too. |
+| "I need this on main right now" | Push the branch, CI runs in minutes. If it's truly urgent, the test suite is your friend, not your obstacle. |
+| "Branch protection is slowing me down" | The "slowness" is CI doing its job. Push, open a PR, let the user review. |
+| Deleting a branch without pulling main first | `git branch -d` can't verify the branch is merged until local main is up to date. Always `git pull --rebase origin main` before cleanup — otherwise you'll need `git branch -D` (force delete). |
+
+## Checklist
+
+- [ ] Currently on a branch, not main
+- [ ] `git pull --rebase origin main` run before branching
+- [ ] Branch is based on latest main
+- [ ] Tests written for any new behavior or bug fixes (see `no-skipped-tests`)
+- [ ] All tests pass with zero skipped
+- [ ] Checked whether CLAUDE.md, README, or other project docs need updating to reflect this change; included any updates in this PR
+- [ ] PR created — auto-merge NOT enabled; left for user to review and merge
+- [ ] PR body includes `Closes #N` / `Fixes #N` / `Resolves #N` if this resolves a GitHub issue (a plain link does not auto-close)
+- [ ] CI passing before merge (enforced by branch protection)
+- [ ] Branch deleted after merge

--- a/.claude-plugin/skills/bug-investigation/SKILL.md
+++ b/.claude-plugin/skills/bug-investigation/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: bug-investigation
+description: Use when investigating a reported bug or about to implement a bug fix — verify the cause before making changes
+---
+
+# Bug Investigation
+
+## Reproduce Before You Fix
+
+The sequence is: **hypothesis → verify → fix**. Never skip the verify step.
+
+Reading code and thinking "ah, this looks like it could cause the problem" is a hypothesis. It is not a verified cause. Before changing any code, you must observe the failure.
+
+The verification bar: write a test, script, or REPL invocation that exercises the code path and **watch it fail in the way the bug describes**. That observation is your proof of cause. Once you have it, the fix follows naturally — and your repro becomes a regression test.
+
+## When You Can't Reproduce
+
+Some bugs require prod data, specific timing, or environment conditions that are hard to replicate locally. If you genuinely cannot reproduce the bug:
+
+**Do not guess at a fix.** A speculative code change has no verified effect and risks introducing regressions.
+
+Instead, add **targeted diagnostics**:
+- Add logging, assertions, or error messages at the specific points your hypotheses implicate
+- Make sure each diagnostic is designed to confirm or refute a specific hypothesis — "log everything" is not a strategy
+- Report what you added and what to look for: "I couldn't repro this. I added logging at X and Y. If hypothesis A is right, you'll see [specific output]. If hypothesis B is right, you'll see [other output]."
+
+Wait for the next real occurrence to gather evidence, then return to fix with actual data.
+
+## Not Acceptable
+
+- Changing code because it "looks suspicious" without observing the failure
+- Claiming "I believe this is the root cause" without evidence
+- Trying a fix speculatively when you haven't reproduced the bug ("let's see if this helps")
+- Adding a change that might address multiple possible causes, hedging because you don't know which applies

--- a/.claude-plugin/skills/no-cherry-pick/SKILL.md
+++ b/.claude-plugin/skills/no-cherry-pick/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: no-cherry-pick
+description: Use when about to run git cherry-pick, or when thinking that cherry-picking commits between branches is the right solution to a problem
+---
+
+# No Cherry-Pick
+
+## Don't. Here's Why.
+
+`git cherry-pick` creates duplicate commits with different SHAs, fractures history, and causes confusion about what's been merged. **It is an anti-pattern. Do not use it without explicit user permission.**
+
+## The Most Common Temptation: Depending on an Unmerged PR
+
+You need code that exists in another branch that hasn't merged yet. Do not cherry-pick those commits. Instead:
+
+1. **Stop work** on the current task
+2. **Identify the blocking PR** — note its number and what it provides
+3. **Tell the user** clearly: "I can't proceed until PR #N is merged. It provides [X]. Please merge it and let me know."
+4. **Wait** — do not duplicate the code, do not work around it, do not cherry-pick
+
+This is correct even if the wait feels inefficient. Cherry-picking from an unmerged PR creates a hidden dependency, risks double-applying changes when the PR eventually merges, and bypasses review for that code.
+
+## If Rebase Fails
+
+If `git rebase origin/main` fails unexpectedly, cherry-pick is not a substitute. Stop, explain what failed, and ask the user to decide the path forward. See `rebase-false-dirty` if the tree appears clean but rebase reports local changes.

--- a/.claude-plugin/skills/no-commit-to-main/SKILL.md
+++ b/.claude-plugin/skills/no-commit-to-main/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: no-commit-to-main
+description: Use when about to run git commit while on the main or master branch
+---
+
+# No Commits to Main
+
+## Don't. Here's Why.
+
+Committing directly to `main` bypasses code review, CI, and the PR workflow. It can block other agents working in parallel, creates noise in the main branch history, and is hard to cleanly revert. **Never commit to main** — not for docs, not for one-liners, not for anything.
+
+## Do This Instead
+
+```bash
+# Before committing, check your branch:
+git branch --show-current   # if this prints "main", stop
+
+# Create a branch first, then commit:
+git checkout -b short-description
+git commit -m "..."
+git push -u origin short-description
+gh pr create --title "..." --body "..."
+```
+
+## If You Already Committed to Main
+
+The commit hasn't been pushed yet — recover cleanly:
+
+```bash
+# 1. Create a branch from the accidental commit
+git checkout -b short-description
+
+# 2. Reset main back to origin
+git checkout main
+git reset --hard origin/main
+
+# 3. Push the branch and open a PR
+git checkout short-description
+git push -u origin short-description
+gh pr create --title "..." --body "..."
+```

--- a/.claude-plugin/skills/no-force-push-main/SKILL.md
+++ b/.claude-plugin/skills/no-force-push-main/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: no-force-push-main
+description: Use when about to run git push --force or --force-with-lease targeting main or any shared protected branch
+---
+
+# No Force-Push to Main
+
+## Don't. Here's Why.
+
+`git push --force` (or `--force-with-lease`) to `main` rewrites shared history. It destroys other people's (and other agents') references to commits, causes divergence requiring manual recovery, and is the #1 cause of lost work in collaborative repos. **Never force-push to main.**
+
+## Feature Branches Are Different
+
+On **feature branches**, `--force-with-lease` is correct after a rebase. Rebasing rewrites commit SHAs, so a plain `git push` will be rejected. Use `--force-with-lease` (not `--force`) — it fails safely if someone else pushed to your branch since your last fetch:
+
+```bash
+# After rebasing a feature branch:
+git push --force-with-lease   # ✓ safe on feature branches after rebase
+git push --force              # ✗ never — bypasses the safety check
+                              # ✗ never to main — under any circumstances
+```

--- a/.claude-plugin/skills/semver/SKILL.md
+++ b/.claude-plugin/skills/semver/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: semver
+description: Use when a PR has been merged and you need to decide whether to recommend a version bump, and at what level (patch/minor/major)
+---
+
+# Semver Version Bump Guidance
+
+## When to Recommend a Bump
+
+| Change type | Bump |
+|---|---|
+| Bug fix, small improvement | `patch` |
+| New user-facing feature | `minor` |
+| Breaking change to public API, CLI, or protocol | `minor` (while in 0.x) / `major` (1.x+) |
+| Internal refactor, doc-only, test-only | none |
+
+## The 0.x Rule
+
+While the package is at `0.x`, breaking changes can ship in a `minor` bump — the major version staying at 0 signals "not yet stable." Reserve `major` (1.0.0) for when you're ready to make a stability commitment to users.
+
+## What Counts as Breaking (General)
+
+- Removing or renaming anything a consumer depends on (commands, flags, exported APIs, config keys)
+- Changing the shape of inputs or outputs in a non-backward-compatible way
+- Dropping support for a previously supported runtime, platform, or protocol version
+
+Additive changes (new optional fields, new commands, new exports) and internal implementation changes are **not** breaking.
+
+## What to Tell the User
+
+Do **not** include the version bump in the PR — it causes merge conflicts when multiple agents are working in parallel. Instead, after the PR merges, recommend:
+
+> This change warrants a **patch/minor** bump. When you're ready to publish, run the appropriate version bump command for this project.
+
+Keep it short — one sentence on why, what level, done. The project docs or CLAUDE.md should have the exact publish command.

--- a/.claude-plugin/skills/test-discipline/SKILL.md
+++ b/.claude-plugin/skills/test-discipline/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: test-discipline
+description: Use when implementing any bug fix, feature, or code change — ensures new tests are written for new behavior, and no existing tests are skipped or failing
+---
+
+# Test Discipline
+
+## Write Tests for New Behavior
+
+For every bug fix or feature, write at least one test that:
+- Would **FAIL** before your change
+- Would **PASS** after your change
+
+"Existing tests still pass" only proves no regressions — it does **not** verify the fix or feature works.
+
+If you believe no new test is needed, you must identify the specific existing test(s) that cover the new behavior and explain why they're sufficient. Vague claims like "existing tests cover this" are not acceptable.
+
+## No Skipped or Failing Tests
+
+All tests must pass. Zero skipped. If a test is failing or skipped, investigate and fix it — don't work around it or leave it for later.
+
+Check for:
+- Tests marked `.skip`, `test.skip`, `xit`, `xdescribe`, `@pytest.mark.skip`, etc.
+- Tests that were skipped due to earlier failures (serial test suites)
+- Flaky tests that "usually pass" — these are bugs
+
+## Match Test Level to Where the Bug Lives
+
+A test at the wrong level of abstraction adds zero value, even if it passes and fails correctly.
+
+**Ask: where does the failure actually occur?**
+
+| Bug type | Right test level | Wrong test level |
+|----------|-----------------|-----------------|
+| Wrong logic inside a function | Unit test on that function | Integration test that incidentally exercises it |
+| Two components not wired together correctly | Integration test using both real components | Unit test on the glue code between them |
+| Wrong URL, path, or config passed across a boundary | Integration test verifying the connection works end-to-end | Unit test asserting the string value |
+| Display or terminal behavior (text output, ordering) | Capture stdout and assert on what the user actually sees | Check that an internal callback fired or a module variable was set |
+
+**For display/TUI tests, "what the user sees" means semantic text content — not terminal control sequences.** Escape codes (`\x1b[K`, cursor movements) are themselves internal mechanisms of the display layer, not user-visible outcomes.
+
+| ❌ Still a mechanism test | ✅ Behavioral |
+|---|---|
+| `expect(events).toEqual(["clearBar", "option", "drawBar"])` | Status bar text ("Connected") appears after option text in stdout |
+| Check for `\x1b[K` before option text | Status bar text appears after option text (clearBar ran, we don't care how) |
+| `expect(display.persistentActive).toBe(true)` | `expect(stdout).toContain("Connected")` |
+| Mock display, assert callback order | Real Display, assert on rendered content |
+
+**Diagnostic question — apply before finalizing any test:** *"Would this test fail if the bug existed but was fixed through a completely different mechanism?"* If no, you are testing the fix's implementation, not the behavior the fix restores. Rewrite the test to assert on the user-visible outcome directly.
+
+**Integration bugs need integration tests.** If the bug is "A couldn't talk to B because of a wrong path/protocol/format," a unit test that checks the path string is just testing string concatenation — it doesn't prove A and B can actually connect. Use real instances of both.
+
+**Red flag:** If your test doesn't exercise any production code path that was broken before the fix, it's testing the wrong thing. Ask: "Would this test have caught the bug if I hadn't already fixed it?"
+
+## Testing Models: Real DB vs. Mocks
+
+Match the approach to what's actually being tested:
+
+**Use a real DB** when the test is verifying DB behavior — constraints, timestamps, queries, state transitions that depend on what's persisted. Mocks here give false confidence.
+
+**Mock the model layer** when the test is verifying logic *above* the DB — routing, protocol, event handling, business rules. Use `vi.spyOn` on static finders and a `fromTest()` factory to construct instances without hitting the DB:
+
+```typescript
+const task = Task.fromTest({ task_id: "t1", issue_number: 42, title: "Fix bug" });
+vi.spyOn(Task, "getByIssue").mockResolvedValue(task);
+vi.spyOn(task, "assign").mockImplementation(async (workerId) => {
+  task.workerId = workerId; // mirror what the real method does in memory
+});
+```
+
+**Anti-pattern: parallel in-memory implementations** — A `createMemoryStore()` that duplicates the real store's behavior just to avoid spinning up a DB. This drifts from the real implementation and gives false confidence. Use `fromTest()` + `vi.spyOn` instead.
+
+## Not Acceptable
+
+- Writing no new test for a bug fix ("the bug was obvious, no test needed")
+- Writing no new test for a feature ("it's small")
+- "It was already skipped before I started"
+- "It's unrelated to my change"
+- "It's flaky but usually passes"
+- Writing a unit test for an integration bug ("at least there's coverage")
+
+If you didn't break it, you still found it. Fix it or flag it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,10 @@ Follows MVC with three subdirectories:
 - `src/` root — `config.ts` (unified config loader with `getConfig()` singleton; also exports `parseCommandFromArgs()` which extracts the first positional CLI arg as a command name for direct CLI invocation), `wire.ts` (re-exports from `shared/wire.ts`)
 - `shared/` — utilities needed by both Node backend and Vite frontend: `wire.ts` (wire protocol types and `PROTOCOL_VERSION`), `formatters.ts` (pure data-to-string helpers)
 
+### Bundled skills (`.claude-plugin/`)
+
+A Claude Code local plugin bundled with the npm package. `AgentController.runQuery()` loads it via the `plugins` SDK option so every worker session gets these skills automatically, without any user setup. Skills are in `.claude-plugin/skills/` (one subdirectory per skill, each with a `SKILL.md`). The plugin path is resolved at runtime relative to `agent-controller.ts` using `import.meta.url`. When adding or updating a skill, edit the file in `.claude-plugin/skills/` directly.
+
 ## Task lifecycle
 
 Status is **derived from timestamps**, not stored: `completedAt` → complete, `issueClosedAt` → closed, `prMergedAt` → merged, `workerId` → assigned, `prNumber` → pushed, open blockers → blocked, else → pending.

--- a/README.md
+++ b/README.md
@@ -2,16 +2,15 @@
 
 * Tag an issue `brunel:ready`, and it will be assigned to an agent
 * Agents automatically respond to test failures, code reviews, and any comments you leave on the PR
-* Agents run in your terminal, with key task-execution skills bundled automatically
+* Agents run in your terminal, and use any skills you have installed
 
 ## Quickstart
 
 1. Install the Brunel GitHub App on your repo: [github.com/apps/brunel-foreman](https://github.com/apps/brunel-foreman)
 2. Install the Brunel client locally: `npm install -g brunel-agent`
-3. Optional: install [obra/superpowers](https://github.com/obra/superpowers#claude-code) for enhanced agent capabilities
-4. Put an Anthropic key/token in your env: `export ANTHROPIC_API_KEY=sk-ant-...` or `export CLAUDE_CODE_OAUTH_TOKEN=sk-ant-...`
-5. Run `brunel worker:start` in your repo
-6. Tag issues `brunel:ready` in GitHub
+3. Put an Anthropic key/token in your env: `export ANTHROPIC_API_KEY=sk-ant-...` or `export CLAUDE_CODE_OAUTH_TOKEN=sk-ant-...`
+4. Run `brunel worker:start` in your repo
+5. Tag issues `brunel:ready` in GitHub
 
 Go to [brunel.dev](https://brunel.dev) and find your repo in the dashboard to see the status of tasks and workers.
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 * Tag an issue `brunel:ready`, and it will be assigned to an agent
 * Agents automatically respond to test failures, code reviews, and any comments you leave on the PR
-* Agents run in your terminal, and use any skills you have installed
+* Agents run in your terminal, with key task-execution skills bundled automatically
 
 ## Quickstart
 
 1. Install the Brunel GitHub App on your repo: [github.com/apps/brunel-foreman](https://github.com/apps/brunel-foreman)
 2. Install the Brunel client locally: `npm install -g brunel-agent`
-3. Strongly recommended: install the skills at [jasoncrawford/claude-skills](https://github.com/jasoncrawford/claude-skills) and also [obra/superpowers](https://github.com/obra/superpowers#claude-code)
+3. Optional: install [obra/superpowers](https://github.com/obra/superpowers#claude-code) for enhanced agent capabilities
 4. Put an Anthropic key/token in your env: `export ANTHROPIC_API_KEY=sk-ant-...` or `export CLAUDE_CODE_OAUTH_TOKEN=sk-ant-...`
 5. Run `brunel worker:start` in your repo
 6. Tag issues `brunel:ready` in GitHub

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "brunel": "bin/brunel.cjs"
   },
   "files": [
+    ".claude-plugin/",
     "bin/",
     "dist/",
     "shared/",

--- a/src/agent/controllers/agent-controller.ts
+++ b/src/agent/controllers/agent-controller.ts
@@ -1,4 +1,6 @@
 import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import type { CanUseTool, PermissionResult } from "@anthropic-ai/claude-agent-sdk";
 import { c } from "../views/style.js";
@@ -8,6 +10,12 @@ import type { PickQuestionResult } from "../views/picker.js";
 import { Settings } from "../models/settings.js";
 import type { ModelInfo } from "../models/settings.js";
 import { QueryStats, STALL_THRESHOLD_SECS } from "../models/query-stats.js";
+
+// ── Plugin path ───────────────────────────────────────────────────────────────
+
+// Resolve the bundled .claude-plugin directory relative to this file's location.
+// This file lives at src/agent/controllers/; the package root is three levels up.
+const PLUGIN_PATH = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..", ".claude-plugin");
 
 // ── Log file ──────────────────────────────────────────────────────────────────
 
@@ -119,6 +127,7 @@ export class AgentController {
         includePartialMessages: true,
         canUseTool,
         abortController: ac,
+        plugins: [{ type: "local", path: PLUGIN_PATH }],
         ...(allowDangerouslySkipPerms ? { allowDangerouslySkipPermissions: true } : {}),
         ...(sessionId ? { resume: sessionId } : {}),
         ...(this.settings.model ? { model: this.settings.model } : {}),


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/` directory with 7 bundled skills: `branch-discipline`, `no-commit-to-main`, `no-cherry-pick`, `no-force-push-main`, `test-discipline`, `bug-investigation`, `semver`
- Passes the plugin path to `query()` in `AgentController.runQuery()` via the `plugins` SDK option, resolving it relative to this file's location at runtime
- Adds `.claude-plugin/` to the `files` field in `package.json` so skills are included in the npm package

Workers now automatically get these skills in every SDK session without any user setup. Skills travel with the installed package version and leave no trace in the user's environment.

## Test plan

- [ ] All existing unit tests pass (`npm test`)
- [ ] TypeScript type-check passes (`npx tsc --noEmit`)
- [ ] ESLint passes with no new errors (`npm run lint`)

Closes #223