### PR TITLE
Upgrade npm in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,25 +20,10 @@ jobs:
         with:
           node-version: 20
 
+      - run: npm install -g npm@latest  # npm 11.5.1+ required for OIDC trusted publishing
+
       - run: npm ci
 
       - run: npm run build
-
-      - name: Diagnose publish environment
-        run: |
-          echo "npm version: $(npm --version)"
-          echo "node version: $(node --version)"
-          echo "NODE_AUTH_TOKEN length: ${#NODE_AUTH_TOKEN}"
-          echo "NODE_AUTH_TOKEN first char: ${NODE_AUTH_TOKEN:0:1}"
-          echo "ACTIONS_ID_TOKEN_REQUEST_URL set: ${ACTIONS_ID_TOKEN_REQUEST_URL:+yes}"
-          echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN set: ${ACTIONS_ID_TOKEN_REQUEST_TOKEN:+yes}"
-          echo "NPM_CONFIG_USERCONFIG: ${NPM_CONFIG_USERCONFIG}"
-          if [ -f "${NPM_CONFIG_USERCONFIG}" ]; then
-            echo "--- .npmrc contents (auth tokens redacted) ---"
-            sed -E 's/(_authToken=).*/\1[REDACTED]/' "${NPM_CONFIG_USERCONFIG}"
-            echo "--- end .npmrc ---"
-          else
-            echo "no .npmrc at NPM_CONFIG_USERCONFIG"
-          fi
 
       - run: npm publish --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           node-version: 20
 
-      - run: npm install -g npm@11.5.1  # version pinned, see engines.npm in package.json
+      - run: corepack enable  # use npm version from packageManager field in package.json
 
       - run: npm ci
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           node-version: 20
 
-      - run: npm install -g npm@latest  # npm 11.5.1+ required for OIDC trusted publishing
+      - run: npm install -g npm@11.5.1  # version pinned, see engines.npm in package.json
 
       - run: npm ci
 

--- a/package.json
+++ b/package.json
@@ -15,9 +15,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "engines": {
-    "npm": ">=11.5.1"
-  },
+  "packageManager": "npm@11.5.1",
   "scripts": {
     "build": "cd frontend && npm install && npm run build",
     "start": "tsx src/foreman/index.ts",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "engines": {
+    "npm": ">=11.5.1"
+  },
   "scripts": {
     "build": "cd frontend && npm install && npm run build",
     "start": "tsx src/foreman/index.ts",


### PR DESCRIPTION
Root cause of the 404 errors on `npm publish`: Node 20 ships with npm 10.8.x, but OIDC trusted publishing requires npm 11.5.1+. Diagnostic data from PR #1155 confirmed npm 10.8.2 was being used, with OIDC env vars correctly set but no auth attempt being made.

This adds `npm install -g npm@latest` to the workflow so the publish step uses a version that supports OIDC trusted publishing.

Also keeps the `workflow_dispatch` trigger added in #1155 for future manual testing — useful but harmless when there's no new version to publish.