### PR TITLE
Diagnose publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 jobs:
   publish:
@@ -22,5 +23,22 @@ jobs:
       - run: npm ci
 
       - run: npm run build
+
+      - name: Diagnose publish environment
+        run: |
+          echo "npm version: $(npm --version)"
+          echo "node version: $(node --version)"
+          echo "NODE_AUTH_TOKEN length: ${#NODE_AUTH_TOKEN}"
+          echo "NODE_AUTH_TOKEN first char: ${NODE_AUTH_TOKEN:0:1}"
+          echo "ACTIONS_ID_TOKEN_REQUEST_URL set: ${ACTIONS_ID_TOKEN_REQUEST_URL:+yes}"
+          echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN set: ${ACTIONS_ID_TOKEN_REQUEST_TOKEN:+yes}"
+          echo "NPM_CONFIG_USERCONFIG: ${NPM_CONFIG_USERCONFIG}"
+          if [ -f "${NPM_CONFIG_USERCONFIG}" ]; then
+            echo "--- .npmrc contents (auth tokens redacted) ---"
+            sed -E 's/(_authToken=).*/\1[REDACTED]/' "${NPM_CONFIG_USERCONFIG}"
+            echo "--- end .npmrc ---"
+          else
+            echo "no .npmrc at NPM_CONFIG_USERCONFIG"
+          fi
 
       - run: npm publish --provenance


### PR DESCRIPTION
Adds diagnostic output and `workflow_dispatch` trigger to investigate why OIDC trusted publishing returns 404. Will be reverted after diagnosis.