### PR TITLE
Fix OIDC npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 20
-          registry-url: https://registry.npmjs.org
 
       - run: npm ci
 


### PR DESCRIPTION
Remove `registry-url` from `actions/setup-node` — it creates an `.npmrc` with token-based auth that overrides OIDC trusted publishing, causing a 404 on `npm publish`.